### PR TITLE
Mantis 17830 - php undefined index notice in plugin

### DIFF
--- a/public_html/lists/index.php
+++ b/public_html/lists/index.php
@@ -386,10 +386,13 @@ function sendPersonalLocationPage($id)
   $html .= $GLOBALS['pagedata']["header"];
   $html .= '<h3>'.$GLOBALS["strPreferencesTitle"].'</h3>';
   $html .= $GLOBALS["msg"];
-  if ($_REQUEST["email"]) {
+
+  if (isset($_REQUEST["email"])) {
     $email = $_REQUEST["email"];
-  } elseif ($_SESSION["userdata"]["email"]["value"]) {
+  } elseif (isset($_SESSION["userdata"]["email"]["value"])) {
     $email = $_SESSION["userdata"]["email"]["value"];
+  } else {
+    $email = '';
   }
   $html .= $GLOBALS["strPersonalLocationInfo"];
 

--- a/public_html/lists/index.php
+++ b/public_html/lists/index.php
@@ -287,13 +287,20 @@ if ($login_required && empty($_SESSION["userloggedin"]) && !$canlogin) {
         break;
       case "preferences":
         if (!isset($_GET["id"]) || !$_GET['id']) $_GET["id"] = $id;
-        $success = require 'admin/subscribelib2.php';
+
         if (!$userid) {
 #          print "Userid not set".$_SESSION["userid"];
           print sendPersonalLocationPage($id);
-        } elseif (ASKFORPASSWORD && $userpassword && !$canlogin) {
+          break;
+        }
+
+        if (ASKFORPASSWORD && $userpassword && !$canlogin) {
           print LoginPage($id,$userid,$emailcheck);
-        } elseif ($success != 3) {
+          break;
+        }
+        $success = require 'admin/subscribelib2.php';
+
+        if ($success != 3) {
           print PreferencesPage($id,$userid);
         }
         break;


### PR DESCRIPTION
The validateSubscriptionPage() method of the Captcha plugin was being called when the captcha field had not been displayed, and then tried to access a non-existent variable.

This seems to be caused by using subscribelib2.php on all the variations of the preferences page. This change restricts that to only when the preferences form has been submitted, not when the personal location page has been requested.

Also fixed a few undefined index and variable php notices.