### PR TITLE
Mantis 18829 - initialisation of targetlist

### DIFF
--- a/public_html/lists/admin/lib.php
+++ b/public_html/lists/admin/lib.php
@@ -197,7 +197,7 @@ function loadMessageData($msgid)
         'status'         => '',
         'tofield'        => '',
         'replyto'        => '',
-        'targetlist'     => '',
+        'targetlist'     => array(),
         'criteria_match' => '',
         'sendurl'        => '',
         'sendmethod'     => 'inputhere', //# make a config


### PR DESCRIPTION
Initialise targetlist as an array not a string.

See https://mantis.phplist.org/view.php?id=18829