### PR TITLE
Mantis 18503 - Clearer error message on plugins page when url fopen wrappers are not enabled

### DIFF
--- a/public_html/lists/admin/plugins.php
+++ b/public_html/lists/admin/plugins.php
@@ -165,6 +165,8 @@ if (!empty($_POST['pluginurl']) && class_exists('ZipArchive')) {
 
 if (defined('PLUGIN_ROOTDIR') && !is_writable(PLUGIN_ROOTDIR)) {
     Info(s('The plugin root directory is not writable, please install plugins manually'));
+} elseif (ini_get('allow_url_fopen') != '1') {
+    Info(s('The PHP option for <a href="http://php.net/manual/en/filesystem.configuration.php#ini.allow-url-fopen">URL-aware fopen wrappers</a> needs to be enabled. This is required to allow installation from a remote URL'));
 } elseif (!class_exists('ZipArchive')) {
     Info(s('PHP has no <a href="http://php.net/zip">Zip capability</a>. This is required to allow installation from a remote URL'));
 } else {


### PR DESCRIPTION
This change adds an explicit test for the ini setting. From the php documentation ini_get() should return a string of value either '0' or '1' for a boolean option. I have tested on three systems and that appears to be the case.
