### PR TITLE
Add login trigger to plugins

### DIFF
--- a/public_html/lists/admin/defaultplugin.php
+++ b/public_html/lists/admin/defaultplugin.php
@@ -726,6 +726,17 @@ class phplistPlugin {
     return false;
   }
 
+  /* login
+   * called on login
+   * @param none
+   * @return true when user is successfully logged by plugin, false instead
+   */
+
+  function login() {
+    return false;
+  }
+
+
   /* logout
    * called on logout
    * @param none

--- a/public_html/lists/admin/login.php
+++ b/public_html/lists/admin/login.php
@@ -1,6 +1,18 @@
 <?php
 require_once dirname(__FILE__).'/accesscheck.php';
 
+$logged=false;
+foreach ($GLOBALS['plugins'] as $pluginname => $plugin) {
+  if ($plugin->login()) {
+    $logged=true;
+    break;
+  }
+}
+if ($logged) {
+  header('Location: '.$_SERVER['REQUEST_URI']);
+  exit();
+}
+
 if (TEST && strpos($_SERVER['HTTP_HOST'],'phplist.org') !== false) {
   print Info($GLOBALS['I18N']->get('default login is')." admin, ".$GLOBALS['I18N']->get('with password')." phplist").'.';
 }


### PR DESCRIPTION
Hello,

I recently wrote a PhpList plugin to support [CAS Single-Sign-On / LDAP administors authentification](https://github.com/brenard/phplist-casldap-plugin) and because SSO signified that PhpList does not have to use it own login form, I need a method to trigger CAS Authentification on login form display.
I initially use the same method used by [Cosign SSO plugin](https://resources.phplist.com/plugin/cosign) but it's not only affect administrators login and also user login (for example, when access subscribe/unsubscribe pages).
To implement this triggers, I duplicate the logic of the logout() plugin method to permit plugins, before administrator login form display, to log user by their own method. When plugin login() method return True, I consider that plugin successfully authenticate the user and I refresh the page (using the same called URL).
