### PR TITLE
[TASK] Require PHP >= 5.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ php:
   - 5.6
   - 5.5
   - 5.4
-  - 5.3
 
 before_script:
   - sudo apt-get update > /dev/null

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,9 @@
     "source": "https://github.com/phpList/phpList3"
   },
   "minimum-stability": "dev",
+  "require": {
+    "php": ">= 5.4.0, <= 7.1.99"
+  },
   "require-dev": {
     "behat/mink": "~1.4",
     "behat/mink-goutte-driver": "~1.2",

--- a/public_html/lists/admin/actions/processqueue.php
+++ b/public_html/lists/admin/actions/processqueue.php
@@ -202,14 +202,6 @@ if (isset($cline['m'])) {
     cl_output('Max to send is '.$cline['m'].' setting num per batch to '.$counters['num_per_batch']);
 }
 
-$safemode = 0;
-if (ini_get('safe_mode')) {
-    // keep an eye on timeouts
-    $safemode = 1;
-    $counters['num_per_batch'] = min(100, $counters['num_per_batch']);
-    echo $GLOBALS['I18N']->get('Running in safe mode').'<br/>';
-}
-
 $original_num_per_batch = $counters['num_per_batch'];
 if ($counters['num_per_batch'] && $batch_period) {
     // check how many were sent in the last batch period and take off that
@@ -524,9 +516,6 @@ if (empty($reload)) { //# only show on first load
 }
 
 if ($counters['num_per_batch'] > 0) {
-    if ($safemode) {
-        processQueueOutput(s('In safe mode, batches are set to a maximum of 100'));
-    }
     if ($original_num_per_batch != $counters['num_per_batch']) {
         if (empty($reload)) {
             processQueueOutput(s('Sending in batches of %s messages', number_format($original_num_per_batch)), 0);

--- a/public_html/lists/admin/actions/storemessage.php
+++ b/public_html/lists/admin/actions/storemessage.php
@@ -53,15 +53,7 @@ foreach ($_POST as $key => $val) { //#17566 - we are only interested in POST dat
       print $key .' '.$val;
     */
     setMessageData($id, $key, $val);
-    if (get_magic_quotes_gpc()) {
-        if (is_string($val)) {
-            $messagedata[$key] = stripslashes($val);
-        } else {
-            $messagedata[$key] = $val;
-        }
-    } else {
-        $messagedata[$key] = $val;
-    }
+    $messagedata[$key] = $val;
 }
 unset($GLOBALS['MD']);
 

--- a/public_html/lists/admin/image.php
+++ b/public_html/lists/admin/image.php
@@ -18,7 +18,7 @@ if (isset($_GET['m'])) {
 
 if (!empty($row['data'])) {
     $imageContent = base64_decode($row['data']);
-    if ($max && function_exists('getimagesizefromstring')) { //# getimagesizefromstring is 5.4 and up
+    if ($max) {
         $imSize = getimagesizefromstring($imageContent);
         $sizeW = $imSize[0];
         $sizeH = $imSize[1];

--- a/public_html/lists/admin/inc/magic_quotes.php
+++ b/public_html/lists/admin/inc/magic_quotes.php
@@ -27,13 +27,6 @@ function stripSlashesArray($array)
     return $array;
 }
 
-if (!ini_get('magic_quotes_gpc') || ini_get('magic_quotes_gpc') == 'off') {
-    $_POST = addSlashesArray($_POST);
-    $_GET = addSlashesArray($_GET);
-    $_REQUEST = addSlashesArray($_REQUEST);
-    $_COOKIE = addSlashesArray($_COOKIE);
-}
-
 function removeXss($string)
 {
     if (is_array($string)) {

--- a/public_html/lists/admin/inc/random_compat/random.php
+++ b/public_html/lists/admin/inc/random_compat/random.php
@@ -109,7 +109,7 @@ if (PHP_VERSION_ID < 70000) {
                 @is_readable('/dev/urandom')
             ) {
                 // Error suppression on is_readable() in case of an open_basedir
-                // or safe_mode failure. All we care about is whether or not we
+                // failure. All we care about is whether or not we
                 // can read it at this point. If the PHP environment is going to
                 // panic over trying to see if the file can be read in the first
                 // place, that is not helpful to us here.
@@ -150,7 +150,7 @@ if (PHP_VERSION_ID < 70000) {
             // Prevent this code from hanging indefinitely on non-Windows;
             // see https://bugs.php.net/bug.php?id=69833
             if (
-                DIRECTORY_SEPARATOR !== '/' || 
+                DIRECTORY_SEPARATOR !== '/' ||
                 (PHP_VERSION_ID <= 50609 || PHP_VERSION_ID >= 50613)
             ) {
                 // See random_bytes_mcrypt.php

--- a/public_html/lists/admin/init.php
+++ b/public_html/lists/admin/init.php
@@ -67,8 +67,6 @@ if (function_exists('iconv') || ((!strtoupper(substr(PHP_OS, 0, 3)) === 'WIN' &&
 if (function_exists('mb_internal_encoding')) {
     mb_internal_encoding('UTF-8');
 }
-//magic quotes are deprecated, so try to switch off if possible
-ini_set('magic_quotes_gpc', 'off');
 
 $IsCommandlinePlugin = '';
 $zlib_compression = ini_get('zlib.output_compression');
@@ -135,12 +133,6 @@ unset($GLOBALS['DBstructuser']);
 unset($GLOBALS['DBstructphplist']);
 
 $GLOBALS['show_dev_errors'] = $show_dev_errors;
-$magic_quotes = ini_get('magic_quotes_gpc');
-if ($magic_quotes == 'off' || empty($magic_quotes)) {
-    define('NO_MAGIC_QUOTES', true);
-} else {
-    define('NO_MAGIC_QUOTES', false);
-}
 
 if (empty($GLOBALS['language_module'])) {
     $GLOBALS['language_module'] = 'english.inc';
@@ -711,9 +703,6 @@ if (!defined('FORWARD_FRIEND_COUNT_ATTRIBUTE')) {
 if (!defined('BLOCK_PASTED_CLICKTRACKLINKS')) {
     define('BLOCK_PASTED_CLICKTRACKLINKS', false);
 }
-if (!defined('SORT_FLAG_CASE')) {
-    define('SORT_FLAG_CASE', 1);
-} // pre PHP5.4
 
 if (FORWARD_EMAIL_COUNT < 1) {
     echo 'Config Error: FORWARD_EMAIL_COUNT must be > (int) 0';

--- a/public_html/lists/admin/locale/da/phplist.po
+++ b/public_html/lists/admin/locale/da/phplist.po
@@ -9500,14 +9500,6 @@ msgstr ""
 #~ "gang, s&aring; der vil blive reloadet flere gange for at sende beskederne. "
 #~ "Rapport vil blive sendt til"
 
-#~ msgid ""
-#~ "Your webserver is running in safe_mode. Please keep this window open. It may "
-#~ "reload several times to make sure all messages are sent."
-#~ msgstr ""
-#~ "Din webserver k&oslash;rer i \"safe_mode\". Venligst hold dette vindue "
-#~ "&aring;ben. Det vil m&aring;ske genopfriske adskillige gange for at v&aelig;"
-#~ "re sikker p&aring; at alle beskeder er blevet sendt."
-
 #~ msgid "Reports will be sent by email to"
 #~ msgstr "Rapporter vil blive sendt via email til"
 

--- a/public_html/lists/admin/locale/de/phplist.po
+++ b/public_html/lists/admin/locale/de/phplist.po
@@ -9860,14 +9860,6 @@ msgstr "pagetitlehover:suppressionlist"
 #~ "darum wird es mehrmals neu laden, um die Nachrichten zu senden. Der Bericht "
 #~ "wird per E-Mail gesendet an"
 
-#~ msgid ""
-#~ "Your webserver is running in safe_mode. Please keep this window open. It may "
-#~ "reload several times to make sure all messages are sent."
-#~ msgstr ""
-#~ "Ihr Webserver arbeite im safe_mode. Bitte lassen Sie dieses Fenster offen. "
-#~ "Es kann öfter aktualisiert werden, um sicherzustellen, dass alle Nachrichten "
-#~ "gesendet werden."
-
 #~ msgid "Reports will be sent by email to"
 #~ msgstr "Berichte werden per E-Mail an folgende Adresse verschickt:"
 

--- a/public_html/lists/admin/locale/en/phplist.po
+++ b/public_html/lists/admin/locale/en/phplist.po
@@ -9664,13 +9664,6 @@ msgstr "Suppression List"
 #~ "Please leave this window open. You have batch processing enabled, so it will "
 #~ "reload several times to send the messages. Reports will be sent by email to"
 
-#~ msgid ""
-#~ "Your webserver is running in safe_mode. Please keep this window open. It may "
-#~ "reload several times to make sure all messages are sent."
-#~ msgstr ""
-#~ "Your webserver is running in safe_mode. Please keep this window open. It may "
-#~ "reload several times to make sure all messages are sent."
-
 #~ msgid "Reports will be sent by email to"
 #~ msgstr "Reports will be sent by email to"
 
@@ -10274,12 +10267,6 @@ msgstr "Suppression List"
 
 #~ msgid "In safe mode, not everything will work as expected"
 #~ msgstr "In safe mode, not everything will work as expected"
-
-#~ msgid "Things will work better when PHP magic_quotes_gpc = on"
-#~ msgstr "Things will work better when PHP magic_quotes_gpc = <b>on</b>"
-
-#~ msgid "Things will work better when PHP magic_quotes_runtime = off"
-#~ msgstr "Things will work better when PHP magic_quotes_runtime = off"
 
 #~ msgid "You do not have enough privileges to access this page"
 #~ msgstr "You do not have enough privileges to access this page"

--- a/public_html/lists/admin/locale/es/phplist.po
+++ b/public_html/lists/admin/locale/es/phplist.po
@@ -9641,14 +9641,6 @@ msgstr ""
 #~ "habilitado, por lo que va a recargar varias veces para enviar los mensajes. "
 #~ "Los informes se pueden enviar por correo electrónico a"
 
-#~ msgid ""
-#~ "Your webserver is running in safe_mode. Please keep this window open. It may "
-#~ "reload several times to make sure all messages are sent."
-#~ msgstr ""
-#~ "Su servidor est&aacute; funcionando en &#171;safe_mode&#187; (modo seguro). "
-#~ "Mantenga esta ventana abierta. Puede que se recargue varias veces para "
-#~ "asegurar que se env&iacute;n todos los mensajes."
-
 #~ msgid "Reports will be sent by email to"
 #~ msgstr "Los informes se enviar&aacute;n por correo a"
 

--- a/public_html/lists/admin/locale/es_AR/phplist.po
+++ b/public_html/lists/admin/locale/es_AR/phplist.po
@@ -9742,14 +9742,6 @@ msgstr ""
 #~ "de paquetes, por eso recargará varias veces para enviar los mensajes. El "
 #~ "informe será enviado por correo a"
 
-#~ msgid ""
-#~ "Your webserver is running in safe_mode. Please keep this window open. It may "
-#~ "reload several times to make sure all messages are sent."
-#~ msgstr ""
-#~ "Su servidor est&aacute; funcionando en &#171;safe_mode&#187; (modo seguro). "
-#~ "Mantenga esta ventana abierta. Puede que se recargue varias veces para "
-#~ "asegurar que se env&iacute;n todos los mensajes."
-
 #~ msgid "Reports will be sent by email to"
 #~ msgstr "Los informes se enviar&aacute;n por correo a"
 

--- a/public_html/lists/admin/locale/fa/phplist.po
+++ b/public_html/lists/admin/locale/fa/phplist.po
@@ -9570,13 +9570,6 @@ msgstr ""
 #~ "این پنجره چند بار بارگذاری مجدد میشود تا پیامها را بفرستد. گزارش کار ایمیل "
 #~ "میشود به"
 
-#~ msgid ""
-#~ "Your webserver is running in safe_mode. Please keep this window open. It may "
-#~ "reload several times to make sure all messages are sent."
-#~ msgstr ""
-#~ "سرور وب شما در حالت \"safe_mode\" است. لطفا این پنجره را باز نگه دارید. ممکن "
-#~ "است چند بار بارگذاری شود تا اطمینان حاصل شود که همه پیامها فرستاده شده اند."
-
 #~ msgid "Reports will be sent by email to"
 #~ msgstr "گزارشها ایمیل میشوند به"
 

--- a/public_html/lists/admin/locale/fi/phplist.po
+++ b/public_html/lists/admin/locale/fi/phplist.po
@@ -2109,12 +2109,6 @@ msgid ""
 msgstr ""
 
 #: public_html/lists/admin/actions/processqueue.php:478
-msgid ""
-"Your webserver is running in safe_mode. Please keep this window open. It may "
-"reload several times to make sure all messages are sent."
-msgstr ""
-
-#: public_html/lists/admin/actions/processqueue.php:478
 msgid "Reports will be sent by email to"
 msgstr ""
 

--- a/public_html/lists/admin/locale/fr/phplist.po
+++ b/public_html/lists/admin/locale/fr/phplist.po
@@ -9922,14 +9922,6 @@ msgstr "titre de page : suppression de liste"
 #~ "lot, la page se rechargera plusieurs fois pour envoyer les messages. Le "
 #~ "rapport sera envoyé à"
 
-#~ msgid ""
-#~ "Your webserver is running in safe_mode. Please keep this window open. It may "
-#~ "reload several times to make sure all messages are sent."
-#~ msgstr ""
-#~ "Votre serveur web est en mode sécurité. Merci de garder cette fenêtre "
-#~ "ouverte. Elle va peut-être se recharger plusieurs fois jusqu'à la fin de "
-#~ "l'envoi de tous les messages."
-
 #~ msgid "Reports will be sent by email to"
 #~ msgstr "Les rapports seront envoyés par courriel à"
 
@@ -10754,9 +10746,6 @@ msgstr "titre de page : suppression de liste"
 #~ msgstr ""
 #~ "Il est plus sain de désactiver les \"Register Globals\" dans votre php.ini. "
 #~ "Des les poistionner à <b>off</b> plutôt qu'à "
-
-#~ msgid "In safe mode, not everything will work as expected"
-#~ msgstr "En safe_mode, tous ne fonctionneras pas comme attendu"
 
 #~ msgid "Reload required"
 #~ msgstr "Il faut rafra&icirc;chir l&rsquo;&eacute;cran"

--- a/public_html/lists/admin/locale/hu/phplist.po
+++ b/public_html/lists/admin/locale/hu/phplist.po
@@ -9502,14 +9502,6 @@ msgstr ""
 #~ "többször újra fog tölteni az üzenetek elküldéséhez. A jelentések e-mailben "
 #~ "kerülnek elküldésre a következőnek:"
 
-#~ msgid ""
-#~ "Your webserver is running in safe_mode. Please keep this window open. It may "
-#~ "reload several times to make sure all messages are sent."
-#~ msgstr ""
-#~ "A webkiszolgáló \"safe_mode\" beállítással fut. Hagyja nyitva ezt az "
-#~ "ablakot. Több alkalommal újratöltődhet, hogy megbizonyosdhasson arról, az "
-#~ "összes üzenet elküldésre került."
-
 #~ msgid "Reports will be sent by email to"
 #~ msgstr "A jelentések e-mailben kerülnek elküldésre a következőnek:"
 

--- a/public_html/lists/admin/locale/it/phplist.po
+++ b/public_html/lists/admin/locale/it/phplist.po
@@ -9735,13 +9735,6 @@ msgstr "Lista revoche"
 #~ "finestra si aggiornerà per inviare tutti i messaggi. Un report verrà inviato "
 #~ "per mail a"
 
-#~ msgid ""
-#~ "Your webserver is running in safe_mode. Please keep this window open. It may "
-#~ "reload several times to make sure all messages are sent."
-#~ msgstr ""
-#~ "Il Webserver è in esecuzione in safe_mode. Per favore tieni aperta questa "
-#~ "finestra. Deve aggiornarsi più volte per inviare tutti i messaggi."
-
 #~ msgid "Reports will be sent by email to"
 #~ msgstr "I report saranno inviati via email a"
 

--- a/public_html/lists/admin/locale/ja/phplist.po
+++ b/public_html/lists/admin/locale/ja/phplist.po
@@ -9442,13 +9442,6 @@ msgstr ""
 #~ "Please leave this window open. You have batch processing enabled, so it will "
 #~ "reload several times to send the messages. Reports will be sent by email to"
 
-#~ msgid ""
-#~ "Your webserver is running in safe_mode. Please keep this window open. It may "
-#~ "reload several times to make sure all messages are sent."
-#~ msgstr ""
-#~ "Your webserver is running in \"safe_mode\". Please keep this window open. It "
-#~ "may reload several times to make sure all messages are sent."
-
 #~ msgid "Reports will be sent by email to"
 #~ msgstr "Reports will be sent by email to"
 

--- a/public_html/lists/admin/locale/nl/phplist.po
+++ b/public_html/lists/admin/locale/nl/phplist.po
@@ -9901,14 +9901,6 @@ msgstr "Onderdrukkingslijst"
 #~ "venster zal verschillende malen opnieuw laden om het bericht te zenden. Een "
 #~ "rapport zal per e-mail bericht worden verzonden naar"
 
-#~ msgid ""
-#~ "Your webserver is running in safe_mode. Please keep this window open. It may "
-#~ "reload several times to make sure all messages are sent."
-#~ msgstr ""
-#~ "De webserver functioneert momenteel in de veilige modus. Laat dit venster "
-#~ "open. Het kan verschillende malen opnieuw laden om er zeker van te zijn dat "
-#~ "alle berichten verstuurd zijn."
-
 #~ msgid "Reports will be sent by email to"
 #~ msgstr "Rapporten zullen worden verzonden naar"
 

--- a/public_html/lists/admin/locale/nl_BE/phplist.po
+++ b/public_html/lists/admin/locale/nl_BE/phplist.po
@@ -9423,14 +9423,6 @@ msgstr ""
 #~ "waardoor dit venster verschillende keren opnieuw zal laden om het bericht te "
 #~ "verzenden. Rapporten worden verzonden per email naar"
 
-#~ msgid ""
-#~ "Your webserver is running in safe_mode. Please keep this window open. It may "
-#~ "reload several times to make sure all messages are sent."
-#~ msgstr ""
-#~ "Uw webserver loop in \"veilige modus\". Lat dit venster aub open.Het kan "
-#~ "verschillende malen herladen om er zeker van te zijn dat alle berichten "
-#~ "verstuurd zijn."
-
 #~ msgid "Reports will be sent by email to"
 #~ msgstr "Rapporten zullen worden verzonden naar"
 

--- a/public_html/lists/admin/locale/pt/phplist.po
+++ b/public_html/lists/admin/locale/pt/phplist.po
@@ -10011,14 +10011,6 @@ msgstr "Lista de remoção"
 #~ "far&aacute; com que a janela atualize v&aacute;rias vezes para poder enviar "
 #~ "todas as mensagens. Ser&atilde;o enviados relat&oacute;rios via email para"
 
-#~ msgid ""
-#~ "Your webserver is running in safe_mode. Please keep this window open. It may "
-#~ "reload several times to make sure all messages are sent."
-#~ msgstr ""
-#~ "O servidor est&aacute; a trabalhar no modo de seguran&ccedil;a. Mantenha "
-#~ "esta janela aberta. Pois para que todas as mensagens sejam enviadas ela "
-#~ "ter&aacute; que ser atualizada diversas vezes."
-
 #~ msgid "Reports will be sent by email to"
 #~ msgstr "Os relat&oacute;rios ser&atilde;o enviados por email para"
 

--- a/public_html/lists/admin/locale/pt_BR/phplist.po
+++ b/public_html/lists/admin/locale/pt_BR/phplist.po
@@ -9723,14 +9723,6 @@ msgstr ""
 #~ "far&aacute; com que a janela atulize v&aacute;rias vezes para poder enviar "
 #~ "todas as mensagens. Ser&atilde; enviados relat&oacute;rios via email para"
 
-#~ msgid ""
-#~ "Your webserver is running in safe_mode. Please keep this window open. It may "
-#~ "reload several times to make sure all messages are sent."
-#~ msgstr ""
-#~ "O servidor est&aacute; rodando no modo de seguran&ccedil;a. Mantenha esta "
-#~ "janela aberta, pois para que todas as mensagens sejam enviadas ela "
-#~ "ter&aacute; que ser atualizada diversas vezes"
-
 #~ msgid "Reports will be sent by email to"
 #~ msgstr "Relat&oacute;rios ser&atilde;o enviados por email para"
 

--- a/public_html/lists/admin/locale/ru/phplist.po
+++ b/public_html/lists/admin/locale/ru/phplist.po
@@ -9698,14 +9698,6 @@ msgstr ""
 #~ "Не закрывайте это окно: в процессе пакетной обработки содержимое будет "
 #~ "обновлено несколько раз. Отчёты будут отправлены по электронной почте на"
 
-#~ msgid ""
-#~ "Your webserver is running in safe_mode. Please keep this window open. It may "
-#~ "reload several times to make sure all messages are sent."
-#~ msgstr ""
-#~ "Не закрывайте окно: веб сервер запущен в безопасном режиме (safe_mode) и "
-#~ "может потребоваться неоднократный перезапуск в окне для гарантии отправки "
-#~ "всех сообщений."
-
 #~ msgid "Reports will be sent by email to"
 #~ msgstr "Отчёты будут отправлены по электронной почте на"
 

--- a/public_html/lists/admin/locale/sl/phplist.po
+++ b/public_html/lists/admin/locale/sl/phplist.po
@@ -9497,13 +9497,6 @@ msgstr ""
 #~ "večkrat osvežilo, da bodo poslana vsa sporočila. Poročila bodo poslana na "
 #~ "e-pošto"
 
-#~ msgid ""
-#~ "Your webserver is running in safe_mode. Please keep this window open. It may "
-#~ "reload several times to make sure all messages are sent."
-#~ msgstr ""
-#~ "Vaš strežnik teče v varnem načinu safe_mode. Imejte to okno odprto. Lahko se "
-#~ "večkrat osveži, da se prepričate, da so bila poslana vsa sporočila."
-
 #~ msgid "Reports will be sent by email to"
 #~ msgstr "Poročila bodo poslana na e-pošto"
 
@@ -10066,7 +10059,24 @@ msgstr ""
 #~ msgstr "Trenutni atributi"
 
 #~ msgid "spamblockemailintro"
-#~ msgstr "  -------------------------------------------------------------------------------- This is a notification of a possible spam attack to your phplist subscribe page. The data submitted has been copied below, so you can check whether this was actually the case. The submitted data has been converted into non-html characters, for security reasons.  If you want to stop receiving this message, set     define('NOTIFY_SPAM',0);  in your phplist config file.  This user has not been added to the database. If there is an error, you will need to  add them manually.  --------------------------------------------------------------------------------  "
+#~ msgstr "
+
+ --------------------------------------------------------------------------------
+ This is a notification of a possible spam attack to your phplist subscribe page.
+ The data submitted has been copied below, so you can check whether this was actually the case.
+ The submitted data has been converted into non-html characters, for security reasons.
+
+ If you want to stop receiving this message, set
+
+   define('NOTIFY_SPAM',0);
+
+ in your phplist config file.
+
+ This user has not been added to the database. If there is an error, you will need to
+ add them manually.
+ --------------------------------------------------------------------------------
+
+ "
 
 #~ msgid "was_subscribed"
 #~ msgstr "Was subscribed to:"
@@ -10267,7 +10277,12 @@ msgstr ""
 #~ msgstr "Kontrolne vrednosti za"
 
 #~ msgid "prependemailtext"
-#~ msgstr " Oprostite, da vas motimo: malo čistimo svojo bazo podatkov in izgleda, da  ste se prijavili na naše novice, niste pa uspeli potrditi vaše prijave.  Sedaj imate ponovno možnost, da vašo prijavo potrdite.Navodila so kot spodaj.   "
+#~ msgstr "
+ Oprostite, da vas motimo: malo čistimo svojo bazo podatkov in izgleda, da
+ ste se prijavili na naše novice, niste pa uspeli potrditi vaše prijave.
+
+ Sedaj imate ponovno možnost, da vašo prijavo potrdite.Navodila so kot spodaj.
+   "
 
 #~ msgid "unreadable"
 #~ msgstr "Cannot read file. It is not readable !"
@@ -10315,7 +10330,9 @@ msgstr ""
 #~ msgstr "Spodaj so uporabniki, ki so bili označeni kot nepotrjeni. Številka v [] je njihova uporabniška ID, številka v () pa je število zaporednih odbojev"
 
 #~ msgid "import3info"
-#~ msgstr "There are two ways to add the names of the users,  either one attribute for the entire name or two attributes, one for first name and one for last name. If you use 'two attributes', the name will be split after the first space."
+#~ msgstr "There are two ways to add the names of the users,
+  either one attribute for the entire name or two attributes, one for first name and one for last name.
+ If you use 'two attributes', the name will be split after the first space."
 
 #~ msgid "whatisprepare"
 #~ msgstr "Kaj je priprava sporočila"
@@ -10420,7 +10437,19 @@ msgstr ""
 #~ msgstr "If you choose ""send notification email"" the users you are adding will be sent the request for confirmation of subscription to which they will have to reply. This is recommended, because it will identify invalid emails."
 
 #~ msgid "importintro"
-#~ msgstr "<p>The file you upload will need to have the attributes of the records on    the first line.     Make sure that the email column is called ""email"" and not something like ""e-mail"" or     ""Email Address"".     Case is not important.     </p>     If you have a column called ""Foreign Key"", this will be used for synchronisation between an     external database and the PHPlist database. The foreignkey will take precedence when matching     an existing user. This will slow down the import process. If you use this, it is allowed to have     records without email, but an ""Invalid Email"" will be created instead. You can then do     a search on ""invalid email"" to find those records. Maximum size of a foreign key is 100.     <br/><br/>     <b>Warning</b>: the file needs to be plain text. Do not upload binary files like a Word Document.     <br/>"
+#~ msgstr "<p>The file you upload will need to have the attributes of the records on    the first line.
+     Make sure that the email column is called ""email"" and not something like ""e-mail"" or
+     ""Email Address"".
+     Case is not important.
+     </p>
+     If you have a column called ""Foreign Key"", this will be used for synchronisation between an
+     external database and the PHPlist database. The foreignkey will take precedence when matching
+     an existing user. This will slow down the import process. If you use this, it is allowed to have
+     records without email, but an ""Invalid Email"" will be created instead. You can then do
+     a search on ""invalid email"" to find those records. Maximum size of a foreign key is 100.
+     <br/><br/>
+     <b>Warning</b>: the file needs to be plain text. Do not upload binary files like a Word Document.
+     <br/>"
 
 #~ msgid "powered by"
 #~ msgstr "powered by"
@@ -10507,13 +10536,17 @@ msgstr ""
 #~ msgstr "Spoji dvojne vnose"
 
 #~ msgid "rulesexistwarning"
-#~ msgstr "Pravila odbojev so že nastavljena.      Bodite pozorni pri oblikovanju novih, saj lahko vplivajo na že obstoječe."
+#~ msgstr "Pravila odbojev so že nastavljena.
+     Bodite pozorni pri oblikovanju novih, saj lahko vplivajo na že obstoječe."
 
 #~ msgid "IncreaseB"
 #~ msgstr "Povečaj štetje odbojev z"
 
 #~ msgid "assigninvalid_blurb"
-#~ msgstr "Assign Invalid will be used to create an email for users with an invalid email address. You can use values between [ and ] to make up a value for the email. For example if your import file contains a column ""First Name"" and one called ""Last Name"", you can use ""[first name] [last name]"" to construct a new value for the email for this user containing their first name and last name. The value [number] can be used to insert the sequence number for importing."
+#~ msgstr "Assign Invalid will be used to create an email for users with an invalid email address.
+ You can use values between [ and ] to make up a value for the email. For example if your import file contains a column ""First Name"" and one called ""Last Name"", you can use
+ ""[first name] [last name]"" to construct a new value for the email for this user containing their first name and last name.
+ The value [number] can be used to insert the sequence number for importing."
 
 #~ msgid "warnnopearhttprequest"
 #~ msgstr "Poslati poskušaš oddaljen URL, ampak PEAR::HTTP/Request ni na voljo, tako, da to ne bo uspešno"
@@ -10552,7 +10585,10 @@ msgstr ""
 #~ msgstr "razširi"
 
 #~ msgid "norulesyet"
-#~ msgstr "Ni definiranih pravil odbojev.      Lahko kliknete na ""Ustvari pravilo za odboje"" za samodejno generiranje pravil osnovanih na obstoječih pravilih.      Rezultat bo veliko pravil, ki jih boste morao pregledati in aktivirati.      S časom je potrebno dodati nova pravila, ko se število odbojev poveča."
+#~ msgstr "Ni definiranih pravil odbojev.
+     Lahko kliknete na ""Ustvari pravilo za odboje"" za samodejno generiranje pravil osnovanih na obstoječih pravilih.
+     Rezultat bo veliko pravil, ki jih boste morao pregledati in aktivirati.
+     S časom je potrebno dodati nova pravila, ko se število odbojev poveča."
 
 #~ msgid "Upload new image"
 #~ msgstr "Prenesi novo sliko"
@@ -10591,7 +10627,16 @@ msgstr ""
 #~ msgstr "Test output:"
 
 #~ msgid "strAccessExplain"
-#~ msgstr "<hr/> <p>Nastavitev dovoljenj za vpogled strani v sistemu:</p> <ul> <li>Vse: admin ima vsa dovoljenja</li> <li>Pogled: admin lahko vidi strani, vendar jih ne more spreminjati. Velja za strani ""uporabnik"", ""uporabniki"" in ""člani"".</li> <li>Noben: admin ne more videti te strani</li> <li>Owner: admin lahko vidi to stran, ampak vidi samo vsebino seznamov, katerih je lastnik</li> </ul> <p>Pozor: Geslo administratorja mora vsebovati najmanj 4 karakterje</p> "
+#~ msgstr "<hr/>
+ <p>Nastavitev dovoljenj za vpogled strani v sistemu:</p>
+ <ul>
+ <li>Vse: admin ima vsa dovoljenja</li>
+ <li>Pogled: admin lahko vidi strani, vendar jih ne more spreminjati. Velja za strani ""uporabnik"", ""uporabniki"" in ""člani"".</li>
+ <li>Noben: admin ne more videti te strani</li>
+ <li>Owner: admin lahko vidi to stran, ampak vidi samo vsebino seznamov, katerih je lastnik</li>
+ </ul>
+ <p>Pozor: Geslo administratorja mora vsebovati najmanj 4 karakterje</p>
+ "
 
 #~ msgid "(default is line break)"
 #~ msgstr "(default is line break)"
@@ -10827,7 +10872,8 @@ msgstr ""
 #~ msgid "nofpdf"
 #~ msgstr "You are trying to use PDF support without having FPDF loaded"
 
-#~ msgid "if there is only one visible list, should it be hidden in the page and automatically     subscribe users who sign up (0/1)"
+#~ msgid "if there is only one visible list, should it be hidden in the page and automatically
+     subscribe users who sign up (0/1)"
 #~ msgstr "Če je vidna le ena kategorija novic, ali naj bo skrita na naročnišči strani in naj se naročniki samodejno včlanijo vanjo? (0/1)"
 
 #~ msgid "adding"
@@ -10840,7 +10886,8 @@ msgstr ""
 #~ msgstr "Kategorija je aktivna"
 
 #~ msgid "excludelistexplain"
-#~ msgstr "Sporočilo bo poslano uporabnikom zgornjih kategorij,     razen, če so člani kategorij, ki ste jih izbrali tukaj."
+#~ msgstr "Sporočilo bo poslano uporabnikom zgornjih kategorij,
+     razen, če so člani kategorij, ki ste jih izbrali tukaj."
 
 #~ msgid "create_subscr_pages"
 #~ msgstr "Ustvari naročniške strani"
@@ -10909,7 +10956,11 @@ msgstr ""
 #~ msgstr "Izberi kolone, ki bodo vključene v izvoz"
 
 #~ msgid "importadmininfo"
-#~ msgstr "   The file you upload will need to contain the administrators you want to add to the system. The columns need to have the following headers: <b>email</b>, <b>loginname</b>, <b>password</b>. Any other columns will be added as admin attributes.  <b>Warning</b>: the file needs to be plain text. Do not upload binary files like a Word Document.   "
+#~ msgstr "
+   The file you upload will need to contain the administrators
+ you want to add to the system. The columns need to have the following headers: <b>email</b>, <b>loginname</b>, <b>password</b>. Any other columns will be added as admin attributes.
+  <b>Warning</b>: the file needs to be plain text. Do not upload binary files like a Word Document.
+   "
 
 #~ msgid "line_break_default"
 #~ msgstr "(default is line break)"
@@ -10977,8 +11028,10 @@ msgstr ""
 #~ msgid "selectlists"
 #~ msgstr "Izberi kategorije za pošiljanje"
 
-#~ msgid "to make sure you are updated when new versions come out.     Sometimes security bugs are found which make it important to upgrade. Traffic on the list is very low."
-#~ msgstr "to make sure you are updated when new versions come out.     Sometimes security bugs are found which make it important to upgrade. Traffic on the list is very low."
+#~ msgid "to make sure you are updated when new versions come out.
+     Sometimes security bugs are found which make it important to upgrade. Traffic on the list is very low."
+#~ msgstr "to make sure you are updated when new versions come out.
+     Sometimes security bugs are found which make it important to upgrade. Traffic on the list is very low."
 
 #~ msgid "Message Sending has started"
 #~ msgstr "Pošiljanje sporočil se je pričelo"
@@ -11152,7 +11205,34 @@ msgstr ""
 #~ msgstr "Dimenzije področja za tekst (vrstice,kolone)"
 
 #~ msgid "TempSample"
-#~ msgstr "  While Socrates was speaking, Pythodorus thought that Parmenides and Zeno were not altogether pleased at the successive steps of the argument; but still they gave the closest attention, and often looked at one another, and smiled as if in admiration of him.  When he had finished, Parmenides expressed their feelings in the following words:--  Socrates, he said, I admire the bent of your mind towards philosophy; tell me now, was this your own distinction between ideas in themselves and the things which partake of them? and do you think that there is an idea of likeness apart from the likeness which we possess, and of the one and many, and of the other things which Zeno mentioned?  I think that there are such ideas, said Socrates.  Parmenides proceeded:  And would you also make absolute ideas of the just and the beautiful and the good, and of all that class?  Yes, he said, I should.  And would you make an idea of man apart from us and from all other human creatures, or of fire and water?  I am often undecided, Parmenides, as to whether I ought to include them or not.  "
+#~ msgstr "
+
+ While Socrates was speaking, Pythodorus thought that Parmenides and Zeno
+ were not altogether pleased at the successive steps of the argument; but
+ still they gave the closest attention, and often looked at one another, and
+ smiled as if in admiration of him.  When he had finished, Parmenides
+ expressed their feelings in the following words:--
+
+ Socrates, he said, I admire the bent of your mind towards philosophy; tell
+ me now, was this your own distinction between ideas in themselves and the
+ things which partake of them? and do you think that there is an idea of
+ likeness apart from the likeness which we possess, and of the one and many,
+ and of the other things which Zeno mentioned?
+
+ I think that there are such ideas, said Socrates.
+
+ Parmenides proceeded:  And would you also make absolute ideas of the just
+ and the beautiful and the good, and of all that class?
+
+ Yes, he said, I should.
+
+ And would you make an idea of man apart from us and from all other human
+ creatures, or of fire and water?
+
+ I am often undecided, Parmenides, as to whether I ought to include them or
+ not.
+
+ "
 
 #~ msgid "Users apply"
 #~ msgstr "Uporabnikov ustreza"
@@ -11215,7 +11295,8 @@ msgstr ""
 #~ msgstr "Info o sporočilu"
 
 #~ msgid "messagefooterexplanation"
-#~ msgstr "Uporabi <b>[UNSUBSCRIBE]</b> za vstavitev osebne strani za odjavo vsakega uporabnika.     <br/>Uporabi <b>[PREFERENCES]</b> za vstavitev povezave za urejanje podrobnosti vsakega uporabnika"
+#~ msgstr "Uporabi <b>[UNSUBSCRIBE]</b> za vstavitev osebne strani za odjavo vsakega uporabnika.
+     <br/>Uporabi <b>[PREFERENCES]</b> za vstavitev povezave za urejanje podrobnosti vsakega uporabnika"
 
 #~ msgid "Is this user Super Admin?"
 #~ msgstr "Ali je ta uporabnik super Administrator?"

--- a/public_html/lists/admin/locale/sr/phplist.po
+++ b/public_html/lists/admin/locale/sr/phplist.po
@@ -9632,13 +9632,6 @@ msgstr "pagetitlehover:lista suzbijenih"
 #~ "Ostavite ovaj prozor otvoren. Pošto ste omogućili grupno slanje prozor će se "
 #~ "više puta učitati dok šalje poruke. Izveštaji će biti poslati e-porukom za"
 
-#~ msgid ""
-#~ "Your webserver is running in safe_mode. Please keep this window open. It may "
-#~ "reload several times to make sure all messages are sent."
-#~ msgstr ""
-#~ "Vaš veb server je u sigurnom režimu. Držite ovaj prozor otvoren.  On će se "
-#~ "učitati više puta dok se sve poruke ne pošalju."
-
 #~ msgid "Reports will be sent by email to"
 #~ msgstr "Izveštaji će biti poslati na "
 

--- a/public_html/lists/admin/locale/sv/phplist.po
+++ b/public_html/lists/admin/locale/sv/phplist.po
@@ -9491,14 +9491,6 @@ msgstr ""
 #~ "partibearbetning, så det kommer uppdateras flera gånger för att sända "
 #~ "utskicken. Rapporter kommer sändas via e-post till"
 
-#~ msgid ""
-#~ "Your webserver is running in safe_mode. Please keep this window open. It may "
-#~ "reload several times to make sure all messages are sent."
-#~ msgstr ""
-#~ "Din webbserver körs i \"safe_mode\". Vänligen håll detta fönster öppet. Det "
-#~ "kan uppdateras flera gånger för att försäkra sig om att alla utskick har "
-#~ "sänts."
-
 #~ msgid "Reports will be sent by email to"
 #~ msgstr "Rapporter kommer sändas via e-post till"
 

--- a/public_html/lists/admin/locale/templates/new.po
+++ b/public_html/lists/admin/locale/templates/new.po
@@ -5507,12 +5507,6 @@ msgstr ""
 msgid "Your version"
 msgstr ""
 
-#: public_html/lists/admin/actions/processqueue.php:478
-msgid ""
-"Your webserver is running in safe_mode. Please keep this window open. It may "
-"reload several times to make sure all messages are sent."
-msgstr ""
-
 #: public_html/lists/admin/defaultconfig.php:416
 msgid "[notify] Change of List-Membership details"
 msgstr ""

--- a/public_html/lists/admin/locale/vi/phplist.po
+++ b/public_html/lists/admin/locale/vi/phplist.po
@@ -9678,13 +9678,6 @@ msgstr ""
 #~ "Please leave this window open. You have batch processing enabled, so it will "
 #~ "reload several times to send the messages. Reports will be sent by email to"
 
-#~ msgid ""
-#~ "Your webserver is running in safe_mode. Please keep this window open. It may "
-#~ "reload several times to make sure all messages are sent."
-#~ msgstr ""
-#~ "Your webserver is running in \"safe_mode\". Please keep this window open. It "
-#~ "may reload several times to make sure all messages are sent."
-
 #~ msgid "Reports will be sent by email to"
 #~ msgstr "Reports will be sent by email to"
 

--- a/public_html/lists/admin/locale/zh_CN/phplist.po
+++ b/public_html/lists/admin/locale/zh_CN/phplist.po
@@ -9445,11 +9445,6 @@ msgstr ""
 #~ "reload several times to send the messages. Reports will be sent by email to"
 #~ msgstr "请保持这个视窗开启，因为您启用了批次处理功能，所以系统会自动重新载入页面多次来发送所有信件；报表将会寄到 "
 
-#~ msgid ""
-#~ "Your webserver is running in safe_mode. Please keep this window open. It may "
-#~ "reload several times to make sure all messages are sent."
-#~ msgstr "您的网站伺服器执行在 \"安全模式\"，请保持开启这个视窗，它也许会重新读取多次来确保所有信件能够顺利寄出。"
-
 #~ msgid "Reports will be sent by email to"
 #~ msgstr "报表会寄到"
 

--- a/public_html/lists/admin/locale/zh_TW/phplist.po
+++ b/public_html/lists/admin/locale/zh_TW/phplist.po
@@ -9462,11 +9462,6 @@ msgstr ""
 #~ "reload several times to send the messages. Reports will be sent by email to"
 #~ msgstr "請保持這個視窗開啟，因為您啟用了批次處理功能，所以系統會自動重新載入頁面多次來寄送所有信件；報表將會寄到 "
 
-#~ msgid ""
-#~ "Your webserver is running in safe_mode. Please keep this window open. It may "
-#~ "reload several times to make sure all messages are sent."
-#~ msgstr "您的網站伺服器執行在 \"安全模式\"，請保持開啟這個視窗，它也許會重新讀取多次來確保所有信件能夠順利寄出。"
-
 #~ msgid "Reports will be sent by email to"
 #~ msgstr "報表會寄到"
 

--- a/public_html/lists/admin/stresstest.php
+++ b/public_html/lists/admin/stresstest.php
@@ -108,37 +108,32 @@ while ($row = Sql_Fetch_Row($res)) {
     array_push($testlists, $row[0]);
 }
 
-if (!ini_get('safe_mode')) {
-    if (!count($testlists)) {
-        echo '<script language="Javascript" type="text/javascript"> document.forms[0].output.value="Error: cannot find any test lists to use";</script>'."\n";
-    } elseif (!isset($eraseall)) {
-        echo '<script language="Javascript" type="text/javascript"> document.forms[0].output.value="Filling ";</script>'."\n";
-        for ($i = 0; $i <= 100; ++$i) {
-            set_time_limit(60);
-            flush();
-            reset($testlists);
-            while (list($key, $val) = each($testlists)) {
-                if (!fill(getmypid().$i, $val)) {
-                    return;
-                }
-            }
-        }
-    } else {
-        $req = Sql_Query("select id from $tables[user] where email like \"testuser%\"");
-        $i = 1;
+if (!count($testlists)) {
+    echo '<script language="Javascript" type="text/javascript"> document.forms[0].output.value="Error: cannot find any test lists to use";</script>'."\n";
+} elseif (!isset($eraseall)) {
+    echo '<script language="Javascript" type="text/javascript"> document.forms[0].output.value="Filling ";</script>'."\n";
+    for ($i = 0; $i <= 100; ++$i) {
         set_time_limit(60);
-        echo '<script language="Javascript" type="text/javascript"> document.forms[0].output.value="Erasing ";</script>'."\n";
         flush();
-        while ($row = Sql_Fetch_row($req)) {
-            Sql_Query("delete quick from $tables[user_attribute] where userid = $row[0]");
-            Sql_Query("delete quick from $tables[listuser] where userid = $row[0]");
-            Sql_Query("delete quick from $tables[usermessage] where userid = $row[0]");
-            Sql_Query("delete quick from $tables[user] where id = $row[0]");
-            ++$i;
+        reset($testlists);
+        while (list($key, $val) = each($testlists)) {
+            if (!fill(getmypid().$i, $val)) {
+                return;
+            }
         }
     }
 } else {
-    echo Error('Cannot do stresstest in safe mode');
+    $req = Sql_Query("select id from $tables[user] where email like \"testuser%\"");
+    $i = 1;
+    set_time_limit(60);
+    echo '<script language="Javascript" type="text/javascript"> document.forms[0].output.value="Erasing ";</script>'."\n";
+    flush();
+    while ($row = Sql_Fetch_row($req)) {
+        Sql_Query("delete quick from $tables[user_attribute] where userid = $row[0]");
+        Sql_Query("delete quick from $tables[listuser] where userid = $row[0]");
+        Sql_Query("delete quick from $tables[usermessage] where userid = $row[0]");
+        Sql_Query("delete quick from $tables[user] where id = $row[0]");
+        ++$i;
+    }
 }
-
 ?>


### PR DESCRIPTION
And drop code that is required for lower PHP versions only, including
code for magic quotes or safe mode.

Fixes #137