### PR TITLE
[CLEANUP] Drop the StyleCI badge from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 [![Build Status](https://travis-ci.org/phpList/phplist3.svg?branch=master)](https://travis-ci.org/phpList/phplist3)
 
-[![StyleCI](https://styleci.io/repos/32042787/shield)](https://styleci.io/repos/32042787)
-
 Open source newsletter and email marketing manager https://www.phplist.org
 
 ---


### PR DESCRIPTION
[ci skip]

This repository no longer uses StyleCI. So the badge does not work anymore
and schould go.