### PR TITLE
Avoid creating unnecessary temporary file when exporting

### DIFF
--- a/public_html/lists/admin/actions/export.php
+++ b/public_html/lists/admin/actions/export.php
@@ -40,9 +40,6 @@ switch ($access) {
         break;
 }
 
-$exportfileName = tempnam($GLOBALS['tmpdir'], $GLOBALS['installation_name'].'-export'.time());
-$exportfile = fopen($exportfileName, 'w');
-
 if ($_SESSION['export']['column'] == 'nodate') {
     //# fetch dates as min and max from user table
     if ($list) {
@@ -60,14 +57,15 @@ if ($_SESSION['export']['column'] == 'nodate') {
     $fromdate = $_SESSION['export']['fromdate'];
     $todate = $_SESSION['export']['todate'];
 }
-if ($list) {
-    $filename = s('phpList Export on %s from %s to %s (%s).csv', ListName($list), $fromdate, $todate, date('Y-M-d'));
-} else {
-    $filename = s('phpList Export from %s to %s (%s).csv', $fromdate, $todate, date('Y-M-d'));
-}
 ob_end_clean();
-$filename = trim(strip_tags($filename));
+
 if (!empty($_SESSION['export']['fileready']) && is_file($_SESSION['export']['fileready'])) {
+    if ($list) {
+        $filename = s('phpList Export on %s from %s to %s (%s).csv', ListName($list), $fromdate, $todate, date('Y-M-d'));
+    } else {
+        $filename = s('phpList Export from %s to %s (%s).csv', $fromdate, $todate, date('Y-M-d'));
+    }
+    $filename = trim(strip_tags($filename));
     header('Content-type: '.$GLOBALS['export_mimetype'].'; charset=UTF-8');
     header("Content-disposition:  attachment; filename=\"$filename\"");
     $fp = fopen($_SESSION['export']['fileready'], 'r');
@@ -80,6 +78,8 @@ if (!empty($_SESSION['export']['fileready']) && is_file($_SESSION['export']['fil
     exit;
 }
 
+$exportfileName = tempnam($GLOBALS['tmpdir'], $GLOBALS['installation_name'].'-export'.time());
+$exportfile = fopen($exportfileName, 'w');
 $col_delim = "\t";
 if (EXPORT_EXCEL) {
     $col_delim = ',';


### PR DESCRIPTION
After exporting subscribers I noticed some zero length files in the temp directory.  Each time that action/export.php is run it creates a temporary file, when it needs to do that only on the first run, as the name of the temporary file is passed to the second run through the session.

There are two changes here:

- Move creation of the temporary file to avoid creating a second one.
- Reposition code dealing with the export file name.