### PR TITLE
Mantis 17893 Some issues with filtering subscribers when sending

### DIFF
--- a/public_html/lists/admin/actions/processqueue.php
+++ b/public_html/lists/admin/actions/processqueue.php
@@ -19,8 +19,8 @@ if (isset($_GET['secret'])) {
         return;
     } else {
         $inRemoteCall = true;
-    ## check that we actually still want remote queue processing
-    $pqChoice = getConfig('pqchoice');
+        ## check that we actually still want remote queue processing
+        $pqChoice = getConfig('pqchoice');
         if (SHOW_PQCHOICE && $pqChoice != 'phplistdotcom') {
             $counters['campaigns'] = 0;
             print outputCounters();
@@ -42,7 +42,7 @@ $domainthrottle = array();
 
 if ((!empty($GLOBALS['commandline']) && isset($cline['f'])) || $inRemoteCall) {
     # force set, so kill other processes
-  cl_output('Force set, killing other send processes');
+    cl_output('Force set, killing other send processes');
     $send_process_id = getPageLock(1);
 } else {
     $send_process_id = getPageLock();
@@ -104,10 +104,10 @@ if ($fp = @fopen('/etc/phplist.conf', 'r')) {
         list($key, $val) = explode('=', $line);
 
         switch ($key) {
-      case 'maxbatch': $maxbatch = sprintf('%d', $val);$ISPrestrictions .= "$key = $val\n";break;
-      case 'minbatchperiod': $minbatchperiod = sprintf('%d', $val);$ISPrestrictions .= "$key = $val\n";break;
-      case 'lockfile': $ISPlockfile = $val;
-    }
+            case 'maxbatch': $maxbatch = sprintf('%d', $val);$ISPrestrictions .= "$key = $val\n";break;
+            case 'minbatchperiod': $minbatchperiod = sprintf('%d', $val);$ISPrestrictions .= "$key = $val\n";break;
+            case 'lockfile': $ISPlockfile = $val;
+        }
     }
 }
 if (MAILQUEUE_BATCH_SIZE) {
@@ -165,21 +165,21 @@ if (VERBOSE && $maxProcessQueueTime) {
 if (isset($cline['m'])) {
     cl_output('Max to send is '.$cline['m'].' num per batch is '.$counters['num_per_batch']);
     $clinemax = (int) $cline['m'];
-  ## slow down just before max
-  if ($clinemax < 20) {
-      $counters['num_per_batch'] = min(2, $clinemax, $counters['num_per_batch']);
-  } elseif ($clinemax < 200) {
-      $counters['num_per_batch'] = min(20, $clinemax, $counters['num_per_batch']);
-  } else {
-      $counters['num_per_batch'] = min($clinemax, $counters['num_per_batch']);
-  }
+    ## slow down just before max
+    if ($clinemax < 20) {
+        $counters['num_per_batch'] = min(2, $clinemax, $counters['num_per_batch']);
+    } elseif ($clinemax < 200) {
+        $counters['num_per_batch'] = min(20, $clinemax, $counters['num_per_batch']);
+    } else {
+        $counters['num_per_batch'] = min($clinemax, $counters['num_per_batch']);
+    }
     cl_output('Max to send is '.$cline['m'].' setting num per batch to '.$counters['num_per_batch']);
 }
 
 $safemode = 0;
 if (ini_get('safe_mode')) {
     # keep an eye on timeouts
-  $safemode = 1;
+    $safemode = 1;
     $counters['num_per_batch'] = min(100, $counters['num_per_batch']);
     print $GLOBALS['I18N']->get('Running in safe mode').'<br/>';
 }
@@ -187,20 +187,20 @@ if (ini_get('safe_mode')) {
 $original_num_per_batch = $counters['num_per_batch'];
 if ($counters['num_per_batch'] && $batch_period) {
     # check how many were sent in the last batch period and take off that
-  # amount from this batch
+    # amount from this batch
 /*
   processQueueOutput(sprintf('select count(*) from %s where entered > date_sub(now(),interval %d second) and status = "sent"',
     $tables["usermessage"],$batch_period));
 */
-  $recently_sent = Sql_Fetch_Row_Query(sprintf('select count(*) from %s where entered > date_sub(now(),interval %d second) and status = "sent"',
+    $recently_sent = Sql_Fetch_Row_Query(sprintf('select count(*) from %s where entered > date_sub(now(),interval %d second) and status = "sent"',
     $tables['usermessage'], $batch_period));
     cl_output('Recently sent : '.$recently_sent[0]);
     $counters['num_per_batch'] -= $recently_sent[0];
 
   # if this ends up being 0 or less, don't send anything at all
-  if ($counters['num_per_batch'] == 0) {
-      $counters['num_per_batch'] = -1;
-  }
+    if ($counters['num_per_batch'] == 0) {
+        $counters['num_per_batch'] = -1;
+    }
 }
 # output some stuff to make sure it's not buffered in the browser
 for ($i = 0;$i < 10000; ++$i) {
@@ -225,7 +225,7 @@ function my_shutdown()
 {
     global $script_stage,$reload;
 #  processQueueOutput( "Script status: ".connection_status(),0); # with PHP 4.2.1 buggy. http://bugs.php.net/bug.php?id=17774
-  processQueueOutput(s('Script stage').': '.$script_stage, 0, 'progress');
+    processQueueOutput(s('Script stage').': '.$script_stage, 0, 'progress');
     global $counters,$report,$send_process_id,$tables,$nothingtodo,$processed,$notsent,$unconfirmed,$batch_period;
     $some = $processed;
     $delaytime = 0;
@@ -242,7 +242,7 @@ function my_shutdown()
     }
     if ($counters['sent']) {
         processQueueOutput(sprintf('%d %s %01.2f %s (%d %s)', $counters['sent'], $GLOBALS['I18N']->get('messages sent in'),
-      $totaltime, $GLOBALS['I18N']->get('seconds'), $msgperhour, $GLOBALS['I18N']->get('msgs/hr')), $counters['sent'], 'progress');
+        $totaltime, $GLOBALS['I18N']->get('seconds'), $msgperhour, $GLOBALS['I18N']->get('msgs/hr')), $counters['sent'], 'progress');
     }
     if ($counters['invalid']) {
         processQueueOutput(s('%d invalid email addresses', $counters['invalid']), 1, 'progress');
@@ -251,7 +251,7 @@ function my_shutdown()
         processQueueOutput(s('%d failed (will retry later)', $counters['failed_sent']), 1, 'progress');
         foreach ($counters as $label => $value) {
             #  processQueueOutput(sprintf('%d %s',$value,$GLOBALS['I18N']->get($label)),1,'progress');
-      cl_output(sprintf('%d %s', $value, $GLOBALS['I18N']->get($label)));
+            cl_output(sprintf('%d %s', $value, $GLOBALS['I18N']->get($label)));
         }
     }
     if ($unconfirmed) {
@@ -270,7 +270,7 @@ function my_shutdown()
         processQueueOutput($GLOBALS['I18N']->get('Warning: script never reached stage 5')."\n".$GLOBALS['I18N']->get('This may be caused by a too slow or too busy server')." \n");
     } elseif ($script_stage == 5 && (!$nothingtodo || isset($GLOBALS['wait']))) {
         # if the script timed out in stage 5, reload the page to continue with the rest
-    ++$reload;
+        ++$reload;
         if (!$GLOBALS['commandline'] && $counters['num_per_batch'] && $batch_period) {
             if ($counters['sent'] + 10 < $GLOBALS['original_num_per_batch']) {
                 processQueueOutput($GLOBALS['I18N']->get('Less than batch size were sent, so reloading imminently'), 1, 'progress');
@@ -278,7 +278,7 @@ function my_shutdown()
             } else {
                 $counters['delaysend'] = (int) ($batch_period - $totaltime);
                 $delaytime = 30; ## actually with the iframe we can reload fairly quickly
-        processQueueOutput(s('Waiting for %d seconds before reloading', $delaytime), 1, 'progress');
+                processQueueOutput(s('Waiting for %d seconds before reloading', $delaytime), 1, 'progress');
             }
         }
         $counters['delaysend'] = (int) ($batch_period - $totaltime);
@@ -337,14 +337,14 @@ function finish($flag, $message, $script_stage)
 
     ## @@TODO work out a way to deal with the order of processing the plugins
     ## as that can make a difference here.
-    foreach ($GLOBALS['plugins'] as $pluginname => $plugin) {
-        if (!$reportSent) {
-            $reportSent = $plugin->sendReport($subject, $message);
+        foreach ($GLOBALS['plugins'] as $pluginname => $plugin) {
+            if (!$reportSent) {
+                $reportSent = $plugin->sendReport($subject, $message);
+            }
         }
-    }
         if (!$reportSent) {
             ## fall back to the central one
-      $message .= "\n\n".s('To stop receiving these reports read:').' https://resources.phplist.com/system/config/send_queue_processing_report'."\n\n";
+            $message .= "\n\n".s('To stop receiving these reports read:').' https://resources.phplist.com/system/config/send_queue_processing_report'."\n\n";
             sendReport($subject, $message);
         }
     }
@@ -381,7 +381,7 @@ function processQueueOutput($message, $logit = 1, $target = 'summary')
         $infostring = '['.date('D j M Y H:i', time()).'] [CL]';
     } elseif ($GLOBALS['inRemoteCall']) {
         ## with a remote call we suppress output
-    @ob_end_clean();
+        @ob_end_clean();
         $infostring = '';
         $message = '';
         @ob_start();
@@ -390,7 +390,7 @@ function processQueueOutput($message, $logit = 1, $target = 'summary')
     } else {
         $infostring = '['.date('D j M Y H:i', time()).'] ['.$_SERVER['REMOTE_ADDR'].']';
     #print "$infostring $message<br/>\n";
-    $lines = explode("\n", $message);
+        $lines = explode("\n", $message);
         foreach ($lines as $line) {
             $line = preg_replace('/"/', '\"', $line);
 
@@ -430,10 +430,10 @@ function outputCounters()
     global $counters;
     $result = '';
     if (function_exists('json_encode')) { // only PHP5.2.0 and up
-    return json_encode($counters);
+        return json_encode($counters);
     } else {
         ## keep track of which php versions we need to continue to support
-    $counters['PHPVERSION'] = phpversion();
+        $counters['PHPVERSION'] = phpversion();
         foreach ($counters as $key => $val) {
             $result .= $key.'='.$val.';';
         }
@@ -450,10 +450,10 @@ function sendEmailTest($messageid, $email)
     } else {
         $report .= "\n".$GLOBALS['I18N']->get('(test)').' '.$GLOBALS['I18N']->get('Would have sent').' '.$messageid.$GLOBALS['I18N']->get('to').' '.$email;
     }
-  // fake a bit of a delay,
-  usleep(0.75 * 1000000);
-  // and say it was fine.
-  return true;
+    // fake a bit of a delay,
+    usleep(0.75 * 1000000);
+    // and say it was fine.
+    return true;
 }
 
 # we don not want to timeout or abort
@@ -472,17 +472,17 @@ if (empty($reload)) { ## only show on first load
 ## ask plugins if processing is allowed at all
 foreach ($GLOBALS['plugins'] as $pluginname => $plugin) {
     #  cl_output('Asking '.$pluginname);
-  if (!$plugin->allowProcessQueue()) {
-      processQueueOutput(s('Processing blocked by plugin %s', $pluginname));
-      finish('info', s('Processing blocked by plugin %s', $pluginname));
-      exit;
-  }
+    if (!$plugin->allowProcessQueue()) {
+        processQueueOutput(s('Processing blocked by plugin %s', $pluginname));
+        finish('info', s('Processing blocked by plugin %s', $pluginname));
+        exit;
+    }
 }
 
 if (empty($reload)) { ## only show on first load
-  if (!empty($ISPrestrictions)) {
-      processQueueOutput($ISPrestrictions);
-  }
+    if (!empty($ISPrestrictions)) {
+        processQueueOutput($ISPrestrictions);
+    }
     if (is_file($ISPlockfile)) {
         ProcessError(s('Processing has been suspended by your ISP, please try again later'), 1);
     }
@@ -581,11 +581,11 @@ if ($num_messages) {
     }
 } else {
     ## check for a future embargo, to be able to report when it expires.
-  $future = Sql_Fetch_Assoc_Query('select unix_timestamp(embargo) - unix_timestamp(now()) as waittime '
-    ." from ${tables['message']}"
-    ." where status not in ('draft', 'sent', 'prepared', 'suspended')"
-    .' and embargo > now()'
-    .' order by embargo asc limit 1');
+    $future = Sql_Fetch_Assoc_Query('select unix_timestamp(embargo) - unix_timestamp(now()) as waittime '
+        ." from ${tables['message']}"
+        ." where status not in ('draft', 'sent', 'prepared', 'suspended')"
+        .' and embargo > now()'
+        .' order by embargo asc limit 1');
     $counters['status'] = 'embargo';
     $counters['delaysend'] = $future['waittime'];
 }
@@ -626,39 +626,39 @@ while ($message = Sql_fetch_array($messages)) {
 
     if (!empty($msgdata['resetstats'])) {
         resetMessageStatistics($msgdata['id']);
-    ## make sure to reset the resetstats flag, so it doesn't clear it every run
-    setMessageData($msgdata['id'], 'resetstats', 0);
+        ## make sure to reset the resetstats flag, so it doesn't clear it every run
+        setMessageData($msgdata['id'], 'resetstats', 0);
     }
 
   ## check the end date of the campaign
-  $stopSending = false;
+    $stopSending = false;
     if (!empty($msgdata['finishsending'])) {
         $finishSendingBefore = mktime($msgdata['finishsending']['hour'], $msgdata['finishsending']['minute'], 0, $msgdata['finishsending']['month'], $msgdata['finishsending']['day'], $msgdata['finishsending']['year']);
         $secondsTogo = $finishSendingBefore - time();
         $stopSending = $secondsTogo < 0;
         if (empty($reload)) {
             ### Hmm, this is probably incredibly confusing. It won't finish then
-      if (VERBOSE) {
-          processQueueOutput(sprintf($GLOBALS['I18N']->get('sending of this campaign will stop, if it is still going in %s'), secs2time($secondsTogo)));
-      }
+            if (VERBOSE) {
+                processQueueOutput(sprintf($GLOBALS['I18N']->get('sending of this campaign will stop, if it is still going in %s'), secs2time($secondsTogo)));
+            }
         }
     }
 
     $userselection = $msgdata['userselection']; ## @@ needs more work
   ## load message in cache
-  if (!precacheMessage($messageid)) {
-      ## precache may fail on eg invalid remote URL
-    ## any reporting needed here?
+    if (!precacheMessage($messageid)) {
+        ## precache may fail on eg invalid remote URL
+        ## any reporting needed here?
 
-    # mark the message as suspended
-    Sql_Query(sprintf('update %s set status = "suspended" where id = %d', $GLOBALS['tables']['message'], $messageid));
-      processQueueOutput(s('Error loading message, please check the eventlog for details'));
-      if (MANUALLY_PROCESS_QUEUE) {
-          # wait a little, otherwise the message won't show
-      sleep(10);
-      }
-      continue;
-  }
+        # mark the message as suspended
+        Sql_Query(sprintf('update %s set status = "suspended" where id = %d', $GLOBALS['tables']['message'], $messageid));
+          processQueueOutput(s('Error loading message, please check the eventlog for details'));
+        if (MANUALLY_PROCESS_QUEUE) {
+            # wait a little, otherwise the message won't show
+            sleep(10);
+        }
+        continue;
+    }
 
     if (!empty($getspeedstats)) {
         processQueueOutput('message data loaded ');
@@ -670,11 +670,11 @@ while ($message = Sql_fetch_array($messages)) {
         $notifications = explode(',', $msgdata['notify_start']);
         foreach ($notifications as $notification) {
             sendMail($notification, s('Campaign started'),
-        s('phplist has started sending the campaign with subject %s', $msgdata['subject'])."\n\n".
-        s('to view the progress of this campaign, go to %s://%s',$GLOBALS['admin_scheme'], getConfig('website').$GLOBALS['adminpages'].'/?page=messages&amp;tab=active'));
+                s('phplist has started sending the campaign with subject %s', $msgdata['subject'])."\n\n".
+                s('to view the progress of this campaign, go to %s://%s',$GLOBALS['admin_scheme'], getConfig('website').$GLOBALS['adminpages'].'/?page=messages&amp;tab=active'));
         }
         Sql_Query(sprintf('insert ignore into %s (name,id,data) values("start_notified",%d,now())',
-      $GLOBALS['tables']['messagedata'], $messageid));
+            $GLOBALS['tables']['messagedata'], $messageid));
     }
 
     if (empty($reload)) {
@@ -692,50 +692,50 @@ while ($message = Sql_fetch_array($messages)) {
         ProcessError(Sql_Error($database_connection));
     }
 
-  # make selection on attribute, users who at least apply to the attributes
-  # lots of ppl seem to use it as a normal mailinglist system, and do not use attributes.
-  # Check this and take anyone in that case.
+    # make selection on attribute, users who at least apply to the attributes
+    # lots of ppl seem to use it as a normal mailinglist system, and do not use attributes.
+    # Check this and take anyone in that case.
 
-  ## keep an eye on how long it takes to find users, and warn if it's a long time
-  $findUserStart = $processqueue_timer->elapsed(1);
+    ## keep an eye on how long it takes to find users, and warn if it's a long time
+    $findUserStart = $processqueue_timer->elapsed(1);
 
     $rs = Sql_Query('select count(*) from '.$tables['attribute']);
     $numattr = Sql_Fetch_Row($rs);
 
     $user_attribute_query = ''; #16552
-  if ($userselection && $numattr[0]) {
-      $res = Sql_Query($userselection);
-      $counters['total_users_for_message'] = Sql_Num_Rows($res);
-      if (empty($reload)) {
-          processQueueOutput($counters['total_users_for_message'].' '.$GLOBALS['I18N']->get('users apply for attributes, now checking lists'), 0, 'progress');
-      }
-      $user_list = '';
-      while ($row = Sql_Fetch_row($res)) {
-          $user_list .= $row[0].',';
-      }
-      $user_list = substr($user_list, 0, -1);
-      if ($user_list) {
-          $user_attribute_query = " and listuser.userid in ($user_list)";
-      } else {
-          if (empty($reload)) {
-              processQueueOutput($GLOBALS['I18N']->get('No users apply for attributes'));
-          }
-          $status = Sql_Query(sprintf('update %s set status = "sent", sent = now() where id = %d', $tables['message'], $messageid));
-          finish('info', "Message $messageid: \nNo users apply for attributes, ie nothing to do");
-          $script_stage = 6;
-      # we should actually continue with the next message
-      return;
-      }
-  }
+    if ($userselection && $numattr[0]) {
+        $res = Sql_Query($userselection);
+        $counters['total_users_for_message'] = Sql_Num_Rows($res);
+        if (empty($reload)) {
+            processQueueOutput($counters['total_users_for_message'].' '.$GLOBALS['I18N']->get('users apply for attributes, now checking lists'), 0, 'progress');
+        }
+        $user_list = '';
+        while ($row = Sql_Fetch_row($res)) {
+            $user_list .= $row[0].',';
+        }
+        $user_list = substr($user_list, 0, -1);
+        if ($user_list) {
+            $user_attribute_query = " and listuser.userid in ($user_list)";
+        } else {
+            if (empty($reload)) {
+                processQueueOutput($GLOBALS['I18N']->get('No users apply for attributes'));
+            }
+            $status = Sql_Query(sprintf('update %s set status = "sent", sent = now() where id = %d', $tables['message'], $messageid));
+            finish('info', "Message $messageid: \nNo users apply for attributes, ie nothing to do");
+            $script_stage = 6;
+            # we should actually continue with the next message
+            return;
+        }
+    }
     if ($script_stage < 3) {
         $script_stage = 3; # we know the users by attribute
     }
 
-  # when using commandline we need to exclude users who have already received
-  # the email
-  # we don't do this otherwise because it slows down the process, possibly
-  # causing us to not find anything at all
-  $exclusion = '';
+    # when using commandline we need to exclude users who have already received
+    # the email
+    # we don't do this otherwise because it slows down the process, possibly
+    # causing us to not find anything at all
+    $exclusion = '';
     $doneusers = array();
     $skipusers = array();
 
@@ -812,34 +812,34 @@ while ($message = Sql_fetch_array($messages)) {
   #  }
     }
 
-  ## if the above didn't find any, run the normal search (again)
-  if (empty($queued)) {
-      ## remove pre-queued messages, otherwise they wouldn't go out
-    Sql_Query(sprintf('delete from '.$tables['usermessage'].' where messageid = %d and status = "todo"', $messageid));
-      $removed = Sql_Affected_Rows();
-      if ($removed) {
-          cl_output('removed pre-queued subscribers '.$removed, 0, 'progress');
-      }
+    ## if the above didn't find any, run the normal search (again)
+    if (empty($queued)) {
+        ## remove pre-queued messages, otherwise they wouldn't go out
+        Sql_Query(sprintf('delete from '.$tables['usermessage'].' where messageid = %d and status = "todo"', $messageid));
+        $removed = Sql_Affected_Rows();
+        if ($removed) {
+            cl_output('removed pre-queued subscribers '.$removed, 0, 'progress');
+        }
 
-      $query = sprintf('select distinct u.id from %s as listuser
-      inner join %s as u ON u.id = listuser.userid
-      inner join %s as listmessage ON listuser.listid = listmessage.listid
-      left join %s as um ON (um.messageid = %d and um.userid = listuser.userid)
-      where 
-      listmessage.messageid = %d
-      and listmessage.listid = listuser.listid
-      and u.id = listuser.userid
-      and um.userid IS NULL
-      and u.confirmed and !u.blacklisted and !u.disabled
-      %s %s',
-      $tables['listuser'],
-      $tables['user'],
-      $tables['listmessage'],
-      $tables['usermessage'],
-      $messageid, $messageid,
-      $exclusion, $user_attribute_query
-    );
-  }
+        $query = sprintf('select distinct u.id from %s as listuser
+        inner join %s as u ON u.id = listuser.userid
+        inner join %s as listmessage ON listuser.listid = listmessage.listid
+        left join %s as um ON (um.messageid = %d and um.userid = listuser.userid)
+        where 
+        listmessage.messageid = %d
+        and listmessage.listid = listuser.listid
+        and u.id = listuser.userid
+        and um.userid IS NULL
+        and u.confirmed and !u.blacklisted and !u.disabled
+        %s %s',
+        $tables['listuser'],
+        $tables['user'],
+        $tables['listmessage'],
+        $tables['usermessage'],
+        $messageid, $messageid,
+        $exclusion, $user_attribute_query
+        );
+    }
 
     if (VERBOSE) {
         processQueueOutput('User select query '.$query);

--- a/public_html/lists/admin/actions/processqueue.php
+++ b/public_html/lists/admin/actions/processqueue.php
@@ -605,9 +605,9 @@ while ($message = Sql_fetch_array($messages)) {
     $counters['total_users_for_message '.$messageid] = 0;
     if (PROCESSCAMPAIGNS_PARALLEL) {
         $counters['max_users_for_message '.$messageid] = (int) $counters['num_per_batch'] / $num_messages; ## not entirely correct if a campaign has less left
-    if (VERBOSE) {
-        cl_output(s('Maximum for campaign %d is %d', $messageid, $counters['max_users_for_message '.$messageid]));
-    }
+        if (VERBOSE) {
+            cl_output(s('Maximum for campaign %d is %d', $messageid, $counters['max_users_for_message '.$messageid]));
+        }
     } else {
         $counters['max_users_for_message '.$messageid] = $counters['num_per_batch'];
     }
@@ -851,7 +851,7 @@ while ($message = Sql_fetch_array($messages)) {
     }
 
   # now we have all our users to send the message to
-  $counters['total_users_for_message '.$messageid] = Sql_Affected_Rows();
+    $counters['total_users_for_message '.$messageid] = Sql_Affected_Rows();
 
     if ($skipped >= 10000) {
         $counters['total_users_for_message '.$messageid] -= $skipped;
@@ -870,16 +870,16 @@ while ($message = Sql_fetch_array($messages)) {
 
     if (defined('MESSAGEQUEUE_PREPARE') && MESSAGEQUEUE_PREPARE && empty($queued)) {
         ## experimental MESSAGEQUEUE_PREPARE will first mark all messages as todo and then work it's way through the todo's
-    ## that should save time when running the queue multiple times, which avoids the user search after the first time
-    ## only do this first time, ie empty($queued);
-    ## the last run will pick up changes
-    while ($userdata = Sql_Fetch_Row($userids)) {
-        ## mark message/user combination as "todo"
-      $userid = $userdata[0];    # id of the user
-      Sql_Query(sprintf('replace into %s (entered,userid,messageid,status) values(now(),%d,%d,"todo")', $tables['usermessage'], $userid, $messageid));
-    }
-    ## rerun the initial query, in order to continue as normal
-    $query = sprintf('select userid from '.$tables['usermessage'].' where messageid = %d and status = "todo"', $messageid);
+        ## that should save time when running the queue multiple times, which avoids the user search after the first time
+        ## only do this first time, ie empty($queued);
+        ## the last run will pick up changes
+        while ($userdata = Sql_Fetch_Row($userids)) {
+            ## mark message/user combination as "todo"
+            $userid = $userdata[0];    # id of the user
+            Sql_Query(sprintf('replace into %s (entered,userid,messageid,status) values(now(),%d,%d,"todo")', $tables['usermessage'], $userid, $messageid));
+        }
+        ## rerun the initial query, in order to continue as normal
+        $query = sprintf('select userid from '.$tables['usermessage'].' where messageid = %d and status = "todo"', $messageid);
         $userids = Sql_Query($query);
         $counters['total_users_for_message '.$messageid] = Sql_Affected_Rows();
     }
@@ -909,7 +909,7 @@ while ($message = Sql_fetch_array($messages)) {
 
     while ($userdata = Sql_Fetch_Row($userids)) {
         $userid = $userdata[0];    # id of the user
-    ++$counters['processed_users_for_message '.$messageid];
+        ++$counters['processed_users_for_message '.$messageid];
 
         if ($counters['processed_users_for_message '.$messageid] > $counters['max_users_for_message '.$messageid]) {
             if (VERBOSE) {
@@ -935,12 +935,12 @@ while ($message = Sql_fetch_array($messages)) {
         $secondsTogo = $finishSendingBefore - time();
         $stopSending = $secondsTogo < 0;
 
-    # check if we have been "killed"
- #   processQueueOutput('Process ID '.$send_process_id);
-    $alive = checkLock($send_process_id);
+        # check if we have been "killed"
+        #   processQueueOutput('Process ID '.$send_process_id);
+        $alive = checkLock($send_process_id);
 
-    ## check for max-process-queue-time
-    $elapsed = $GLOBALS['processqueue_timer']->elapsed(1);
+        ## check for max-process-queue-time
+        $elapsed = $GLOBALS['processqueue_timer']->elapsed(1);
         if ($maxProcessQueueTime && $elapsed > $maxProcessQueueTime && $counters['sent'] > 0) {
             cl_output($GLOBALS['I18N']->get('queue processing time has exceeded max processing time ').$maxProcessQueueTime);
             break;
@@ -953,8 +953,8 @@ while ($message = Sql_fetch_array($messages)) {
             ProcessError($GLOBALS['I18N']->get('Process Killed by other process'));
         }
 
-    # check if the message we are working on is still there and in process
-    $status = Sql_Fetch_Array_query("select id,status from {$tables['message']} where id = $messageid");
+        # check if the message we are working on is still there and in process
+        $status = Sql_Fetch_Array_query("select id,status from {$tables['message']} where id = $messageid");
         if (!$status['id']) {
             ProcessError($GLOBALS['I18N']->get('Message I was working on has disappeared'));
         } elseif ($status['status'] != 'inprocess') {
@@ -963,19 +963,19 @@ while ($message = Sql_fetch_array($messages)) {
         }
         flush();
 
-    ##
-    #Sql_Query(sprintf('delete from %s where userid = %d and messageid = %d and status = "active"',$tables['usermessage'],$userid,$messageid));
+        ##
+        #Sql_Query(sprintf('delete from %s where userid = %d and messageid = %d and status = "active"',$tables['usermessage'],$userid,$messageid));
 
-    # check whether the user has already received the message
-    if (!empty($getspeedstats)) {
-        processQueueOutput('verify message can go out to '.$userid);
-    }
+        # check whether the user has already received the message
+        if (!empty($getspeedstats)) {
+            processQueueOutput('verify message can go out to '.$userid);
+        }
 
         $um = Sql_Query(sprintf('select entered from %s where userid = %d and messageid = %d and status != "todo"', $tables['usermessage'], $userid, $messageid));
         if (!Sql_Num_Rows($um)) {
-            ## mark this message that we're working on it, so that no other process will take it
-      ## between two lines ago and here, should hopefully be quick enough
-      $userlock = Sql_Query(sprintf('replace into %s (entered,userid,messageid,status) values(now(),%d,%d,"active")', $tables['usermessage'], $userid, $messageid));
+                ## mark this message that we're working on it, so that no other process will take it
+            ## between two lines ago and here, should hopefully be quick enough
+            $userlock = Sql_Query(sprintf('replace into %s (entered,userid,messageid,status) values(now(),%d,%d,"active")', $tables['usermessage'], $userid, $messageid));
 
             if ($script_stage < 4) {
                 $script_stage = 4; # we know a subscriber to send to
@@ -983,23 +983,23 @@ while ($message = Sql_fetch_array($messages)) {
             $someusers = 1;
             $users = Sql_query("select id,email,uniqid,htmlemail,confirmed,blacklisted,disabled from {$tables['user']} where id = $userid");
 
-      # pick the first one (rather historical from before email was unique)
-      $user = Sql_fetch_Assoc($users);
+            # pick the first one (rather historical from before email was unique)
+            $user = Sql_fetch_Assoc($users);
             if ($user['confirmed'] && is_email($user['email'])) {
                 $userid = $user['id'];    # id of the subscriber
-        $useremail = $user['email']; # email of the subscriber
-        $userhash = $user['uniqid'];  # unique string of the user
-        $htmlpref = $user['htmlemail'];  # preference for HTML emails
-        $confirmed = $user['confirmed'] && !$user['disabled']; ## 7 = disabled flag
-        $blacklisted = $user['blacklisted'];
+                $useremail = $user['email']; # email of the subscriber
+                $userhash = $user['uniqid'];  # unique string of the user
+                $htmlpref = $user['htmlemail'];  # preference for HTML emails
+                $confirmed = $user['confirmed'] && !$user['disabled']; ## 7 = disabled flag
+                $blacklisted = $user['blacklisted'];
 
                 $cansend = !$blacklisted && $confirmed;
 /*
 ## Ask plugins if they are ok with sending this message to this user
 */
-      if (!empty($getspeedstats)) {
-          processQueueOutput('start check plugins ');
-      }
+                if (!empty($getspeedstats)) {
+                  processQueueOutput('start check plugins ');
+                }
 
                 reset($GLOBALS['plugins']);
                 while ($cansend && $plugin = current($GLOBALS['plugins'])) {
@@ -1024,7 +1024,7 @@ while ($message = Sql_fetch_array($messages)) {
 ####################################
 # Throttling
 
-        $throttled = 0;
+                $throttled = 0;
                 if ($cansend && USE_DOMAIN_THROTTLE) {
                     list($mailbox, $throttleDomain) = explode('@', $useremail);
                     foreach ($GLOBALS['plugins'] as $pluginname => $plugin) {
@@ -1037,20 +1037,20 @@ while ($message = Sql_fetch_array($messages)) {
                     $interval = $now - ($now % DOMAIN_BATCH_PERIOD);
                     if (!isset($domainthrottle[$throttleDomain]) || !is_array($domainthrottle[$throttleDomain])) {
                         $domainthrottle[$throttleDomain] = array(
-              'interval'  => '',
-              'sent'      => 0,
-              'attempted' => 0,
-            );
+                            'interval'  => '',
+                            'sent'      => 0,
+                            'attempted' => 0,
+                        );
                     } elseif (isset($domainthrottle[$throttleDomain]['interval']) && $domainthrottle[$throttleDomain]['interval'] == $interval) {
                         $throttled = $domainthrottle[$throttleDomain]['sent'] >= DOMAIN_BATCH_SIZE;
                         if ($throttled) {
                             ++$counters['send blocked by domain throttle'];
                             ++$domainthrottle[$throttleDomain]['attempted'];
                             if (DOMAIN_AUTO_THROTTLE
-                && $domainthrottle[$throttleDomain]['attempted'] > 25 # skip a few before auto throttling
-                && $num_messages <= 1 # only do this when there's only one message to process otherwise the other ones don't get a chance
-                && $counters['total_users_for_message '.$messageid] < 1000 # and also when there's not too many left, because then it's likely they're all being throttled
-              ) {
+                                && $domainthrottle[$throttleDomain]['attempted'] > 25 # skip a few before auto throttling
+                                && $num_messages <= 1 # only do this when there's only one message to process otherwise the other ones don't get a chance
+                                && $counters['total_users_for_message '.$messageid] < 1000 # and also when there's not too many left, because then it's likely they're all being throttled
+                            ) {
                                 $domainthrottle[$throttleDomain]['attempted'] = 0;
                                 logEvent(sprintf($GLOBALS['I18N']->get('There have been more than 10 attempts to send to %s that have been blocked for domain throttling.'), $throttleDomain));
                                 logEvent($GLOBALS['I18N']->get('Introducing extra delay to decrease throttle failures'));
@@ -1062,7 +1062,7 @@ while ($message = Sql_fetch_array($messages)) {
                                 } else {
                                     $running_throttle_delay += (int) (DOMAIN_BATCH_PERIOD / (DOMAIN_BATCH_SIZE * 4));
                                 }
-                #processQueueOutput("Running throttle delay: ".$running_throttle_delay);
+                                #processQueueOutput("Running throttle delay: ".$running_throttle_delay);
                             } elseif (VERBOSE) {
                                 processQueueOutput(sprintf($GLOBALS['I18N']->get('%s is currently over throttle limit of %d per %d seconds').' ('.$domainthrottle[$throttleDomain]['sent'].')', $throttleDomain, DOMAIN_BATCH_SIZE, DOMAIN_BATCH_PERIOD));
                             }
@@ -1092,12 +1092,12 @@ while ($message = Sql_fetch_array($messages)) {
                             $emailSentTimer = new timer();
                             ++$counters['batch_count'];
                             $success = sendEmail($messageid, $useremail, $userhash, $htmlpref); // $rssitems Obsolete by rssmanager plugin
-              if (!$success) {
-                  ++$counters['sendemail returned false total'];
-                  ++$counters['sendemail returned false'];
-              } else {
-                  $counters['sendemail returned false'] = 0;
-              }
+                            if (!$success) {
+                                ++$counters['sendemail returned false total'];
+                                ++$counters['sendemail returned false'];
+                            } else {
+                                $counters['sendemail returned false'] = 0;
+                            }
                             if ($counters['sendemail returned false'] > 10) {
                                 foreach ($GLOBALS['plugins'] as $pluginname => $plugin) {
                                     $plugin->processError(s('Warning: a lot of errors while sending campaign %d', $messageid));
@@ -1117,45 +1117,45 @@ while ($message = Sql_fetch_array($messages)) {
                         setMessageData($messageid, 'sentastest', $counters['sentastest']);
                     }
 
-          #############################
-          # tried to send email , process succes / failure
-          if ($success) {
-              if (USE_DOMAIN_THROTTLE) {
-                  if ($domainthrottle[$throttleDomain]['interval'] != $interval) {
-                      $domainthrottle[$throttleDomain]['interval'] = $interval;
-                      $domainthrottle[$throttleDomain]['sent'] = 1;
-                  } else {
-                      ++$domainthrottle[$throttleDomain]['sent'];
-                  }
-              }
-              ++$counters['sent'];
-              ++$counters['sent_users_for_message '.$messageid];
-              $um = Sql_Query(sprintf('replace into %s (entered,userid,messageid,status) values(now(),%d,%d,"sent")', $tables['usermessage'], $userid, $messageid));
+                    #############################
+                    # tried to send email , process succes / failure
+                    if ($success) {
+                        if (USE_DOMAIN_THROTTLE) {
+                          if ($domainthrottle[$throttleDomain]['interval'] != $interval) {
+                              $domainthrottle[$throttleDomain]['interval'] = $interval;
+                              $domainthrottle[$throttleDomain]['sent'] = 1;
+                          } else {
+                              ++$domainthrottle[$throttleDomain]['sent'];
+                          }
+                        }
+                        ++$counters['sent'];
+                        ++$counters['sent_users_for_message '.$messageid];
+                        $um = Sql_Query(sprintf('replace into %s (entered,userid,messageid,status) values(now(),%d,%d,"sent")', $tables['usermessage'], $userid, $messageid));
 
-          } else {
-              ++$counters['failed_sent'];
-              ++$counters['failed_sent_for_message '.$messageid];
-             ## need to check this, the entry shouldn't be there in the first place, so no need to delete it
-             ## might be a cause for duplicated emails
-             if (defined('MESSAGEQUEUE_PREPARE') && MESSAGEQUEUE_PREPARE) {
-                 Sql_Query(sprintf('update %s set status = "todo" where userid = %d and messageid = %d and status = "active"', $tables['usermessage'], $userid, $messageid));
-             } else {
-                 Sql_Query(sprintf('delete from %s where userid = %d and messageid = %d and status = "active"', $tables['usermessage'], $userid, $messageid));
-             }
-              if (VERBOSE) {
-                  processQueueOutput($GLOBALS['I18N']->get('Failed sending to').' '.$useremail);
-                  logEvent("Failed sending message $messageid to $useremail");
-              }
-             # make sure it's not because it's an underdeliverable email
-             # unconfirm this user, so they're not included next time
-             if (!$throttled && !validateEmail($useremail)) {
-                 ++$unconfirmed;
-                 ++$counters['email address invalidated'];
-                 logEvent("invalid email address $useremail user marked unconfirmed");
-                 Sql_Query(sprintf('update %s set confirmed = 0 where email = "%s"',
-                 $GLOBALS['tables']['user'], $useremail));
-             }
-          }
+                    } else {
+                        ++$counters['failed_sent'];
+                        ++$counters['failed_sent_for_message '.$messageid];
+                        ## need to check this, the entry shouldn't be there in the first place, so no need to delete it
+                        ## might be a cause for duplicated emails
+                        if (defined('MESSAGEQUEUE_PREPARE') && MESSAGEQUEUE_PREPARE) {
+                         Sql_Query(sprintf('update %s set status = "todo" where userid = %d and messageid = %d and status = "active"', $tables['usermessage'], $userid, $messageid));
+                        } else {
+                         Sql_Query(sprintf('delete from %s where userid = %d and messageid = %d and status = "active"', $tables['usermessage'], $userid, $messageid));
+                        }
+                        if (VERBOSE) {
+                          processQueueOutput($GLOBALS['I18N']->get('Failed sending to').' '.$useremail);
+                          logEvent("Failed sending message $messageid to $useremail");
+                        }
+                         # make sure it's not because it's an underdeliverable email
+                         # unconfirm this user, so they're not included next time
+                        if (!$throttled && !validateEmail($useremail)) {
+                             ++$unconfirmed;
+                             ++$counters['email address invalidated'];
+                             logEvent("invalid email address $useremail user marked unconfirmed");
+                             Sql_Query(sprintf('update %s set confirmed = 0 where email = "%s"',
+                                 $GLOBALS['tables']['user'], $useremail));
+                        }
+                    }
 
                     if ($script_stage < 5) {
                         $script_stage = 5; # we have actually sent one user
@@ -1164,7 +1164,7 @@ while ($message = Sql_fetch_array($messages)) {
                         sleep($running_throttle_delay);
                         if ($counters['sent'] % 5 == 0) {
                             # retry running faster after some more messages, to see if that helps
-               unset($running_throttle_delay);
+                            unset($running_throttle_delay);
                         }
                     } elseif (MAILQUEUE_THROTTLE) {
                         usleep(MAILQUEUE_THROTTLE * 1000000);
@@ -1173,104 +1173,104 @@ while ($message = Sql_fetch_array($messages)) {
                         $msgperhour = (3600 / $totaltime) * $counters['sent'];
                         $msgpersec = $msgperhour / 3600;
 
-             ##11336 - this may cause "division by 0", but 'secpermsg' isn't used at all
-           #  $secpermsg = $totaltime / $counters['sent'];
-             $target = (MAILQUEUE_BATCH_PERIOD / MAILQUEUE_BATCH_SIZE) * $counters['sent'];
+                        ##11336 - this may cause "division by 0", but 'secpermsg' isn't used at all
+                        #  $secpermsg = $totaltime / $counters['sent'];
+                        $target = (MAILQUEUE_BATCH_PERIOD / MAILQUEUE_BATCH_SIZE) * $counters['sent'];
                         $delay = $target - $totaltime;
 
                         if ($delay > 0) {
                             if (VERBOSE) {
                                 /* processQueueOutput($GLOBALS['I18N']->get('waiting for').' '.$delay.' '.$GLOBALS['I18N']->get('seconds').' '.
-                   $GLOBALS['I18N']->get('to make sure we don\'t exceed our limit of ').MAILQUEUE_BATCH_SIZE.' '.
-                   $GLOBALS['I18N']->get('messages in ').' '.MAILQUEUE_BATCH_PERIOD.$GLOBALS['I18N']->get('seconds')); */
-                processQueueOutput(sprintf($GLOBALS['I18N']->get('waiting for %.1f seconds to meet target of %s seconds per message'),
-                        $delay, (MAILQUEUE_BATCH_PERIOD / MAILQUEUE_BATCH_SIZE))
-                );
+                               $GLOBALS['I18N']->get('to make sure we don\'t exceed our limit of ').MAILQUEUE_BATCH_SIZE.' '.
+                               $GLOBALS['I18N']->get('messages in ').' '.MAILQUEUE_BATCH_PERIOD.$GLOBALS['I18N']->get('seconds')); */
+                                processQueueOutput(sprintf($GLOBALS['I18N']->get('waiting for %.1f seconds to meet target of %s seconds per message'),
+                                    $delay, (MAILQUEUE_BATCH_PERIOD / MAILQUEUE_BATCH_SIZE))
+                                );
                             }
                             usleep($delay * 1000000);
                         }
                     }
                 } else {
                     ++$cannotsend;
-          # mark it as sent anyway, because otherwise the process will never finish
-          if (VERBOSE) {
-              processQueueOutput($GLOBALS['I18N']->get('not sending to ').$useremail);
-          }
+                    # mark it as sent anyway, because otherwise the process will never finish
+                    if (VERBOSE) {
+                      processQueueOutput($GLOBALS['I18N']->get('not sending to ').$useremail);
+                    }
                     $um = Sql_query("replace into {$tables['usermessage']} (entered,userid,messageid,status) values(now(),$userid,$messageid,\"not sent\")");
                 }
 
-        # update possible other users matching this email as well,
-        # to avoid duplicate sending when people have subscribed multiple times
-        # bit of legacy code after making email unique in the database
-#        $emails = Sql_query("select * from {$tables['user']} where email =\"$useremail\"");
-#        while ($email = Sql_fetch_row($emails))
-#          Sql_query("replace into {$tables['usermessage']} (userid,messageid) values($email[0],$messageid)");
+                # update possible other users matching this email as well,
+                # to avoid duplicate sending when people have subscribed multiple times
+                # bit of legacy code after making email unique in the database
+                #        $emails = Sql_query("select * from {$tables['user']} where email =\"$useremail\"");
+                #        while ($email = Sql_fetch_row($emails))
+                #          Sql_query("replace into {$tables['usermessage']} (userid,messageid) values($email[0],$messageid)");
             } else {
                 # some "invalid emails" are entirely empty, ah, that is because they are unconfirmed
 
-        ## this is quite old as well, with the preselection that avoids unconfirmed users
-        # it is unlikely this is every processed.
+                ## this is quite old as well, with the preselection that avoids unconfirmed users
+                # it is unlikely this is every processed.
 
-        if (!$user['confirmed'] || $user['disabled']) {
-            if (VERBOSE) {
-                processQueueOutput($GLOBALS['I18N']->get('Unconfirmed user').': '.$userid.' '.$user['email'].' '.$user['id']);
-            }
-            ++$unconfirmed;
-          # when running from commandline we mark it as sent, otherwise we might get
-          # stuck when using batch processing
-         # if ($GLOBALS["commandline"]) {
-            $um = Sql_query("replace into {$tables['usermessage']} (entered,userid,messageid,status) values(now(),$userid,$messageid,\"unconfirmed user\")");
-         # }
-        } elseif ($user['email'] || $user['id']) {
-            if (VERBOSE) {
-                processQueueOutput(s('Invalid email address').': '.$user['email'].' '.$user['id']);
-            }
-            logEvent(s('Invalid email address').': userid  '.$user['id'].'  email '.$user['email']);
-          # mark it as sent anyway
-          if ($user['id']) {
-              $um = Sql_query(sprintf('replace into %s (entered,userid,messageid,status) values(now(),%d,%d,"invalid email address")', $tables['usermessage'], $userid, $messageid));
-              Sql_Query(sprintf('update %s set confirmed = 0 where id = %d',
-              $GLOBALS['tables']['user'], $user['id']));
-              addUserHistory(
-                $user['email'],
-                s('Subscriber marked unconfirmed for invalid email address'),
-                s('Marked unconfirmed while sending campaign %d', $messageid)
-            );
-          }
-            ++$counters['invalid'];
-        }
+                if (!$user['confirmed'] || $user['disabled']) {
+                    if (VERBOSE) {
+                        processQueueOutput($GLOBALS['I18N']->get('Unconfirmed user').': '.$userid.' '.$user['email'].' '.$user['id']);
+                    }
+                    ++$unconfirmed;
+                    # when running from commandline we mark it as sent, otherwise we might get
+                    # stuck when using batch processing
+                    # if ($GLOBALS["commandline"]) {
+                    $um = Sql_query("replace into {$tables['usermessage']} (entered,userid,messageid,status) values(now(),$userid,$messageid,\"unconfirmed user\")");
+                    # }
+                } elseif ($user['email'] || $user['id']) {
+                    if (VERBOSE) {
+                        processQueueOutput(s('Invalid email address').': '.$user['email'].' '.$user['id']);
+                    }
+                    logEvent(s('Invalid email address').': userid  '.$user['id'].'  email '.$user['email']);
+                    # mark it as sent anyway
+                    if ($user['id']) {
+                        $um = Sql_query(sprintf('replace into %s (entered,userid,messageid,status) values(now(),%d,%d,"invalid email address")', $tables['usermessage'], $userid, $messageid));
+                        Sql_Query(sprintf('update %s set confirmed = 0 where id = %d',
+                        $GLOBALS['tables']['user'], $user['id']));
+                        addUserHistory(
+                            $user['email'],
+                            s('Subscriber marked unconfirmed for invalid email address'),
+                            s('Marked unconfirmed while sending campaign %d', $messageid)
+                        );
+                    }
+                    ++$counters['invalid'];
+                }
             }
         } else {
 
-      ## and this is quite historical, and also unlikely to be every called
-      # because we now exclude users who have received the message from the
-      # query to find users to send to
+            ## and this is quite historical, and also unlikely to be every called
+            # because we now exclude users who have received the message from the
+            # query to find users to send to
 
-      ## when trying to send the message, it was already marked for this user
-      ## June 2010, with the multiple send process extension, that's quite possible to happen again
+            ## when trying to send the message, it was already marked for this user
+            ## June 2010, with the multiple send process extension, that's quite possible to happen again
 
-      $um = Sql_Fetch_Row($um);
-            ++$notsent;
-            if (VERBOSE) {
-                processQueueOutput($GLOBALS['I18N']->get('Not sending to').' '.$userid.', '.$GLOBALS['I18N']->get('already sent').' '.$um[0]);
-            }
+            $um = Sql_Fetch_Row($um);
+                ++$notsent;
+                if (VERBOSE) {
+                    processQueueOutput($GLOBALS['I18N']->get('Not sending to').' '.$userid.', '.$GLOBALS['I18N']->get('already sent').' '.$um[0]);
+                }
         }
         $status = Sql_query("update {$tables['message']} set processed = processed + 1 where id = $messageid");
         $processed = $notsent + $counters['sent'] + $counters['invalid'] + $unconfirmed + $cannotsend + $counters['failed_sent'];
-    #if ($processed % 10 == 0) {
-    if (0) {
-        processQueueOutput('AR'.$affrows.' N '.$counters['total_users_for_message '.$messageid].' P'.$processed.' S'.$counters['sent'].' N'.$notsent.' I'.$counters['invalid'].' U'.$unconfirmed.' C'.$cannotsend.' F'.$counters['failed_sent']);
-        $rn = $reload * $counters['num_per_batch'];
-        processQueueOutput('P '.$processed.' N'.$counters['total_users_for_message '.$messageid].' NB'.$counters['num_per_batch'].' BT'.$batch_total.' R'.$reload.' RN'.$rn);
-    }
-    /* 
-     * don't calculate this here, but in the "msgstatus" instead, so that
-     * the total speed can be calculated, eg when there are multiple send processes
-     * 
-     * re-added for commandline outputting
-     */
+        #if ($processed % 10 == 0) {
+        if (0) {
+            processQueueOutput('AR'.$affrows.' N '.$counters['total_users_for_message '.$messageid].' P'.$processed.' S'.$counters['sent'].' N'.$notsent.' I'.$counters['invalid'].' U'.$unconfirmed.' C'.$cannotsend.' F'.$counters['failed_sent']);
+            $rn = $reload * $counters['num_per_batch'];
+            processQueueOutput('P '.$processed.' N'.$counters['total_users_for_message '.$messageid].' NB'.$counters['num_per_batch'].' BT'.$batch_total.' R'.$reload.' RN'.$rn);
+        }
+        /* 
+         * don't calculate this here, but in the "msgstatus" instead, so that
+         * the total speed can be calculated, eg when there are multiple send processes
+         * 
+         * re-added for commandline outputting
+         */
 
-    $totaltime = $GLOBALS['processqueue_timer']->elapsed(1);
+        $totaltime = $GLOBALS['processqueue_timer']->elapsed(1);
         if ($counters['sent'] > 0) {
             $msgperhour = (3600 / $totaltime) * $counters['sent'];
             $secpermsg = $totaltime / $counters['sent'];
@@ -1289,19 +1289,19 @@ while ($message = Sql_fetch_array($messages)) {
 
         setMessageData($messageid, 'to process', $counters['total_users_for_message '.$messageid] - $counters['sent']);
         setMessageData($messageid, 'last msg sent', time());
-  #  setMessageData($messageid,'totaltime',$GLOBALS['processqueue_timer']->elapsed(1));
-    if (!empty($getspeedstats)) {
-        processQueueOutput('end process user '."\n".'-----------------------------------'."\n".$userid);
-    }
+        #  setMessageData($messageid,'totaltime',$GLOBALS['processqueue_timer']->elapsed(1));
+        if (!empty($getspeedstats)) {
+            processQueueOutput('end process user '."\n".'-----------------------------------'."\n".$userid);
+        }
     }
     $processed = $notsent + $counters['sent'] + $counters['invalid'] + $unconfirmed + $cannotsend + $counters['failed_sent'];
     processQueueOutput(s('Processed %d out of %d subscribers', $counters['processed_users_for_message '.$messageid], $counters['total_users_for_message '.$messageid]), 1, 'progress');
 
     if ($counters['total_users_for_message '.$messageid] - $counters['sent_users_for_message '.$messageid] <= 0 || $stopSending) {
         # this message is done
-    if (!$someusers) {
-        processQueueOutput($GLOBALS['I18N']->get('Hmmm, No users found to send to'), 1, 'progress');
-    }
+        if (!$someusers) {
+            processQueueOutput($GLOBALS['I18N']->get('Hmmm, No users found to send to'), 1, 'progress');
+        }
         if (!$counters['failed_sent']) {
             repeatMessage($messageid);
             foreach ($GLOBALS['plugins'] as $pluginname => $plugin) {
@@ -1325,12 +1325,12 @@ while ($message = Sql_fetch_array($messages)) {
             processQueueOutput($GLOBALS['I18N']->get('It took').' '.timeDiff($timetaken[0], $timetaken[1]).' '.$GLOBALS['I18N']->get('to send this message'));
             sendMessageStats($messageid);
         }
-    ## flush cached message track stats to the DB
-    if (isset($GLOBALS['cached']['linktracksent'])) {
-        flushClicktrackCache();
-      # we're done with $messageid, so get rid of the cache
-      unset($GLOBALS['cached']['linktracksent'][$messageid]);
-    }
+        ## flush cached message track stats to the DB
+        if (isset($GLOBALS['cached']['linktracksent'])) {
+            flushClicktrackCache();
+            # we're done with $messageid, so get rid of the cache
+            unset($GLOBALS['cached']['linktracksent'][$messageid]);
+        }
     } else {
         if ($script_stage < 5) {
             $script_stage = 5;


### PR DESCRIPTION
This PR covers the part of the Mantis issue concerning the batch limit being compared with the number of subscribers processed instead of the number of subscribers who have actually been sent an email. Currently sending to  a subset of subscribers, for example using the Segment plugin, takes the same length of time as sending to the full list, apart from any throttle. A comment regarding the throttle also being applied was wrong.

There are three commits. The first and last consist only of making the indentation consistent, the real changes are in the second commit. The approach is to use the number of emails sent for a message when testing whether the batch limit has been reached. If a subscriber is rejected by a plugin then it does not count towards the batch limit, but does count towards the number processed.

I removed a chunk of code that set a LIMIT (based on the batch size) for the user query, because the main loop has to process an open-ended number of users. The other changes are to use the appropriate counter where needed, and moving some code to the end of the loop.