### PR TITLE
Update processqueue.php

### DIFF
--- a/public_html/lists/admin/actions/processqueue.php
+++ b/public_html/lists/admin/actions/processqueue.php
@@ -314,10 +314,18 @@ function my_shutdown()
         }
         $counters['delaysend'] = (int) ($batch_period - $totaltime);
         if (empty($GLOBALS['inRemoteCall']) && empty($GLOBALS['commandline'])) {
-            sleep($delaytime);
-            printf('<script type="text/javascript">
-          document.location = "./?page=pageaction&action=processqueue&ajaxed=true&reload=%d&lastsent=%d&lastskipped=%d%s";
-        </script></body></html>', $reload, $counters['sent'], $notsent, addCsrfGetToken());
+            if (defined('JSLEEPMETHOD')) {
+                printf('<script type="text/javascript">
+                setTimeout(function() {
+                    document.location = "./?page=pageaction&action=processqueue&ajaxed=true&reload=%d&lastsent=%d&lastskipped=%d%s";
+                }, %d);
+                </script></body></html>', $reload, $counters['sent'], $notsent, addCsrfGetToken(), $delaytime*1000);
+            } else {
+			    sleep($delaytime);
+                printf('<script type="text/javascript">
+                document.location = "./?page=pageaction&action=processqueue&ajaxed=true&reload=%d&lastsent=%d&lastskipped=%d%s";
+                </script></body></html>', $reload, $counters['sent'], $notsent, addCsrfGetToken());
+		    }
         }
     } elseif ($script_stage == 6 || $nothingtodo) {
         foreach ($GLOBALS['plugins'] as $pluginname => $plugin) {


### PR DESCRIPTION
Add option to use Javascript timeout function instead of php sleep()
To use, you just need to add the following line to config/config.php
define('JSLEEPMETHOD', 1);

NOTES
The amended section is only accessed in browser context, not by cron.
By using a define, if undeclared, current function is unchanged.
Allows for further expansion of this functionality by defining other values of JSLEEPMETHOD
Instead of concurrent connections to same website/server potentially hanging during the sleep() process, new method better allows concurrent operations and ties up less resources