### PR TITLE
Fixed missing space in anchor text

### DIFF
--- a/public_html/lists/admin/home.php
+++ b/public_html/lists/admin/home.php
@@ -380,7 +380,7 @@ if (checkAccess('initialise') && !$_GET['pi']) {
     $some = 1;
     $element = $GLOBALS['I18N']->get('setup');
     $ls->addElement($element, PageURL2('setup'));
-    $ls->addColumn($element, '&nbsp;', PageLinkClass('setup', $GLOBALS['I18N']->get('Setup ') . NAME, '', 'hometext'));
+    $ls->addColumn($element, '&nbsp;', PageLinkClass('setup', $GLOBALS['I18N']->get('Setup ') . ' ' . NAME, '', 'hometext'));
     $ls->setClass($element, 'setup');
 }
 if (checkAccess('upgrade') && !$_GET['pi'] && $upgrade_required) {


### PR DESCRIPTION
Changes e.g. "SetupphpList" to "Setup phpList"