### PR TITLE
Mantis 18011 - Change "Messages" to "Message" in user history table

### DIFF
--- a/public_html/lists/admin/inc/interfacelib.php
+++ b/public_html/lists/admin/inc/interfacelib.php
@@ -55,6 +55,7 @@ class UIPanel
 class WebblerListing
 {
     public $title;
+    public $elementHeading;
     public $help;
     public $elements = array();
     public $columns = array();
@@ -85,6 +86,11 @@ class WebblerListing
             $this->suppressGreenline();
             $this->buttonsOutsideTable = true;
         }
+    }
+
+    public function setElementHeading($heading)
+    {
+        $this->elementHeading = $heading;
     }
 
     public function noShader()
@@ -232,9 +238,11 @@ class WebblerListing
         if (!count($this->columns)) {
             $tophelp = $this->help;
         }
+
+        $heading = isset($this->elementHeading) ? $this->elementHeading : $this->title;
         $html = '<tr valign="top">';
         $html .= sprintf('<th><a name="%s"></a><div class="listinghdname">%s%s</div></th>',
-            str_replace(' ', '_', htmlspecialchars(mb_strtolower($this->title))), $tophelp, $this->title);
+            str_replace(' ', '_', htmlspecialchars(mb_strtolower($heading))), $tophelp, $heading);
         $c = 1;
         foreach ($this->columns as $column => $columnname) {
             if ($c == count($this->columns)) {
@@ -488,7 +496,8 @@ class WebblerListing
 
     public function tabDelimited()
     {
-        print $this->title . "\t";
+        $heading = isset($this->elementHeading) ? $this->elementHeading : $this->title;
+        print $heading . "\t";
         foreach ($this->columns as $column => $columnname) {
             print $this->plainText($column) . "\t";
         }

--- a/public_html/lists/admin/userhistory.php
+++ b/public_html/lists/admin/userhistory.php
@@ -94,6 +94,8 @@ printf('%d ' . $GLOBALS['I18N']->get('messages sent to this user') . '<br/>', $n
 if ($num) {
     $resptime = 0;
     $totalresp = 0;
+    $ls->setElementHeading($GLOBALS['I18N']->get('Campaign Id'));
+
     while ($msg = Sql_Fetch_Array($msgs)) {
         $ls->addElement($msg['messageid'],
             PageURL2('message', $GLOBALS['I18N']->get('view'), 'id=' . $msg['messageid']));
@@ -178,6 +180,7 @@ if (isBlackListed($user['email'])) {
 }
 
 $ls = new WebblerListing($GLOBALS['I18N']->get('Subscription History'));
+$ls->setElementHeading($GLOBALS['I18N']->get('Event'));
 $req = Sql_Query(sprintf('select * from %s where userid = %d order by id desc', $tables['user_history'], $user['id']));
 if (!Sql_Affected_Rows()) {
     print $GLOBALS['I18N']->get('no details found');


### PR DESCRIPTION
This change adds a field to the WebblerListing class for the heading of the left most column (the element heading). This allows different text to be used for the panel title and the column heading, which currently are the same.

There are also changes to the userhistory page to use the new field.