### PR TITLE
Added headings to the 'list messages' page tables

### DIFF
--- a/public_html/lists/admin/css/app.css
+++ b/public_html/lists/admin/css/app.css
@@ -162,6 +162,13 @@ table.adminDetails td {
     padding: 5px;
 }
 
+/* Style nested table heading row */
+tr table th {
+    text-decoration: underline; 
+    text-align: center; 
+    font-weight: normal;
+}
+
 .actionresult, .result {
     border: 2px solid;
     margin: 15px 0;

--- a/public_html/lists/admin/messages.php
+++ b/public_html/lists/admin/messages.php
@@ -408,18 +408,21 @@ if ($total) {
             $resultStats = '<table class="messagesendstats">
       <thead>
         <tr>
-          <th colspan="3" style="text-decoration: underline; text-align: center; font-weight: normal;">Statistics</th>
+          <th colspan="3">Statistics</th>
         </tr>
       </thead>
-      <tr><td>' .s('Viewed').'</td><td>'.$msg['viewed'].'</td></tr>
-      <tr><td>' .s('Unique Views').'</td><td>'.$uniqueviews[0].'</td></tr>';
-            if ($clicks[0]) {
-                $resultStats .= '
-           <tr><td>' .s('Total Clicks').'</td><td>'.$clicks[0].'</td></tr>';
-            }
+      <tbody>
+        <tr><td>' .s('Viewed').'</td><td>'.$msg['viewed'].'</td></tr>
+        <tr><td>' .s('Unique Views').'</td><td>'.$uniqueviews[0].'</td></tr>';
+                if ($clicks[0]) {
+                    $resultStats .= '
+            <tr><td>' .s('Total Clicks').'</td><td>'.$clicks[0].'</td></tr>';
+                }
             $resultStats .= '
-         <tr><td>' .s('Bounced').'</td><td>'.$msg['bouncecount'].'</td></tr>';
-            $resultStats .= '</table>';
+            <tr><td>' .s('Bounced').'</td><td>'.$msg['bouncecount'].'</td></tr>';
+                $resultStats .= '
+        <tbody>
+    </table>';
 
 //      $ls->addColumn($listingelement,s('Results'),$resultStats);
 
@@ -457,18 +460,20 @@ if ($total) {
 
         $sendstats =
             sprintf('<table class="messagesendstats">
-      <thead>
-        <tr>
-          <th colspan="3" style="text-decoration: underline; text-align: center; font-weight: normal;">Processed</th>
-        </tr>
-      </thead>
-      %s
-      <tr><td>' .$GLOBALS['I18N']->get('total').'</td><td>'.$GLOBALS['I18N']->get('text').'</td><td>'.$GLOBALS['I18N']->get('html').'</td>
-        %s%s
-      </tr>
-      <tr><td><b>%d</b></td><td><b>%d</b></td><td><b>%d</b></td>
-        %s %s %s %s
-      </tr>
+          <thead>
+            <tr>
+              <th colspan="3">Processed</th>
+            </tr>
+          </thead>
+          <tbody>
+              %s
+              <tr><td>' .$GLOBALS['I18N']->get('total').'</td><td>'.$GLOBALS['I18N']->get('text').'</td><td>'.$GLOBALS['I18N']->get('html').'</td>
+                %s%s
+              </tr>
+              <tr><td><b>%d</b></td><td><b>%d</b></td><td><b>%d</b></td>
+                %s %s %s %s
+              </tr>
+          </tbody>
       </table>',
                 !empty($timetosend) ? '<tr><td colspan="'.$colspan.'">'.$timetosend.'</td></tr>' : '',
                 !empty($msg['aspdf']) ? '<td>'.$GLOBALS['I18N']->get('PDF').'</td>' : '',

--- a/public_html/lists/admin/messages.php
+++ b/public_html/lists/admin/messages.php
@@ -406,6 +406,11 @@ if ($total) {
 //      $ls->addColumn($listingelement,$GLOBALS['I18N']->get("both"), $msg["astextandpdf"]);
 //    }
             $resultStats = '<table class="messagesendstats">
+      <thead>
+        <tr>
+          <td colspan="3" style="text-decoration: underline; text-align: center">Statistics</td>
+        </tr>
+      </thead>
       <tr><td>' .s('Viewed').'</td><td>'.$msg['viewed'].'</td></tr>
       <tr><td>' .s('Unique Views').'</td><td>'.$uniqueviews[0].'</td></tr>';
             if ($clicks[0]) {
@@ -452,6 +457,11 @@ if ($total) {
 
         $sendstats =
             sprintf('<table class="messagesendstats">
+      <thead>
+        <tr>
+          <td colspan="3" style="text-decoration: underline; text-align: center">Processed</td>
+        </tr>
+      </thead>
       %s
       <tr><td>' .$GLOBALS['I18N']->get('total').'</td><td>'.$GLOBALS['I18N']->get('text').'</td><td>'.$GLOBALS['I18N']->get('html').'</td>
         %s%s

--- a/public_html/lists/admin/messages.php
+++ b/public_html/lists/admin/messages.php
@@ -408,7 +408,7 @@ if ($total) {
             $resultStats = '<table class="messagesendstats">
       <thead>
         <tr>
-          <th colspan="3">Statistics</th>
+          <th colspan="2">Statistics</th>
         </tr>
       </thead>
       <tbody>
@@ -421,7 +421,7 @@ if ($total) {
             $resultStats .= '
             <tr><td>' .s('Bounced').'</td><td>'.$msg['bouncecount'].'</td></tr>';
                 $resultStats .= '
-        <tbody>
+        </tbody>
     </table>';
 
 //      $ls->addColumn($listingelement,s('Results'),$resultStats);

--- a/public_html/lists/admin/messages.php
+++ b/public_html/lists/admin/messages.php
@@ -408,7 +408,7 @@ if ($total) {
             $resultStats = '<table class="messagesendstats">
       <thead>
         <tr>
-          <td colspan="3" style="text-decoration: underline; text-align: center">Statistics</td>
+          <th colspan="3" style="text-decoration: underline; text-align: center; font-weight: normal;">Statistics</th>
         </tr>
       </thead>
       <tr><td>' .s('Viewed').'</td><td>'.$msg['viewed'].'</td></tr>
@@ -459,7 +459,7 @@ if ($total) {
             sprintf('<table class="messagesendstats">
       <thead>
         <tr>
-          <td colspan="3" style="text-decoration: underline; text-align: center">Processed</td>
+          <th colspan="3" style="text-decoration: underline; text-align: center; font-weight: normal;">Processed</th>
         </tr>
       </thead>
       %s


### PR DESCRIPTION
Added headings to the 'list messages' table, to clarify that 'text' & 'HTML' refer to processed, not sent. Sometimes sending errors cause the 'Total' and 'HTML' totals to increase indefinitely, resulting in huge numbers. This does not indicate that messages have actually been sent however (the statistics page does that)