### PR TITLE
Mantis 17847 - Allow plugins to modify the cached message

### DIFF
--- a/public_html/lists/admin/defaultplugin.php
+++ b/public_html/lists/admin/defaultplugin.php
@@ -459,6 +459,17 @@ class phplistPlugin {
     return '';
   }
   
+  /* 
+   * Allows plugins to modify the fields of the loaded message.
+   * Those fields will then be customised for each subscriber
+   *
+   * @param integer $messageid: ID of the message
+   * @param array   &$message: associative array of message data
+   * @return void
+   */
+  public function processLoadedMessage($messageid, array &$message)
+  {
+  }
   
   /* 
    * parseOutgoingTextMessage

--- a/public_html/lists/admin/sendemaillib.php
+++ b/public_html/lists/admin/sendemaillib.php
@@ -1484,6 +1484,10 @@ exit;
 }
 */
 
+  foreach ($GLOBALS['plugins'] as $plugin) {
+    $plugin->processLoadedMessage($messageid, $cached[$messageid]);
+  }
+
   if (VERBOSE && !empty($GLOBALS['getspeedstats'])) {
     output('parse config start');
   }


### PR DESCRIPTION
I have added a hook to sendemaillib.php to allow plugins to modify the cached message.
The plugins are called after the message template, content and remote urls have been processed, but prior to some placeholder processing. So you might want to review whether that is the best place.

Note that the message is passed by reference, so there is no return value from the plugin.