### PR TITLE
plugin dependency checking

### DIFF
--- a/public_html/lists/admin/defaultplugin.php
+++ b/public_html/lists/admin/defaultplugin.php
@@ -78,17 +78,19 @@ class phplistPlugin {
   
   /* dependency check
    * 
-   * provides tests to run to determine whether this plugin can be used
+   * provides tests to determine whether this plugin can be used
    * example:
    *    array(
-   *        'description of dependency' => 'tests that evals true or false',
+   *        'description of dependency' => condition for plugin to be enabled
    *    )
    */
-   public $dependencyCheck = array(
-//        'description of dependency' => 'true',
-      'phpList version' => 'VERSION >= "3.0.10";',
-   );
-  
+  function dependencyCheck()
+  {
+      return array(
+        'phpList version' => version_compare(VERSION, '3.0.12') >= 0
+      );
+  }
+
   function name() {
     return $this->name;
   }

--- a/public_html/lists/admin/pluginlib.php
+++ b/public_html/lists/admin/pluginlib.php
@@ -172,25 +172,20 @@ function pluginsCall($method) {
 }
 
 function pluginCanEnable($plugin) {
-  $canEnable = true;
-  if (isset($GLOBALS['allplugins'][$plugin])) {
-    if (sizeof($GLOBALS['allplugins'][$plugin]->dependencyCheck)) {
-      $dependencyPasses = true;
-      foreach ($GLOBALS['allplugins'][$plugin]->dependencyCheck as $dependenyDesc => $dependencyCheck) {
-        eval("\$dependencyPasses = $dependencyCheck;");
-        if (!$dependencyPasses) {
-          $GLOBALS['allplugins'][$plugin]->dependencyFailure = $dependenyDesc;
-        }
-        $canEnable = $canEnable && $dependencyPasses;
-      }
+  global $allplugins;
+
+  $canEnable = false;
+
+  if (isset($allplugins[$plugin])) {
+    $dependencies = $allplugins[$plugin]->dependencyCheck();
+    $dependencyDesc = array_search(false, $dependencies);
+
+    if ($dependencyDesc === false) {
+        $canEnable = true;        
+    } else {
+        $allplugins[$plugin]->dependencyFailure = $dependencyDesc;
     }
   }
-  //if ($canEnable) {
-    //print "plugin can be enabled<br/>";
-  //} else {
-    //print "plugin can not be enabled<br/>";
-  //}
   return $canEnable;
 }
-
 

--- a/public_html/lists/admin/plugins.php
+++ b/public_html/lists/admin/plugins.php
@@ -244,7 +244,7 @@ foreach ($GLOBALS['allplugins'] as $pluginname => $plugin) {
   
   if (!pluginCanEnable($pluginname)) {
     $details .= '<div class="detail"><span class="label">'.s('Dependency check').'</span>';
-    $details .= '<span class="value">'.s('Plugin can not be enabled, because it fails a dependency check'). '</span></div>';
+    $details .= '<span class="value">'.s('Plugin can not be enabled, because it fails a dependency check - '). $plugin->dependencyFailure . '</span></div>';
   }
   
   if (!empty($pluginDetails['installUrl']) && class_exists('ZipArchive')) {


### PR DESCRIPTION
Use a method for dependency check so that conditions are evaluated by calling the method, instead of using eval.
On the plugins page display the (first) reason for dependency check failing