### PR TITLE
[TASK] Drop support for PHP < 5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ language: php
 php:
   - 7.0
   - 5.6
-  - 5.5
-  - 5.4
-  - 5.3
 
 before_script:
   - sudo apt-get update > /dev/null

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,9 @@
     "source": "https://github.com/phpList/phpList3"
   },
   "minimum-stability": "dev",
+  "require": {
+    "php": ">=5.6.0,<=7.1.99"
+  },
   "require-dev": {
     "behat/mink": "~1.4",
     "behat/mink-goutte-driver": "~1.2",

--- a/public_html/lists/admin/PHPMailer/PHPMailerAutoload.php
+++ b/public_html/lists/admin/PHPMailer/PHPMailerAutoload.php
@@ -23,8 +23,7 @@
  */
 function PHPMailerAutoload($classname)
 {
-    //Can't use __DIR__ as it's only in PHP 5.3+
-    $filename = dirname(__FILE__).DIRECTORY_SEPARATOR.'class.'.strtolower($classname).'.php';
+    $filename = __DIR__.DIRECTORY_SEPARATOR.'class.'.strtolower($classname).'.php';
     if (is_readable($filename)) {
         require $filename;
     }

--- a/public_html/lists/admin/PHPMailer/class.phpmaileroauth.php
+++ b/public_html/lists/admin/PHPMailer/class.phpmaileroauth.php
@@ -1,7 +1,6 @@
 <?php
 /**
  * PHPMailer - PHP email creation and transport class.
- * PHP Version 5.4
  * @package PHPMailer
  * @link https://github.com/PHPMailer/PHPMailer/ The PHPMailer GitHub project
  * @author Marcus Bointon (Synchro/coolbru) <phpmailer@synchromedia.co.uk>

--- a/public_html/lists/admin/PHPMailer/class.phpmaileroauthgoogle.php
+++ b/public_html/lists/admin/PHPMailer/class.phpmaileroauthgoogle.php
@@ -1,7 +1,6 @@
 <?php
 /**
  * PHPMailer - PHP email creation and transport class.
- * PHP Version 5.4
  * @package PHPMailer
  * @link https://github.com/PHPMailer/PHPMailer/ The PHPMailer GitHub project
  * @author Marcus Bointon (Synchro/coolbru) <phpmailer@synchromedia.co.uk>

--- a/public_html/lists/admin/PHPMailer/get_oauth_token.php
+++ b/public_html/lists/admin/PHPMailer/get_oauth_token.php
@@ -9,8 +9,6 @@
  * * Set the script address as the app's redirect URL
  * If no refresh token is obtained when running this file, revoke access to your app
  * using link: https://accounts.google.com/b/0/IssuedAuthSubTokens and run the script again.
- * This script requires PHP 5.4 or later
- * PHP Version 5.4
  */
 
 namespace League\OAuth2\Client\Provider;

--- a/public_html/lists/admin/actions/storemessage.php
+++ b/public_html/lists/admin/actions/storemessage.php
@@ -53,15 +53,7 @@ foreach ($_POST as $key => $val) { //#17566 - we are only interested in POST dat
       print $key .' '.$val;
     */
     setMessageData($id, $key, $val);
-    if (get_magic_quotes_gpc()) {
-        if (is_string($val)) {
-            $messagedata[$key] = stripslashes($val);
-        } else {
-            $messagedata[$key] = $val;
-        }
-    } else {
-        $messagedata[$key] = $val;
-    }
+    $messagedata[$key] = $val;
 }
 unset($GLOBALS['MD']);
 

--- a/public_html/lists/admin/connect.php
+++ b/public_html/lists/admin/connect.php
@@ -1832,7 +1832,7 @@ function repeatMessage($msgid)
 
         return;
     }
-    
+
     //  Do not copy columns that use default values or are explicitly set
     $columnsToCopy = array_diff(
         array_keys($DBstruct['message']),
@@ -1951,11 +1951,7 @@ function formatDateTime($datetime, $short = 0)
 function cl_processtitle($title)
 {
     $title = preg_replace('/[^\w-]/', '', $title);
-    if (function_exists('cli_set_process_title')) { // PHP5.5 and up
-        cli_set_process_title('phpList:' . $GLOBALS['installation_name'] . ':' . $title);
-    } elseif (function_exists('setproctitle')) { // pecl extension
-        setproctitle('phpList:' . $GLOBALS['installation_name'] . ':' . $title);
-    }
+    cli_set_process_title('phpList:' . $GLOBALS['installation_name'] . ':' . $title);
 }
 
 function cl_output($message)

--- a/public_html/lists/admin/image.php
+++ b/public_html/lists/admin/image.php
@@ -18,7 +18,7 @@ if (isset($_GET['m'])) {
 
 if (!empty($row['data'])) {
     $imageContent = base64_decode($row['data']);
-    if ($max && function_exists('getimagesizefromstring')) { ## getimagesizefromstring is 5.4 and up
+    if ($max) {
         $imSize = getimagesizefromstring($imageContent);
         $sizeW = $imSize[0];
         $sizeH = $imSize[1];

--- a/public_html/lists/admin/inc/magic_quotes.php
+++ b/public_html/lists/admin/inc/magic_quotes.php
@@ -27,12 +27,10 @@ function stripSlashesArray($array)
     return $array;
 }
 
-if (!ini_get('magic_quotes_gpc') || ini_get('magic_quotes_gpc') == 'off') {
-    $_POST = addSlashesArray($_POST);
-    $_GET = addSlashesArray($_GET);
-    $_REQUEST = addSlashesArray($_REQUEST);
-    $_COOKIE = addSlashesArray($_COOKIE);
-}
+$_POST = addSlashesArray($_POST);
+$_GET = addSlashesArray($_GET);
+$_REQUEST = addSlashesArray($_REQUEST);
+$_COOKIE = addSlashesArray($_COOKIE);
 
 function removeXss($string)
 {

--- a/public_html/lists/admin/inc/maillib.php
+++ b/public_html/lists/admin/inc/maillib.php
@@ -98,7 +98,6 @@ function replaceChars($text)
         "'&(copy|#169);'i",
         "'&rsquo;'i",
         "'&ndash;'i",
-//                 "'&#(\d+);'e" // evaluate as php, deprecated in 5.5 and up
     );
 
     $replace = array(

--- a/public_html/lists/admin/index.php
+++ b/public_html/lists/admin/index.php
@@ -481,8 +481,8 @@ if (!$ajax && $page != 'login') {
     if (TEST) {
         print Info($GLOBALS['I18N']->get('Running in testmode, no emails will be sent. Check your config file.'));
     }
-    if (version_compare(PHP_VERSION, '5.4.0', '<') && WARN_ABOUT_PHP_SETTINGS) {
-        Error(s('Your PHP version is out of date. phpList requires PHP version 5.4.0 or higher.'));
+    if (version_compare(PHP_VERSION, '5.6.0', '<') && WARN_ABOUT_PHP_SETTINGS) {
+        Error(s('Your PHP version is out of date. phpList requires PHP version 5.6.0 or higher.'));
     }
     if (defined('ENABLE_RSS') && ENABLE_RSS && !function_exists('xml_parse') && WARN_ABOUT_PHP_SETTINGS) {
         Warn($GLOBALS['I18N']->get('You are trying to use RSS, but XML is not included in your PHP'));
@@ -542,10 +542,10 @@ if (USEFCK) {
 }
 */
 
-/* 
- * 
- * show global news, based on the version in use 
- * 
+/*
+ *
+ * show global news, based on the version in use
+ *
  * **/
 
 #if (empty($_SESSION['newsshown'])) { ## keep flag to only show one message per session
@@ -628,10 +628,10 @@ if (!empty($_SESSION['logindetails']['id']) && defined('PHPLISTNEWSROOT') && PHP
 }
 #} // end of show one per session (not used)
 
-/* 
- * 
+/*
+ *
  * end of news
- * 
+ *
  * **/
 
 if (defined('USE_PDF') && USE_PDF && !defined('FPDF_VERSION')) {

--- a/public_html/lists/admin/init.php
+++ b/public_html/lists/admin/init.php
@@ -67,8 +67,6 @@ if (function_exists('iconv') || ((!strtoupper(substr(PHP_OS, 0, 3)) === 'WIN' &&
 if (function_exists('mb_internal_encoding')) {
     mb_internal_encoding('UTF-8');
 }
-#magic quotes are deprecated, so try to switch off if possible
-ini_set('magic_quotes_gpc', 'off');
 
 $IsCommandlinePlugin = '';
 $zlib_compression = ini_get('zlib.output_compression');
@@ -135,12 +133,6 @@ unset($GLOBALS['DBstructuser']);
 unset($GLOBALS['DBstructphplist']);
 
 $GLOBALS['show_dev_errors'] = $show_dev_errors;
-$magic_quotes = ini_get('magic_quotes_gpc');
-if ($magic_quotes == 'off' || empty($magic_quotes)) {
-    define('NO_MAGIC_QUOTES', true);
-} else {
-    define('NO_MAGIC_QUOTES', false);
-}
 
 if (empty($GLOBALS['language_module'])) {
     $GLOBALS['language_module'] = 'english.inc';
@@ -697,9 +689,6 @@ if (!defined('FORWARD_FRIEND_COUNT_ATTRIBUTE')) {
 if (!defined('BLOCK_PASTED_CLICKTRACKLINKS')) {
     define('BLOCK_PASTED_CLICKTRACKLINKS', false);
 }
-if (!defined('SORT_FLAG_CASE')) {
-    define('SORT_FLAG_CASE', 1);
-} // pre PHP5.4
 
 if (FORWARD_EMAIL_COUNT < 1) {
     print 'Config Error: FORWARD_EMAIL_COUNT must be > (int) 0';

--- a/public_html/lists/admin/locale/en/phplist.po
+++ b/public_html/lists/admin/locale/en/phplist.po
@@ -10275,12 +10275,6 @@ msgstr "Suppression List"
 #~ msgid "In safe mode, not everything will work as expected"
 #~ msgstr "In safe mode, not everything will work as expected"
 
-#~ msgid "Things will work better when PHP magic_quotes_gpc = on"
-#~ msgstr "Things will work better when PHP magic_quotes_gpc = <b>on</b>"
-
-#~ msgid "Things will work better when PHP magic_quotes_runtime = off"
-#~ msgstr "Things will work better when PHP magic_quotes_runtime = off"
-
 #~ msgid "You do not have enough privileges to access this page"
 #~ msgstr "You do not have enough privileges to access this page"
 

--- a/public_html/lists/admin/locale/sl/phplist.po
+++ b/public_html/lists/admin/locale/sl/phplist.po
@@ -10066,7 +10066,24 @@ msgstr ""
 #~ msgstr "Trenutni atributi"
 
 #~ msgid "spamblockemailintro"
-#~ msgstr "  -------------------------------------------------------------------------------- This is a notification of a possible spam attack to your phplist subscribe page. The data submitted has been copied below, so you can check whether this was actually the case. The submitted data has been converted into non-html characters, for security reasons.  If you want to stop receiving this message, set     define('NOTIFY_SPAM',0);  in your phplist config file.  This user has not been added to the database. If there is an error, you will need to  add them manually.  --------------------------------------------------------------------------------  "
+#~ msgstr "
+
+ --------------------------------------------------------------------------------
+ This is a notification of a possible spam attack to your phplist subscribe page.
+ The data submitted has been copied below, so you can check whether this was actually the case.
+ The submitted data has been converted into non-html characters, for security reasons.
+
+ If you want to stop receiving this message, set
+
+   define('NOTIFY_SPAM',0);
+
+ in your phplist config file.
+
+ This user has not been added to the database. If there is an error, you will need to
+ add them manually.
+ --------------------------------------------------------------------------------
+
+ "
 
 #~ msgid "was_subscribed"
 #~ msgstr "Was subscribed to:"
@@ -10267,7 +10284,12 @@ msgstr ""
 #~ msgstr "Kontrolne vrednosti za"
 
 #~ msgid "prependemailtext"
-#~ msgstr " Oprostite, da vas motimo: malo čistimo svojo bazo podatkov in izgleda, da  ste se prijavili na naše novice, niste pa uspeli potrditi vaše prijave.  Sedaj imate ponovno možnost, da vašo prijavo potrdite.Navodila so kot spodaj.   "
+#~ msgstr "
+ Oprostite, da vas motimo: malo čistimo svojo bazo podatkov in izgleda, da
+ ste se prijavili na naše novice, niste pa uspeli potrditi vaše prijave.
+
+ Sedaj imate ponovno možnost, da vašo prijavo potrdite.Navodila so kot spodaj.
+   "
 
 #~ msgid "unreadable"
 #~ msgstr "Cannot read file. It is not readable !"
@@ -10315,7 +10337,9 @@ msgstr ""
 #~ msgstr "Spodaj so uporabniki, ki so bili označeni kot nepotrjeni. Številka v [] je njihova uporabniška ID, številka v () pa je število zaporednih odbojev"
 
 #~ msgid "import3info"
-#~ msgstr "There are two ways to add the names of the users,  either one attribute for the entire name or two attributes, one for first name and one for last name. If you use 'two attributes', the name will be split after the first space."
+#~ msgstr "There are two ways to add the names of the users,
+  either one attribute for the entire name or two attributes, one for first name and one for last name.
+ If you use 'two attributes', the name will be split after the first space."
 
 #~ msgid "whatisprepare"
 #~ msgstr "Kaj je priprava sporočila"
@@ -10420,7 +10444,19 @@ msgstr ""
 #~ msgstr "If you choose ""send notification email"" the users you are adding will be sent the request for confirmation of subscription to which they will have to reply. This is recommended, because it will identify invalid emails."
 
 #~ msgid "importintro"
-#~ msgstr "<p>The file you upload will need to have the attributes of the records on    the first line.     Make sure that the email column is called ""email"" and not something like ""e-mail"" or     ""Email Address"".     Case is not important.     </p>     If you have a column called ""Foreign Key"", this will be used for synchronisation between an     external database and the PHPlist database. The foreignkey will take precedence when matching     an existing user. This will slow down the import process. If you use this, it is allowed to have     records without email, but an ""Invalid Email"" will be created instead. You can then do     a search on ""invalid email"" to find those records. Maximum size of a foreign key is 100.     <br/><br/>     <b>Warning</b>: the file needs to be plain text. Do not upload binary files like a Word Document.     <br/>"
+#~ msgstr "<p>The file you upload will need to have the attributes of the records on    the first line.
+     Make sure that the email column is called ""email"" and not something like ""e-mail"" or
+     ""Email Address"".
+     Case is not important.
+     </p>
+     If you have a column called ""Foreign Key"", this will be used for synchronisation between an
+     external database and the PHPlist database. The foreignkey will take precedence when matching
+     an existing user. This will slow down the import process. If you use this, it is allowed to have
+     records without email, but an ""Invalid Email"" will be created instead. You can then do
+     a search on ""invalid email"" to find those records. Maximum size of a foreign key is 100.
+     <br/><br/>
+     <b>Warning</b>: the file needs to be plain text. Do not upload binary files like a Word Document.
+     <br/>"
 
 #~ msgid "powered by"
 #~ msgstr "powered by"
@@ -10507,13 +10543,17 @@ msgstr ""
 #~ msgstr "Spoji dvojne vnose"
 
 #~ msgid "rulesexistwarning"
-#~ msgstr "Pravila odbojev so že nastavljena.      Bodite pozorni pri oblikovanju novih, saj lahko vplivajo na že obstoječe."
+#~ msgstr "Pravila odbojev so že nastavljena.
+     Bodite pozorni pri oblikovanju novih, saj lahko vplivajo na že obstoječe."
 
 #~ msgid "IncreaseB"
 #~ msgstr "Povečaj štetje odbojev z"
 
 #~ msgid "assigninvalid_blurb"
-#~ msgstr "Assign Invalid will be used to create an email for users with an invalid email address. You can use values between [ and ] to make up a value for the email. For example if your import file contains a column ""First Name"" and one called ""Last Name"", you can use ""[first name] [last name]"" to construct a new value for the email for this user containing their first name and last name. The value [number] can be used to insert the sequence number for importing."
+#~ msgstr "Assign Invalid will be used to create an email for users with an invalid email address.
+ You can use values between [ and ] to make up a value for the email. For example if your import file contains a column ""First Name"" and one called ""Last Name"", you can use
+ ""[first name] [last name]"" to construct a new value for the email for this user containing their first name and last name.
+ The value [number] can be used to insert the sequence number for importing."
 
 #~ msgid "warnnopearhttprequest"
 #~ msgstr "Poslati poskušaš oddaljen URL, ampak PEAR::HTTP/Request ni na voljo, tako, da to ne bo uspešno"
@@ -10552,7 +10592,10 @@ msgstr ""
 #~ msgstr "razširi"
 
 #~ msgid "norulesyet"
-#~ msgstr "Ni definiranih pravil odbojev.      Lahko kliknete na ""Ustvari pravilo za odboje"" za samodejno generiranje pravil osnovanih na obstoječih pravilih.      Rezultat bo veliko pravil, ki jih boste morao pregledati in aktivirati.      S časom je potrebno dodati nova pravila, ko se število odbojev poveča."
+#~ msgstr "Ni definiranih pravil odbojev.
+     Lahko kliknete na ""Ustvari pravilo za odboje"" za samodejno generiranje pravil osnovanih na obstoječih pravilih.
+     Rezultat bo veliko pravil, ki jih boste morao pregledati in aktivirati.
+     S časom je potrebno dodati nova pravila, ko se število odbojev poveča."
 
 #~ msgid "Upload new image"
 #~ msgstr "Prenesi novo sliko"
@@ -10591,7 +10634,16 @@ msgstr ""
 #~ msgstr "Test output:"
 
 #~ msgid "strAccessExplain"
-#~ msgstr "<hr/> <p>Nastavitev dovoljenj za vpogled strani v sistemu:</p> <ul> <li>Vse: admin ima vsa dovoljenja</li> <li>Pogled: admin lahko vidi strani, vendar jih ne more spreminjati. Velja za strani ""uporabnik"", ""uporabniki"" in ""člani"".</li> <li>Noben: admin ne more videti te strani</li> <li>Owner: admin lahko vidi to stran, ampak vidi samo vsebino seznamov, katerih je lastnik</li> </ul> <p>Pozor: Geslo administratorja mora vsebovati najmanj 4 karakterje</p> "
+#~ msgstr "<hr/>
+ <p>Nastavitev dovoljenj za vpogled strani v sistemu:</p>
+ <ul>
+ <li>Vse: admin ima vsa dovoljenja</li>
+ <li>Pogled: admin lahko vidi strani, vendar jih ne more spreminjati. Velja za strani ""uporabnik"", ""uporabniki"" in ""člani"".</li>
+ <li>Noben: admin ne more videti te strani</li>
+ <li>Owner: admin lahko vidi to stran, ampak vidi samo vsebino seznamov, katerih je lastnik</li>
+ </ul>
+ <p>Pozor: Geslo administratorja mora vsebovati najmanj 4 karakterje</p>
+ "
 
 #~ msgid "(default is line break)"
 #~ msgstr "(default is line break)"
@@ -10827,7 +10879,8 @@ msgstr ""
 #~ msgid "nofpdf"
 #~ msgstr "You are trying to use PDF support without having FPDF loaded"
 
-#~ msgid "if there is only one visible list, should it be hidden in the page and automatically     subscribe users who sign up (0/1)"
+#~ msgid "if there is only one visible list, should it be hidden in the page and automatically
+     subscribe users who sign up (0/1)"
 #~ msgstr "Če je vidna le ena kategorija novic, ali naj bo skrita na naročnišči strani in naj se naročniki samodejno včlanijo vanjo? (0/1)"
 
 #~ msgid "adding"
@@ -10840,7 +10893,8 @@ msgstr ""
 #~ msgstr "Kategorija je aktivna"
 
 #~ msgid "excludelistexplain"
-#~ msgstr "Sporočilo bo poslano uporabnikom zgornjih kategorij,     razen, če so člani kategorij, ki ste jih izbrali tukaj."
+#~ msgstr "Sporočilo bo poslano uporabnikom zgornjih kategorij,
+     razen, če so člani kategorij, ki ste jih izbrali tukaj."
 
 #~ msgid "create_subscr_pages"
 #~ msgstr "Ustvari naročniške strani"
@@ -10909,7 +10963,11 @@ msgstr ""
 #~ msgstr "Izberi kolone, ki bodo vključene v izvoz"
 
 #~ msgid "importadmininfo"
-#~ msgstr "   The file you upload will need to contain the administrators you want to add to the system. The columns need to have the following headers: <b>email</b>, <b>loginname</b>, <b>password</b>. Any other columns will be added as admin attributes.  <b>Warning</b>: the file needs to be plain text. Do not upload binary files like a Word Document.   "
+#~ msgstr "
+   The file you upload will need to contain the administrators
+ you want to add to the system. The columns need to have the following headers: <b>email</b>, <b>loginname</b>, <b>password</b>. Any other columns will be added as admin attributes.
+  <b>Warning</b>: the file needs to be plain text. Do not upload binary files like a Word Document.
+   "
 
 #~ msgid "line_break_default"
 #~ msgstr "(default is line break)"
@@ -10977,8 +11035,10 @@ msgstr ""
 #~ msgid "selectlists"
 #~ msgstr "Izberi kategorije za pošiljanje"
 
-#~ msgid "to make sure you are updated when new versions come out.     Sometimes security bugs are found which make it important to upgrade. Traffic on the list is very low."
-#~ msgstr "to make sure you are updated when new versions come out.     Sometimes security bugs are found which make it important to upgrade. Traffic on the list is very low."
+#~ msgid "to make sure you are updated when new versions come out.
+     Sometimes security bugs are found which make it important to upgrade. Traffic on the list is very low."
+#~ msgstr "to make sure you are updated when new versions come out.
+     Sometimes security bugs are found which make it important to upgrade. Traffic on the list is very low."
 
 #~ msgid "Message Sending has started"
 #~ msgstr "Pošiljanje sporočil se je pričelo"
@@ -10988,9 +11048,6 @@ msgstr ""
 
 #~ msgid "PHPList Users"
 #~ msgstr "PHPList Uporabniki"
-
-#~ msgid "magicquoteswarning"
-#~ msgstr "Things will work better when PHP magic_quotes_gpc = <b>on</b>"
 
 #~ msgid "It is safe to click your stop button now, report will be sent by email to"
 #~ msgstr "Sedaj je varno za klik na gumb ""stop"", poročilo bo poslano na e-pošto:"
@@ -11054,9 +11111,6 @@ msgstr ""
 
 #~ msgid "WhenSignedUp"
 #~ msgstr "Ko so se prijavili"
-
-#~ msgid "magicruntimewarning"
-#~ msgstr "Things will work better when PHP magic_quotes_runtime = off"
 
 #~ msgid "name_not_unique"
 #~ msgstr "Ime ni dovolj unikatno"
@@ -11152,7 +11206,34 @@ msgstr ""
 #~ msgstr "Dimenzije področja za tekst (vrstice,kolone)"
 
 #~ msgid "TempSample"
-#~ msgstr "  While Socrates was speaking, Pythodorus thought that Parmenides and Zeno were not altogether pleased at the successive steps of the argument; but still they gave the closest attention, and often looked at one another, and smiled as if in admiration of him.  When he had finished, Parmenides expressed their feelings in the following words:--  Socrates, he said, I admire the bent of your mind towards philosophy; tell me now, was this your own distinction between ideas in themselves and the things which partake of them? and do you think that there is an idea of likeness apart from the likeness which we possess, and of the one and many, and of the other things which Zeno mentioned?  I think that there are such ideas, said Socrates.  Parmenides proceeded:  And would you also make absolute ideas of the just and the beautiful and the good, and of all that class?  Yes, he said, I should.  And would you make an idea of man apart from us and from all other human creatures, or of fire and water?  I am often undecided, Parmenides, as to whether I ought to include them or not.  "
+#~ msgstr "
+
+ While Socrates was speaking, Pythodorus thought that Parmenides and Zeno
+ were not altogether pleased at the successive steps of the argument; but
+ still they gave the closest attention, and often looked at one another, and
+ smiled as if in admiration of him.  When he had finished, Parmenides
+ expressed their feelings in the following words:--
+
+ Socrates, he said, I admire the bent of your mind towards philosophy; tell
+ me now, was this your own distinction between ideas in themselves and the
+ things which partake of them? and do you think that there is an idea of
+ likeness apart from the likeness which we possess, and of the one and many,
+ and of the other things which Zeno mentioned?
+
+ I think that there are such ideas, said Socrates.
+
+ Parmenides proceeded:  And would you also make absolute ideas of the just
+ and the beautiful and the good, and of all that class?
+
+ Yes, he said, I should.
+
+ And would you make an idea of man apart from us and from all other human
+ creatures, or of fire and water?
+
+ I am often undecided, Parmenides, as to whether I ought to include them or
+ not.
+
+ "
 
 #~ msgid "Users apply"
 #~ msgstr "Uporabnikov ustreza"
@@ -11215,7 +11296,8 @@ msgstr ""
 #~ msgstr "Info o sporočilu"
 
 #~ msgid "messagefooterexplanation"
-#~ msgstr "Uporabi <b>[UNSUBSCRIBE]</b> za vstavitev osebne strani za odjavo vsakega uporabnika.     <br/>Uporabi <b>[PREFERENCES]</b> za vstavitev povezave za urejanje podrobnosti vsakega uporabnika"
+#~ msgstr "Uporabi <b>[UNSUBSCRIBE]</b> za vstavitev osebne strani za odjavo vsakega uporabnika.
+     <br/>Uporabi <b>[PREFERENCES]</b> za vstavitev povezave za urejanje podrobnosti vsakega uporabnika"
 
 #~ msgid "Is this user Super Admin?"
 #~ msgstr "Ali je ta uporabnik super Administrator?"

--- a/public_html/lists/admin/locale/templates/phplist.pot
+++ b/public_html/lists/admin/locale/templates/phplist.pot
@@ -7276,7 +7276,7 @@ msgstr ""
 
 #: public_html/lists/admin/index.php:485
 msgid ""
-"Your PHP version is out of date. phpList requires PHP version 5.4.0 or "
+"Your PHP version is out of date. phpList requires PHP version 5.6.0 or "
 "higher."
 msgstr ""
 


### PR DESCRIPTION
PHP 5.4 and PHP 5.5 have reached their end of life and thus are not
supported anymore (not even with security updates). So PHPList will
not support it anymore, either.

This will also fix the Travis build which has been broken for PHP 5.3.