### PR TITLE
Fix Reply-To header support

### DIFF
--- a/public_html/lists/admin/lib.php
+++ b/public_html/lists/admin/lib.php
@@ -511,7 +511,9 @@ function sendMailPhpMailer($to, $subject, $message)
     $removeurl = getConfig('unsubscribeurl');
     $sep = strpos($removeurl, '?') === false ? '?' : '&';
     $mail->addCustomHeader('List-Unsubscribe: <' . $removeurl . $sep . 'email=' . $to . '&jo=1>');
-
+    if(isset($reply_to)) {
+        $mail->addCustomHeader('Reply-To: '.$reply_to);
+    }
     return $mail->compatSend('', $destinationemail, $fromname, $fromemail, $subject);
 }
 


### PR DESCRIPTION
While there is a function in the GUI to define a Reply-To address it simply is never used, as can be seen in the code path `$reply_to` is unused and the resulting mails do not contain any header.

This is not the most elegant fix but does it's work.

cc @jospoortvliet To what lengths I go for you :-)
cc @samtuke Howdy 😉 
