### PR TITLE
Tighten simplified linktrack decoding

### DIFF
--- a/public_html/lists/lt.php
+++ b/public_html/lists/lt.php
@@ -47,7 +47,7 @@ if ($id != $_GET['id']) {
 $track = base64_decode($id);
 $track = $track ^ XORmask;
 
-if (!preg_match('/^(H|T)\|(\d+)\|(\d+)\|(\d+)$/', $track, $matches)) {
+if (!preg_match('/^(H|T)\|([1-9]\d*)\|([1-9]\d*)\|([1-9]\d*)$/', $track, $matches)) {
     FileNotFound();
     exit;
 }


### PR DESCRIPTION
Reject inputs with leading zero's as they are never used