### PR TITLE
Avoid warning about developer_email being undefined

### DIFF
--- a/public_html/lists/admin/index.php
+++ b/public_html/lists/admin/index.php
@@ -502,7 +502,7 @@ if (!$GLOBALS['commandline']) {
 
 if (!$ajax && $page != 'login') {
     if (strpos(VERSION, 'dev') && !TEST) {
-        if ($GLOBALS['developer_email']) {
+        if (!empty($GLOBALS['developer_email'])) {
             Info('Running DEV version. All emails will be sent to '.$GLOBALS['developer_email']);
         } else {
             Info('Running DEV version, but developer email is not set');


### PR DESCRIPTION
When using git version and with error reporting enabled there is a php warning about developer_email being undefined.
![image](https://user-images.githubusercontent.com/3147688/30819765-c15b523e-a217-11e7-9586-f188a807d728.png)
