### PR TITLE
Mantis 18345 - link tracking in test messages

### DIFF
--- a/public_html/lists/lt.php
+++ b/public_html/lists/lt.php
@@ -79,15 +79,9 @@ $allowPersonalised = true;
 ## normal URLS on test messages, but block personalised ones
 $allowed = Sql_Fetch_Row_Query(sprintf('select userid from %s where userid = %d and messageid = %d',
     $GLOBALS['tables']['usermessage'], $userid, $messageid));
-if ($allowed[0] != $userid || !$allowed[0])  {
-    ## has this campaign been sent yet, if not, it's most likely an admin testing
-    $sent = Sql_Fetch_Row_Query(sprintf('select count(userid) from %s where messageid = %d',
-        $GLOBALS['tables']['usermessage'], $messageid));
-    if (empty($sent[0])) {
-        $allowPersonalised = !empty($_SESSION['adminloggedin']);
-    } else {
-        FileNotFound();
-    }
+
+if (!$allowed) {
+    $allowPersonalised = !empty($_SESSION['adminloggedin']);
 }
 
 ## hmm a bit heavy to use here @@@optimise

--- a/public_html/lists/lt.php
+++ b/public_html/lists/lt.php
@@ -73,7 +73,7 @@ if (!$fwdid || $linkdata['id'] != $fwdid || !$userid || !$messageid || $userid !
     exit;
 }
 
-$allowPersonalised = false;
+$allowPersonalised = true;
 
 ## verify that this subscriber actually received this message, otherwise they're not allowed
 ## normal URLS on test messages, but block personalised ones


### PR DESCRIPTION
Three commits

- correct the assignment of $allowPersonalised. It defaulted to false instead of true.

- remove validation of whether a campaign has been sent, as there is a scenario where a campaign can be edited after being sent and further test emails sent out. These would fail with a 404 error.

- use a regular expression to simplify the decoding of the linktrack id