### PR TITLE
Mantis_18133 - Incorrect parameters to mysqli_connect

### DIFF
--- a/public_html/lists/admin/init.php
+++ b/public_html/lists/admin/init.php
@@ -148,6 +148,12 @@ if (empty($GLOBALS['language_module'])) {
 if (empty($GLOBALS['database_module']) || !is_file(dirname(__FILE__) . '/' . $GLOBALS['database_module'])) {
     $GLOBALS['database_module'] = 'mysqli.inc';
 }
+if (!isset($database_port)) {
+    $database_port = null;
+}
+if (!isset($database_socket)) {
+    $database_socket = null;
+}
 if (!isset($database_connection_compression)) {
     $database_connection_compression = false;
 }

--- a/public_html/lists/admin/mysqli.inc
+++ b/public_html/lists/admin/mysqli.inc
@@ -3,7 +3,7 @@
 # sql functions, currently only set up to work with MySql
 # replace functions in this file to make it work with other Databases
 
-if (!function_exists("mysqli_connect")) {
+if (!function_exists("mysqli_init")) {
     header('Mysqli functionality missing', true, 500);
     print "Fatal Error: Mysql is not supported in your PHP, recompile and try again.";
     exit;
@@ -11,18 +11,20 @@ if (!function_exists("mysqli_connect")) {
 
 function Sql_Connect($host, $user, $password, $database)
 {
-    $compress = (empty($GLOBALS['database_connection_compression'])) ? 0 : MYSQLI_CLIENT_COMPRESS;
-    $secure = (empty($GLOBALS['database_connection_ssl'])) ? 0 : MYSQLI_CLIENT_SSL;
+    global $database_port, $database_socket, $database_connection_compression, $database_connection_ssl;
 
-    if ($host && $user) {
-        $db = mysqli_connect($host, $user, $password, false, $compress | $secure);
+    if (!$host || !$user) {
+        header('Cannot connect to database', true, 508);
+        print "Cannot connect to Database, host and user are required. Please check your configuration";
+        exit;
     }
-    $errno = mysqli_connect_errno();
-    if (!$errno) {
-        $res = mysqli_select_db($db, $database);
-        $errno = mysqli_errno($db);
-    }
-    if ($errno) {
+    $db = mysqli_init();
+    $compress = empty($database_connection_compression) ? 0 : MYSQLI_CLIENT_COMPRESS;
+    $secure = empty($database_connection_ssl) ? 0 : MYSQLI_CLIENT_SSL;
+
+    if (!mysqli_real_connect($db, $host, $user, $password, $database, $database_port, $database_socket, $compress | $secure)) {
+        $errno = mysqli_connect_errno();
+
         if (isset($GLOBALS['plugins']) && is_array($GLOBALS['plugins'])) {
             foreach ($GLOBALS['plugins'] as $pluginname => $plugin) {
                 $plugin->processDBerror($errno);
@@ -72,6 +74,7 @@ function Sql_Connect($host, $user, $password, $database)
     }
     mysqli_query($db, "SET NAMES 'utf8'");
     unset($GLOBALS['lastquery']);
+
     return $db;
 }
 

--- a/public_html/lists/config/config_extended.php
+++ b/public_html/lists/config/config_extended.php
@@ -29,6 +29,12 @@ $database_user = 'phplist';
 # and what password do we use
 $database_password = 'phplist';
 
+# the mysql server port number if not the default
+$database_port = null;
+
+# the socket to be used
+$database_socket = null;
+
 # enable database connection compression
 $database_connection_compression = false;
 


### PR DESCRIPTION
Use mysqli_init and mysqli_real_connect instead of mysqli_connect.
Add config parameters for the port and socket, which are used by mysqli_real_connect.