### PR TITLE
Add backward compatibility support for PHP 5.3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ php:
   - 5.6
   - 5.5
   - 5.4
+  - 5.3
 
 before_script:
   - sudo apt-get update > /dev/null

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   },
   "minimum-stability": "dev",
   "require": {
-    "php": ">= 5.3.0, <= 7.1.99"
+    "php": ">= 5.3.3, <= 7.1.99"
   },
   "require-dev": {
     "behat/mink": "~1.4",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   },
   "minimum-stability": "dev",
   "require": {
-    "php": ">= 5.4.0, <= 7.1.99"
+    "php": ">= 5.3.0, <= 7.1.99"
   },
   "require-dev": {
     "behat/mink": "~1.4",

--- a/public_html/lists/admin/inc/php_compat.php
+++ b/public_html/lists/admin/inc/php_compat.php
@@ -64,13 +64,9 @@ if (!function_exists('hex2bin')) { // PHP 5.4 and up
      * @return string Returns the binary representation of the given data or FALSE on failure. 
      */
     function hex2bin($data) {
-        static $old;
-        if ($old === null) {
-            $old = version_compare(PHP_VERSION, '5.2', '<');
-        }
         $isobj = false;
         if (is_scalar($data) || (($isobj = is_object($data)) && method_exists($data, '__toString'))) {
-            if ($isobj && $old) {
+            if ($isobj) {
                 ob_start();
                 echo $data;
                 $data = ob_get_clean();

--- a/public_html/lists/admin/inc/php_compat.php
+++ b/public_html/lists/admin/inc/php_compat.php
@@ -64,16 +64,8 @@ if (!function_exists('hex2bin')) { // PHP 5.4 and up
      * @return string Returns the binary representation of the given data or FALSE on failure. 
      */
     function hex2bin($data) {
-        $isobj = false;
-        if (is_scalar($data) || (($isobj = is_object($data)) && method_exists($data, '__toString'))) {
-            if ($isobj) {
-                ob_start();
-                echo $data;
-                $data = ob_get_clean();
-            }
-            else {
-                $data = (string) $data;
-            }
+        if (is_scalar($data) || (method_exists($data, '__toString'))) {
+            $data = (string) $data;
         }
         else {
             trigger_error(__FUNCTION__.'() expects parameter 1 to be string, ' . gettype($data) . ' given', E_USER_WARNING);

--- a/public_html/lists/admin/inc/php_compat.php
+++ b/public_html/lists/admin/inc/php_compat.php
@@ -52,3 +52,46 @@ if (!function_exists('hash_equals')) { // 5.6 and up
         return $ret === 0;
     }
 }
+
+if (!function_exists('hex2bin')) { // PHP 5.4 and up
+    function hex2bin($data) {
+    /**
+     * Convert hexadecimal values to ASCII characters.
+     *
+     * Credits to walf from http://php.net/manual/en/function.hex2bin.php#113472
+     *
+     * @param string $data The hexadecimal representation of data to be converted
+     *
+     * @return string Returns the binary representation of the given data or FALSE on failure. 
+     */
+        static $old;
+        if ($old === null) {
+            $old = version_compare(PHP_VERSION, '5.2', '<');
+        }
+        $isobj = false;
+        if (is_scalar($data) || (($isobj = is_object($data)) && method_exists($data, '__toString'))) {
+            if ($isobj && $old) {
+                ob_start();
+                echo $data;
+                $data = ob_get_clean();
+            }
+            else {
+                $data = (string) $data;
+            }
+        }
+        else {
+            trigger_error(__FUNCTION__.'() expects parameter 1 to be string, ' . gettype($data) . ' given', E_USER_WARNING);
+            return;//null in this case
+        }
+        $len = strlen($data);
+        if ($len % 2) {
+            trigger_error(__FUNCTION__.'(): Hexadecimal input string must have an even length', E_USER_WARNING);
+            return false;
+        }
+        if (strspn($data, '0123456789abcdefABCDEF') != $len) {
+            trigger_error(__FUNCTION__.'(): Input string must be hexadecimal string', E_USER_WARNING);
+            return false;
+        }
+        return pack('H*', $data);
+    }
+}

--- a/public_html/lists/admin/inc/php_compat.php
+++ b/public_html/lists/admin/inc/php_compat.php
@@ -57,7 +57,9 @@ if (!function_exists('hex2bin')) { // PHP 5.4 and up
     /**
      * Convert hexadecimal values to ASCII characters.
      *
-     * Credits to walf from http://php.net/manual/en/function.hex2bin.php#113472
+     * Credits: Walf's user note from PHP Documentation Group - http://php.net/manual/en/function.hex2bin.php#113472
+     * License: CC-BY 3.0 (http://creativecommons.org/licenses/by/3.0/)
+     * Changes: The original part of the code has been simplified assuming PHP >= 5.3.3
      *
      * @param string $data The hexadecimal representation of data to be converted
      *

--- a/public_html/lists/admin/inc/php_compat.php
+++ b/public_html/lists/admin/inc/php_compat.php
@@ -54,7 +54,6 @@ if (!function_exists('hash_equals')) { // 5.6 and up
 }
 
 if (!function_exists('hex2bin')) { // PHP 5.4 and up
-    function hex2bin($data) {
     /**
      * Convert hexadecimal values to ASCII characters.
      *
@@ -64,6 +63,7 @@ if (!function_exists('hex2bin')) { // PHP 5.4 and up
      *
      * @return string Returns the binary representation of the given data or FALSE on failure. 
      */
+    function hex2bin($data) {
         static $old;
         if ($old === null) {
             $old = version_compare(PHP_VERSION, '5.2', '<');

--- a/public_html/lists/admin/index.php
+++ b/public_html/lists/admin/index.php
@@ -1,6 +1,6 @@
 <?php
 
-if (!defined('PHP_VERSION_ID') || PHP_VERSION_ID < 50300) {
+if (!defined('PHP_VERSION_ID') || PHP_VERSION_ID < 50303) {
     die('Your PHP version is too old. Please upgrade PHP before continuing.');
 }
 
@@ -491,7 +491,7 @@ if (!$ajax && $page != 'login') {
     if (TEST) {
         echo Info($GLOBALS['I18N']->get('Running in testmode, no emails will be sent. Check your config file.'));
     }
-    if (version_compare(PHP_VERSION, '5.3.0', '<') && WARN_ABOUT_PHP_SETTINGS) {
+    if (version_compare(PHP_VERSION, '5.3.3', '<') && WARN_ABOUT_PHP_SETTINGS) {
         Error(s('Your PHP version is out of date. phpList requires PHP version 5.4.0 or higher.'));
     }
     if (defined('RELEASEDATE') && ((time() - RELEASEDATE) / 31536000) > 2) {
@@ -501,10 +501,6 @@ if (!$ajax && $page != 'login') {
         return;
     }
 
-    if (!defined('PHP_VERSION_ID') || PHP_VERSION_ID < 50300) {
-        Fatal_Error(s('Your PHP version is too old. Please upgrade PHP before continuing'));
-        return;
-    }
     if (defined('ENABLE_RSS') && ENABLE_RSS && !function_exists('xml_parse') && WARN_ABOUT_PHP_SETTINGS) {
         Warn($GLOBALS['I18N']->get('You are trying to use RSS, but XML is not included in your PHP'));
     }

--- a/public_html/lists/admin/index.php
+++ b/public_html/lists/admin/index.php
@@ -491,7 +491,7 @@ if (!$ajax && $page != 'login') {
     if (TEST) {
         echo Info($GLOBALS['I18N']->get('Running in testmode, no emails will be sent. Check your config file.'));
     }
-    if (version_compare(PHP_VERSION, '5.4.0', '<') && WARN_ABOUT_PHP_SETTINGS) {
+    if (version_compare(PHP_VERSION, '5.3.0', '<') && WARN_ABOUT_PHP_SETTINGS) {
         Error(s('Your PHP version is out of date. phpList requires PHP version 5.4.0 or higher.'));
     }
     if (defined('RELEASEDATE') && ((time() - RELEASEDATE) / 31536000) > 2) {

--- a/public_html/lists/admin/index.php
+++ b/public_html/lists/admin/index.php
@@ -492,7 +492,7 @@ if (!$ajax && $page != 'login') {
         echo Info($GLOBALS['I18N']->get('Running in testmode, no emails will be sent. Check your config file.'));
     }
     if (version_compare(PHP_VERSION, '5.3.3', '<') && WARN_ABOUT_PHP_SETTINGS) {
-        Error(s('Your PHP version is out of date. phpList requires PHP version 5.4.0 or higher.'));
+        Error(s('Your PHP version is out of date. phpList requires PHP version 5.3.3 or higher.'));
     }
     if (defined('RELEASEDATE') && ((time() - RELEASEDATE) / 31536000) > 2) {
         Fatal_Error(s('Your phpList version is older than two years. Please %supgrade phpList</a> before continuing.</br>


### PR DESCRIPTION
As discussed in commit 452a009, I've successfully managed to keep phpList 3.3.1 working on el6 which provides only 5.3.3 via EPEL.