### PR TITLE
Clarified labels

### DIFF
--- a/public_html/lists/admin/list.php
+++ b/public_html/lists/admin/list.php
@@ -36,9 +36,9 @@ function listMemberCounts($listId)
         '<span class="memberCount" title="%s">%s</span>'.' ('
         .'<span class="unconfirmedCount" title="%s">%s</span>, '.' '
         .'<span class="blacklistedCount" title="%s">%s</span>'.')',
-        s('Confirmed members'),
+        s('Confirmed and not blacklisted members'),
         number_format($counts['confirmed']),
-        s('Unconfirmed members'),
+        s('Unconfirmed and not blacklisted members'),
         number_format($counts['notconfirmed']),
         s('Blacklisted members'),
         number_format($counts['blacklisted'])


### PR DESCRIPTION
Existing labels are ambiguous; new labels are designed to explicitly state what the numbers show.