### PR TITLE
Clarified clicks label

### DIFF
--- a/public_html/lists/admin/actions/statsoverview.php
+++ b/public_html/lists/admin/actions/statsoverview.php
@@ -125,7 +125,7 @@ while ($row = Sql_Fetch_Array($req)) {
 
     $totalclicked = Sql_Fetch_Row_Query(sprintf('select count(distinct userid) from %s where messageid = %d',
         $GLOBALS['tables']['linktrack_uml_click'], $row['messageid']));
-    $ls->addColumn($element, $GLOBALS['I18N']->get('clicks'), $totalclicked[0],
+    $ls->addColumn($element, $GLOBALS['I18N']->get('Unique Clicks'), $totalclicked[0],
         $totalclicked[0] ? PageURL2('mclicks&id='.$row['messageid']) : '');
 
     $ls->addRow($element, '',

--- a/public_html/lists/admin/messages.php
+++ b/public_html/lists/admin/messages.php
@@ -410,7 +410,7 @@ if ($total) {
       <tr><td>' .s('Unique Views').'</td><td>'.$uniqueviews[0].'</td></tr>';
             if ($clicks[0]) {
                 $resultStats .= '
-           <tr><td>' .s('Clicks').'</td><td>'.$clicks[0].'</td></tr>';
+           <tr><td>' .s('Total Clicks').'</td><td>'.$clicks[0].'</td></tr>';
             }
             $resultStats .= '
          <tr><td>' .s('Bounced').'</td><td>'.$msg['bouncecount'].'</td></tr>';

--- a/public_html/lists/admin/statsoverview.php
+++ b/public_html/lists/admin/statsoverview.php
@@ -69,6 +69,7 @@ if (!$id) {
         unset($_SESSION['LoadDelay']);
     }
 
+    // Load page content via AJAX
     echo '<div id="contentdiv"></div>';
     echo asyncLoadContent('./?page=pageaction&action=statsoverview&ajaxed=true&id='.$id.'&start='.$start.addCsrfGetToken());
 


### PR DESCRIPTION
Clarifying use of 'clicks' label -- fixes inconsistent use of this label. E.g. the statsoverview page and the messages page show different statistics under the same label 'clicks'. This commit uses more descriptive labels. The longer labels take more column space/ width, which is not ideal. Improvements on space optimisation welcome.