### PR TITLE
Capitalised language names; Switched Czech to use local language name

### DIFF
--- a/public_html/lists/admin/locale/cs/language_info
+++ b/public_html/lists/admin/locale/cs/language_info
@@ -1,3 +1,3 @@
-name=Czech
+name=&#268;esky
 charset=UTF-8
 

--- a/public_html/lists/admin/locale/en/language_info
+++ b/public_html/lists/admin/locale/en/language_info
@@ -1,3 +1,3 @@
-name=english
+name=English
 charset=UTF-8
 

--- a/public_html/lists/admin/locale/es/language_info
+++ b/public_html/lists/admin/locale/es/language_info
@@ -1,3 +1,3 @@
-name=espa&ntilde;ol
+name=Espa&ntilde;ol
 charset=UTF-8
 

--- a/public_html/lists/admin/locale/it/language_info
+++ b/public_html/lists/admin/locale/it/language_info
@@ -1,3 +1,3 @@
-name=italiano
+name=Italiano
 charset=UTF-8
 

--- a/public_html/lists/admin/locale/pl/language_info
+++ b/public_html/lists/admin/locale/pl/language_info
@@ -1,3 +1,3 @@
-name=polski
+name=Polski
 charset=iso-8859-2
 

--- a/public_html/lists/admin/locale/pt_BR/language_info
+++ b/public_html/lists/admin/locale/pt_BR/language_info
@@ -1,3 +1,3 @@
-name=portugu&ecirc;s (Brazil)
+name=Portugu&ecirc;s (Brazil)
 charset=iso-8859-1
 


### PR DESCRIPTION
Improving language names as they appear in the phpList interface. Please check that this patch will not conflict with Pootle localisation automation / integration before merging.