### PR TITLE
Use $id instead of $_GET['id']

### DIFF
--- a/public_html/lists/admin/viewtemplate.php
+++ b/public_html/lists/admin/viewtemplate.php
@@ -17,7 +17,7 @@ if (empty($_GET['embed'])) {
     print '<iframe src="?page=viewtemplate&embed=yes&omitall=yes&id=' . $id . $more . '"
     scrolling="auto" width=100% height=450 margin=0 frameborder=0>
   </iframe>';
-    print '<p class="button">' . PageLink2('template&amp;id=' . $_GET['id'],
+    print '<p class="button">' . PageLink2('template&amp;id=' . $id,
             $GLOBALS['I18N']->get('Back to edit template')) . '</p>';
 } else {
     ob_end_clean();


### PR DESCRIPTION
$_GET['id'] is user-controlled input, since it is not sanitized and printed directly this leads to a reflected XSS vulnerability.

$id itself is fine since the code above guarantees that it is an integer.

Fixes https://hackerone.com/reports/153799, this has been reported to the PHPList developers on July 28th. Since no further updates have been coming I decided to create a patch myself.