### PR TITLE
Mantis 18294 Allow a plugin to be responsible for sending emails

### DIFF
--- a/public_html/lists/admin/EmailSender.php
+++ b/public_html/lists/admin/EmailSender.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * A plugin should implement this interface if it wants to be responsible
+ * for sending emails.
+ *
+ */
+interface EmailSender
+{
+    /**
+     * Send an email.
+     *
+     * @param PHPlistMailer $phplistmailer mailer instance
+     * @param string        $header the message http headers
+     * @param string        $body   the message body
+     *
+     * @return bool success/failure
+     */
+    public function send(PHPlistMailer $mailer, $header, $body);
+}

--- a/public_html/lists/admin/pluginlib.php
+++ b/public_html/lists/admin/pluginlib.php
@@ -1,10 +1,12 @@
 <?php
 
 require_once dirname(__FILE__) . '/accesscheck.php';
+require_once dirname(__FILE__) . '/EmailSender.php';
 
 $GLOBALS['plugins'] = array();
 $GLOBALS['editorplugin'] = false;
 $GLOBALS['authenticationplugin'] = false;
+$GLOBALS['emailsenderplugin'] = false;
 
 if (!defined('PLUGIN_ROOTDIR')) {
     define('PLUGIN_ROOTDIR', 'notdefined');
@@ -98,6 +100,10 @@ foreach ($pluginFiles as $file) {
                             'validateLogin')
                     ) {
                         $GLOBALS['authenticationplugin'] = $className;
+                    }
+
+                    if (!$GLOBALS['emailsenderplugin'] && $pluginInstance instanceof EmailSender) {
+                        $GLOBALS['emailsenderplugin'] = $pluginInstance;
                     }
                     #     print $className.' '.md5('plugin-'.$className.'-initialised').'<br/>';
                     $plugin_initialised = getConfig(md5('plugin-' . $className . '-initialised'));


### PR DESCRIPTION
This is one part of Mantis 18294, to allow a plugin to be responsible for sending emails, instead of smtp, mail() etc.

A plugin will need to implement an interface to be recognised as being able to send emails. Similarly to the authentication plugin approach, only one plugin, the first found to implement the interface, will be selected.

The PHPlistmailer class will now use the approach shown in https://github.com/PHPMailer/PHPMailer/pull/110 so that phpmailer calls a specific method based on the value of $Mailer.

The existing code for Amazon SES and for local spool has also been changed to fit into this approach.