### PR TITLE
Fix bug: https://mantis.phplist.org/view.php?id=18240

### DIFF
--- a/public_html/lists/admin/connect.php
+++ b/public_html/lists/admin/connect.php
@@ -1389,9 +1389,10 @@ function listSelectHTML($current, $fieldname, $subselect, $alltab = '')
             if ($category == 'all') {
                 $category = '@';
             }
-            if ($some > 1) { //# don't show tabs, when there's just one
+/* "if" commented on 2017-5-8 to show tabs always fixing UI bugs on all themes with jQuery in checkboxes. I suggest to remove it permanently. */
+//            if ($some > 1) { //# don't show tabs, when there's just one
                 $listindex .= sprintf('<li><a href="#%s%d">%s</a></li>', $fieldname, $tabno, $category);
-            }
+ //           }
             if ($fieldname == 'targetlist') {
                 // Add select all checkbox in every category to select all lists in that category.
                 if ($category == 'selected') {

--- a/public_html/lists/admin/send_core.php
+++ b/public_html/lists/admin/send_core.php
@@ -1172,7 +1172,7 @@ $GLOBALS['pagefooter']['sendtabs'] = "<script language='Javascript' type='text/j
 		var tabvis = (($('.sendtabs_container').width()-50)/102)+'';
 		var arrvis = tabvis.split('.');
 		var tabdif = currenttab-arrvis[0];
-		if (counttab <= arrvis[0]) {arrvis[0] = counttab-1};
+		if (counttab <= arrvis[0]) {arrvis[0] = counttab};
 		$('.sendcampaign').cycle({ slides:'> li', timeout:0, fx:'carousel', allowWrap:false, carouselVisible:arrvis[0], next:'.nexttab', prev:'.prevtab' });
 		$('.sendcampaign').cycle('goto',tabdif); 
 
@@ -1181,7 +1181,7 @@ $GLOBALS['pagefooter']['sendtabs'] = "<script language='Javascript' type='text/j
 			tabvis = (($('.sendtabs_container').width()-50)/102)+'';
 			arrvis = tabvis.split('.');
 			tabdif = currenttab-arrvis[0];
-			if (counttab <= arrvis[0]) {arrvis[0] = counttab-1};
+			if (counttab <= arrvis[0]) {arrvis[0] = counttab};
 			$('.sendcampaign').cycle({ slides:'> li', timeout:0, fx:'carousel', allowWrap:false, carouselVisible:arrvis[0], next:'.nexttab', prev:'.prevtab' });
 			$('.sendcampaign').cycle('goto',tabdif); 
 		});


### PR DESCRIPTION
@michield and @bramley please check if this change is ok for you. It will show tabs now, when there are no categories and less than 5 lists. This is the easy solution I found to the checkbox missing bug on "exclude list" accordion in both themes.

THis is the issue on github:
https://github.com/phpList/phplist3/issues/171