### PR TITLE
[TASK] Make all .htaccess files Apache 2.4 compatible

### DIFF
--- a/public_html/lists/.htaccess
+++ b/public_html/lists/.htaccess
@@ -2,12 +2,28 @@
 DirectoryIndex index.php
 
 <FilesMatch "\.(php|inc)$">
-Order allow,deny
-deny from all
+	# Apache < 2.3
+	<IfModule !mod_authz_core.c>
+		Order allow,deny
+		Deny from all
+		Satisfy All
+	</IfModule>
+	# Apache ≥ 2.3
+	<IfModule mod_authz_core.c>
+		Require all denied
+	</IfModule>
 </FilesMatch>
 <FilesMatch "(index.php|dl.php|ut.php|lt.php|download.php|connector.php)$">
-Order allow,deny
-allow from all
+	# Apache < 2.3
+	<IfModule !mod_authz_core.c>
+		Order allow,deny
+		Allow from all
+		Satisfy All
+	</IfModule>
+	# Apache ≥ 2.3
+	<IfModule mod_authz_core.c>
+		Require all granted
+	</IfModule>
 </FilesMatch>
 
 # if you want more than this for attachments, you can increase these values

--- a/public_html/lists/admin/.htaccess
+++ b/public_html/lists/admin/.htaccess
@@ -1,8 +1,24 @@
 <FilesMatch "\.(php|inc)$">
-Order allow,deny
-Deny from all
+	# Apache < 2.3
+	<IfModule !mod_authz_core.c>
+		Order allow,deny
+		Deny from all
+		Satisfy All
+	</IfModule>
+	# Apache ≥ 2.3
+	<IfModule mod_authz_core.c>
+		Require all denied
+	</IfModule>
 </FilesMatch>
 <FilesMatch "(index.php|connector.php|upload.php)$">
-Order allow,deny
-allow from all
+	# Apache < 2.3
+	<IfModule !mod_authz_core.c>
+		Order allow,deny
+		Allow from all
+		Satisfy All
+	</IfModule>
+	# Apache ≥ 2.3
+	<IfModule mod_authz_core.c>
+		Require all granted
+	</IfModule>
 </FilesMatch>

--- a/public_html/lists/admin/actions/.htaccess
+++ b/public_html/lists/admin/actions/.htaccess
@@ -1,2 +1,12 @@
-Order allow,deny
-deny from all
+<FilesMatch "\.(php|inc)$">
+	# Apache < 2.3
+	<IfModule !mod_authz_core.c>
+		Order allow,deny
+		Deny from all
+		Satisfy All
+	</IfModule>
+	# Apache ≥ 2.3
+	<IfModule mod_authz_core.c>
+		Require all denied
+	</IfModule>
+</FilesMatch>

--- a/public_html/lists/admin/inc/.htaccess
+++ b/public_html/lists/admin/inc/.htaccess
@@ -1,4 +1,12 @@
 <FilesMatch "\.(php|inc)$">
-Order allow,deny
-deny from all
+	# Apache < 2.3
+	<IfModule !mod_authz_core.c>
+		Order allow,deny
+		Deny from all
+		Satisfy All
+	</IfModule>
+	# Apache ≥ 2.3
+	<IfModule mod_authz_core.c>
+		Require all denied
+	</IfModule>
 </FilesMatch>

--- a/public_html/lists/admin/onyxrss/.htaccess
+++ b/public_html/lists/admin/onyxrss/.htaccess
@@ -1,8 +1,24 @@
 <FilesMatch "\.(php|inc)$">
-Order allow,deny
-deny from all
+	# Apache < 2.3
+	<IfModule !mod_authz_core.c>
+		Order allow,deny
+		Deny from all
+		Satisfy All
+	</IfModule>
+	# Apache ≥ 2.3
+	<IfModule mod_authz_core.c>
+		Require all denied
+	</IfModule>
 </FilesMatch>
 <FilesMatch "index.php$">
-Order allow,deny
-allow from all
+	# Apache < 2.3
+	<IfModule !mod_authz_core.c>
+		Order allow,deny
+		Allow from all
+		Satisfy All
+	</IfModule>
+	# Apache ≥ 2.3
+	<IfModule mod_authz_core.c>
+		Require all granted
+	</IfModule>
 </FilesMatch>

--- a/public_html/lists/admin/plugins/.htaccess
+++ b/public_html/lists/admin/plugins/.htaccess
@@ -1,8 +1,24 @@
 <FilesMatch "\.(php|inc)$">
-Order allow,deny
-deny from all
+	# Apache < 2.3
+	<IfModule !mod_authz_core.c>
+		Order allow,deny
+		Deny from all
+		Satisfy All
+	</IfModule>
+	# Apache ≥ 2.3
+	<IfModule mod_authz_core.c>
+		Require all denied
+	</IfModule>
 </FilesMatch>
 <FilesMatch "index.php$">
-Order allow,deny
-allow from all
+	# Apache < 2.3
+	<IfModule !mod_authz_core.c>
+		Order allow,deny
+		Allow from all
+		Satisfy All
+	</IfModule>
+	# Apache ≥ 2.3
+	<IfModule mod_authz_core.c>
+		Require all granted
+	</IfModule>
 </FilesMatch>

--- a/public_html/lists/config/.htaccess
+++ b/public_html/lists/config/.htaccess
@@ -1,2 +1,12 @@
-Order allow,deny
-deny from all
+<FilesMatch "\.(php|inc)$">
+	# Apache < 2.3
+	<IfModule !mod_authz_core.c>
+		Order allow,deny
+		Deny from all
+		Satisfy All
+	</IfModule>
+	# Apache ≥ 2.3
+	<IfModule mod_authz_core.c>
+		Require all denied
+	</IfModule>
+</FilesMatch>


### PR DESCRIPTION
mod_access_compat may not be loaded in Apache 2.4, hence
the new access control directives must be used.