### PR TITLE
Mantis 17918 - plugins control authentication

### DIFF
--- a/public_html/lists/admin/admins.php
+++ b/public_html/lists/admin/admins.php
@@ -7,7 +7,7 @@ if (isset($_GET['remember_find'])) {
     $remember_find = '';
 }
 
-$external = $require_login && $GLOBALS['admin_auth_module'] != 'phplist_auth.inc';
+$external = $require_login && !is_a($GLOBALS['admin_auth'], 'phpListAdminAuthentication');
 $start = isset($_GET['start']) ? sprintf('%d', $_GET['start']) : 0;
 $listid = isset($_GET['id']) ? sprintf('%d', $_GET['id']) : 0;
 $find = isset($_REQUEST['find']) ? $_REQUEST['find'] : '';

--- a/public_html/lists/admin/index.php
+++ b/public_html/lists/admin/index.php
@@ -240,7 +240,7 @@ if (!empty($GLOBALS['require_login'])) {
     $remoteAddr = getClientIP();
 
     if ($GLOBALS['authenticationplugin']) {
-        $GLOBALS['admin_auth'] = new $GLOBALS['authenticationplugin']();
+        $GLOBALS['admin_auth'] = $GLOBALS['plugins'][$GLOBALS['authenticationplugin']];
     } else {
         require __DIR__ . '/phpListAdminAuthentication.php';
         $GLOBALS['admin_auth'] = new phpListAdminAuthentication();

--- a/public_html/lists/admin/index.php
+++ b/public_html/lists/admin/index.php
@@ -239,12 +239,11 @@ if (!empty($GLOBALS['require_login'])) {
     #bth 7.1.2015 to support x-forwarded-for
     $remoteAddr = getClientIP();
 
-    if (class_exists($GLOBALS['authenticationplugin'])) {
+    if ($GLOBALS['authenticationplugin']) {
         $GLOBALS['admin_auth'] = new $GLOBALS['authenticationplugin']();
     } else {
-        print Fatal_Error($GLOBALS['I18N']->get('Admin Authentication initialisation failure'));
-
-        return;
+        require __DIR__ . '/phpListAdminAuthentication.php';
+        $GLOBALS['admin_auth'] = new phpListAdminAuthentication();
     }
     if ((!isset($_SESSION['adminloggedin']) || !$_SESSION['adminloggedin']) && isset($_REQUEST['login']) && isset($_REQUEST['password']) && !empty($_REQUEST['password'])) {
         $loginresult = $GLOBALS['admin_auth']->validateLogin($_REQUEST['login'], $_REQUEST['password']);

--- a/public_html/lists/admin/phpListAdminAuthentication.php
+++ b/public_html/lists/admin/phpListAdminAuthentication.php
@@ -1,12 +1,11 @@
 <?php
 
-class phpListAdminAuthentication extends phplistPlugin
+class phpListAdminAuthentication
 {
-    public $name = 'Default phpList Authentication Plugin';
+    public $name = 'Default phpList Authentication';
     public $version = 0.1;
     public $authors = 'Michiel Dethmers';
     public $description = 'Provides authentication to phpList using the internal phpList administration database';
-    public $authProvider = true;
 
     /**
      * validateLogin, verify that the login credentials are correct.

--- a/public_html/lists/admin/pluginlib.php
+++ b/public_html/lists/admin/pluginlib.php
@@ -55,8 +55,6 @@ foreach ($pluginRootDirs as $pluginRootDir) {
         closedir($dh);
     }
 }
-// load the defaultAdminAuth last, to fall back to it
-array_push($pluginFiles, dirname(__FILE__) . '/phpListAdminAuthentication.php');
 
 $auto_enable_plugins = array();
 if (isset($GLOBALS['plugins_autoenable'])) {
@@ -132,13 +130,6 @@ foreach ($pluginFiles as $file) {
             #print "$className = ".$pluginInstance->name."<br/>";
         }
     }
-}
-## enable the default auth plugin, if no other was activated
-if (empty($GLOBALS['authenticationplugin'])) {
-    $GLOBALS['authenticationplugin'] = 'phpListAdminAuthentication';
-} else {
-# otherwise remove it, so it can't be enabled either
-    unset($GLOBALS['allplugins']['phpListAdminAuthentication']);
 }
 
 $GLOBALS['pluginsendformats'] = array();


### PR DESCRIPTION
These changes fix the problem of admins being read-only on the admins page, and also (I think) simplifies the selection of the admin authentication class.

admins.php - correct the test of whether authentication is being done externally

phpListAdminAuthentication.php - change to not be a plugin, just a class.

pluginlib.php - sets $authenticationplugin only for a "real" plugin. Remove code that handles phpListAdminAuthentication as a plugin.

index.php - now $authenticationplugin is set if a plugin wants to handle authentication, otherwise fallback to the internal class. Use the already-existing instance of the plugin class instead of creating a new one.