### PR TITLE
Added comma separator between statistics

### DIFF
--- a/public_html/lists/admin/list.php
+++ b/public_html/lists/admin/list.php
@@ -33,7 +33,7 @@ function listMemberCounts($listId)
     $counts = Sql_Fetch_Assoc($req);
     $membersDisplay = sprintf(
         '<span class="memberCount" title="%s">%s</span>' .  ' ('
-        . '<span class="unconfirmedCount" title="%s">%s</span>' . ' '
+        . '<span class="unconfirmedCount" title="%s">%s</span>, ' . ' '
         . '<span class="blacklistedCount" title="%s">%s</span>' . ')',
         s('Confirmed members'),
         number_format($counts['confirmed']),


### PR DESCRIPTION
Changed "Subscriber lists" page list member stats formatting from:

List name 1 (2 0)

To:

List name 1 (2, 0)