### PR TITLE
Removed application of lower case to page titles

### DIFF
--- a/public_html/lists/admin/index.php
+++ b/public_html/lists/admin/index.php
@@ -466,7 +466,7 @@ if (!$ajax) {
 }
 
 if (!$ajax) {
-    echo '<h4 class="pagetitle">'.mb_strtolower($page_title).'</h4>';
+    echo '<h4 class="pagetitle">'.$page_title.'</h4>';
 }
 echo '<div class="hidden">'.PageLink2('home', s('Main page')).'</div>';
 


### PR DESCRIPTION
Currently most pages have capitalised page titles but some (notably some account pages in Coipasa theme), which use this method if injecting the title, do not. This makes page titles be capitalised consistently.