### PR TITLE
Replaced responsetime string with existant 'Response time'

### DIFF
--- a/public_html/lists/admin/mviews.php
+++ b/public_html/lists/admin/mviews.php
@@ -139,7 +139,7 @@ while ($row = Sql_Fetch_Array($req)) {
         $ls->addColumn($element, $GLOBALS['I18N']->get('views'), $row['viewcount']);
     } else {
         $ls->addColumn($element, $GLOBALS['I18N']->get('firstview'), formatDateTime($row['firstview'], 1));
-        $ls->addColumn($element, $GLOBALS['I18N']->get('responsetime'), secs2time($row['responsetime']));
+        $ls->addColumn($element, $GLOBALS['I18N']->get('Response time'), secs2time($row['responsetime']));
     }
 }
 if ($download) {


### PR DESCRIPTION
Two translated strings already exist: responsetime and 'Response time'. This is a table heading and so we should make use of the latter.