### PR TITLE
Add config entry to enable smtp debug for test messages

### DIFF
--- a/public_html/lists/admin/init.php
+++ b/public_html/lists/admin/init.php
@@ -560,6 +560,9 @@ if (!defined('PHPMAILERTESTHOST') && defined('PHPMAILERHOST')) {
 if (!defined('PHPMAILER_SECURE')) {
     define('PHPMAILER_SECURE', false);
 }
+if (!defined('PHPMAILER_SMTP_DEBUG')) {
+    define('PHPMAILER_SMTP_DEBUG', 0);
+}
 if (!defined('USERSPAGE_MAX')) {
     define('USERSPAGE_MAX', 1000);
 }

--- a/public_html/lists/admin/sendemaillib.php
+++ b/public_html/lists/admin/sendemaillib.php
@@ -766,6 +766,12 @@ function sendEmail($messageid, $email, $hash, $htmlpref = 0, $rssitems = array()
 
   # build the email
   $mail = new PHPlistMailer($messageid, $destinationemail);
+
+    if ($isTestMail) {
+        $mail->SMTPDebug = PHPMAILER_SMTP_DEBUG;
+        $mail->Debugoutput = 'html';
+    }
+
     if ($forwardedby) {
         $mail->add_timestamp();
     }

--- a/public_html/lists/config/config_extended.php
+++ b/public_html/lists/config/config_extended.php
@@ -570,6 +570,11 @@ define('PHPMAILERHOST', '');
 # it can either be "ssl" or "tls", nothing else
 # define("PHPMAILER_SECURE",'ssl');
 
+## SMTP debugging
+# Enable debugging output by phpmailer when sending test emails
+# See https://phpmailer.github.io/PHPMailer/classes/PHPMailer.html#property_SMTPDebug
+# define('PHPMAILER_SMTP_DEBUG', 0);
+
 ## Smtp Timeout
 ## If you use SMTP for sending, you can set the timeout of the SMTP connection
 ## defaults to 5 seconds


### PR DESCRIPTION
Enable smtp debug in phpmailer to help in diagnosing connection problems. 
Only for test messages. Format output as html so that it is displayed reasonably.