### PR TITLE
Add translation repository folders to gitignore and remove symlinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ composer.lock
 /behat.yml
 .php_cs.cache
 /.idea/
-
+public_html/lists/admin/help/
+public_html/lists/admin/info/

--- a/public_html/lists/admin/help
+++ b/public_html/lists/admin/help
@@ -1,1 +1,0 @@
-../../../../phplist-lan-help

--- a/public_html/lists/admin/info
+++ b/public_html/lists/admin/info
@@ -1,1 +1,0 @@
-../../../../phplist-lan-info


### PR DESCRIPTION
Packaged versions of phpList include the help and info folders within the admin directory, and this is the default location for them. However phpList 3 currently ships with symlinks pointing to above the repo root directory for these folders. This does not follow the behaviour of packaged phpList versions therefore, and also results in missing config file errors unless the Apache variable is set to give the config file path. That variable is not relevant to other web servers, and is not always set in local development environments.
Therefore this commit removes the symlinks and ensures that Git will not track the files. This makes it easier for developers to checkout the language repositories without errors.
Those wishing to use the former directory structure, with langage repo folders above the root directory of phpList 3, can easily add their own symlinks. This is also true of CI servers -- symlinks can be added as part of the test setup procedure if necessary.