### PR TITLE
Start output buffering selectively

### DIFF
--- a/public_html/lists/admin/index.php
+++ b/public_html/lists/admin/index.php
@@ -4,7 +4,9 @@ if (!defined('PHP_VERSION_ID') || PHP_VERSION_ID < 50300) {
     die('Your PHP version is too old. Please upgrade PHP before continuing.');
 }
 
-@ob_start();
+if (ob_get_level() == 0) {
+    @ob_start();
+}
 $er = error_reporting(0);
 // check for commandline and cli version
 if (!isset($_SERVER['SERVER_NAME']) && PHP_SAPI != 'cli') {


### PR DESCRIPTION
Currently if output buffering is enabled in php.ini then there are two levels of buffering. 

That causes progress indicators, such as when exporting, to be buffered and not displayed immediately in the browser. So instead of showing progress every 50 subscribers it is shown every 1350.

With this change, and output buffering enabled in php.ini, the progress indicator shows every 50 subscribers.