### PR TITLE
Many changes on buttons locations.

### DIFF
--- a/public_html/lists/admin/actions/domainstats.php
+++ b/public_html/lists/admin/actions/domainstats.php
@@ -88,8 +88,8 @@ if (Sql_Num_Rows($req) > 0) {
     }
 
     // Print download button
-    $status .= '<div class="actions">'.PageLinkButton('page=pageaction&action=domainstats&dl=true',
-            s('Download as CSV file')).'</div>';
+    $status .= '<div class="actions pull-right">'.PageLinkButton('page=pageaction&action=domainstats&dl=true',
+            s('Download as CSV file')).'</div><div class="clearfix"></div>';
 } else {
     // Print missing data notice
     $status .= '<h3>'.s('Once you have some more subscribers, this page will list statistics on the domains of your subscribers. It will list domains that have 5 or more subscribers.').'</h3>';

--- a/public_html/lists/admin/actions/mclicks.php
+++ b/public_html/lists/admin/actions/mclicks.php
@@ -100,8 +100,8 @@ while ($row = Sql_Fetch_Array($req)) {
 }
 if ($some) {
     $status .= '<div class="action">';
-    $status .= '<p>'.PageLinkButton('mclicks&dl=true', $GLOBALS['I18N']->get('Download as CSV file')).'</p>';
-    $status .= '</div>';
+    $status .= '<p class="pull-right">'.PageLinkButton('mclicks&dl=true', $GLOBALS['I18N']->get('Download as CSV file')).'</p>';
+    $status .= '</div><div class="clearfix"></div>';
 //    print '<p>'.$GLOBALS['I18N']->get('Select Message to view').'</p>';
     $status .= $ls->display();
 }

--- a/public_html/lists/admin/actions/mviews.php
+++ b/public_html/lists/admin/actions/mviews.php
@@ -54,7 +54,7 @@ if (!$id) {
         header('Content-disposition:  attachment; filename="phpList Message open statistics.csv"');
         ob_start();
     }
-    $status .= '<p>'.PageLinkButton('page=pageaction&action=mviews&dl=true', s('Download as CSV file')).'</p>';
+    $status .= '<p class="pull-right">'.PageLinkButton('page=pageaction&action=mviews&dl=true', s('Download as CSV file')).'</p><div class="clearfix"></div>';
 //  print '<p>'.$GLOBALS['I18N']->get('Select Message to view').'</p>';
     $timerange = ' and msg.entered  > date_sub(now(),interval 12 month)';
     $timerange = '';

--- a/public_html/lists/admin/actions/statsoverview.php
+++ b/public_html/lists/admin/actions/statsoverview.php
@@ -59,8 +59,8 @@ if ($download) {
 }
 
 if (empty($start)) {
-    $status .= '<div class="actions">'.PageLinkButton('pageaction&action=statsoverview&dl=true',
-            $GLOBALS['I18N']->get('Download as CSV file')).'</div>';
+    $status .= '<div class="actions pull-right">'.PageLinkButton('pageaction&action=statsoverview&dl=true',
+            $GLOBALS['I18N']->get('Download as CSV file')).'</div><div class="clearfix"></div>';
 }
 if (!empty($_SESSION['LoadDelay'])) {
     sleep($_SESSION['LoadDelay']);

--- a/public_html/lists/admin/admins.php
+++ b/public_html/lists/admin/admins.php
@@ -18,9 +18,11 @@ if (!empty($find)) {
     $remember_find = '';
 }
 
+echo '<div class="button">'.PageLink2('importadmin', $GLOBALS['I18N']->get('Import list of admins')).'</div>';
+
 // with external admins we simply display information
 if (!$external) {
-    echo PageLinkActionButton('admin', $GLOBALS['I18N']->get('Add new admin'), "start=$start".$remember_find);
+    echo '<div class="pull-right fright">'.PageLinkActionButton('admin', $GLOBALS['I18N']->get('Add new admin'), "start=$start".$remember_find).'</div><div class="clearfix"></div>';
 
     if (isset($_GET['delete']) && $_GET['delete']) {
         // delete the index in delete
@@ -119,8 +121,6 @@ while ($admin = Sql_fetch_array($result)) {
     }
 }
 echo $ls->display();
-echo '<br/><hr/>';
-echo PageLinkButton('admin', $GLOBALS['I18N']->get('Add a new administrator'), "start=$start".$remember_find);
-echo '<p class="button">'.PageLink2('importadmin', $GLOBALS['I18N']->get('Import list of admins')).'</p>';
+echo '<br/><hr class="hidden-lg hidden-md hidden-sm hidden-xs" />';
 
 ?>

--- a/public_html/lists/admin/catlists.php
+++ b/public_html/lists/admin/catlists.php
@@ -68,7 +68,7 @@ if (!Sql_Affected_Rows()) {
     Info(s('All lists have already been assigned a category').'<br/>'.PageLinkButton('list', s('Back')), true);
 }
 
-echo '<div class="fright">'.PageLinkButton('catlists&show=all', s('Re-edit all lists')).'</div>';
+echo '<div class="fright pull-right">'.PageLinkButton('catlists&show=all', s('Re-edit all lists')).'</div>';
 echo '<div class="fright">'.PageLinkButton('configure&id=list_categories&ret=catlists',
         $I18N->get('Configure Categories')).'</div>';
 

--- a/public_html/lists/admin/configure.php
+++ b/public_html/lists/admin/configure.php
@@ -36,7 +36,7 @@ if (empty($_GET['id'])) {
         PageURL2('configure&resetdefault=yes', 'reset', ''),
         s('Reset to default'));
 
-    echo '<div class="fright">'.$button->show().'</div>';
+    echo '<div class="fright pull-right">'.$button->show().'</div><div class="clearfix"></div>';
     echo Info(s('You can edit all of the values in this page, and click the "save changes" button once to save all the changes you made.'),
         1);
 }

--- a/public_html/lists/admin/list.php
+++ b/public_html/lists/admin/list.php
@@ -87,16 +87,16 @@ switch ($access) {
 }
 
 echo '<div class="actions">';
-echo PageLinkButton('catlists', $I18N->get('Categorise lists'));
+echo '<div class="pull-left">'.PageLinkButton('catlists', $I18N->get('Categorise lists')).'</div>';
 $canaddlist = false;
 if ( !isSuperUser()) {
     $numlists = Sql_Fetch_Row_query("select count(*) from {$tables['list']} where owner = ".$_SESSION['logindetails']['id']);
     if ($numlists[0] < MAXLIST) {
-        echo PageLinkButton('editlist', $GLOBALS['I18N']->get('Add a list'));
+        echo '<div class="pull-right">'.PageLinkButton('editlist', $GLOBALS['I18N']->get('Add a list')).'</div>';
         $canaddlist = true;
     }
 } else {
-    echo PageLinkButton('editlist', $GLOBALS['I18N']->get('Add a list'));
+    echo '<div class="pull-right">'.PageLinkButton('editlist', $GLOBALS['I18N']->get('Add a list')).'</div>';
     $canaddlist = true;
 }
 echo '</div>';
@@ -325,7 +325,7 @@ if (!$some) {
 ?>
 
 </form>
-<p>
+<p class="hidden-lg hidden-md hidden-sm hidden-xs">
     <?php
     if ($canaddlist) {
         echo PageLinkButton('editlist', $GLOBALS['I18N']->get('Add a list'));

--- a/public_html/lists/admin/members.php
+++ b/public_html/lists/admin/members.php
@@ -64,11 +64,11 @@ function addUserForm($listid)
 if (!empty($id)) {
     echo '<h3>'.$GLOBALS['I18N']->get('Members of').' '.ListName($id).'</h3>';
     echo '<div class="actions">';
-    echo PageLinkButton('editlist', $GLOBALS['I18N']->get('edit list details'), "id=$id", 'pill-l');
+    echo '<div class="pull-right">'.PageLinkButton('editlist', $GLOBALS['I18N']->get('edit list details'), "id=$id", 'pill-l').'</div>';
     echo PageLinkButton("export&amp;list=$id", $GLOBALS['I18N']->get('Download subscribers'), '', 'pill-c');
     echo PageLinkDialog("importsimple&amp;list=$id", $GLOBALS['I18N']->get('Import Subscribers to this list'), '',
         'pill-r');
-    echo '</div>';
+    echo '</div><div class="clearfix"></div>';
 } else {
     if ($_REQUEST['id'] != 'all') {
         Redirect('list');

--- a/public_html/lists/admin/message.php
+++ b/public_html/lists/admin/message.php
@@ -91,7 +91,7 @@ if ($msgdata['status'] == 'draft' || $msgdata['status'] == 'suspended') {
         s('Editing an active or finished campaign will place it back in the draft queue, continue?'),
         PageURL2('send&id='.$id),
         s('Edit campaign'));
-    echo $editbutton->show();
+    echo '<div class="pull-right">'.$editbutton->show().'</div>';
 
     // Print view campaign statistics button
     echo PageLinkButton( 'statsoverview&id='.$id, s('Statistics'), s('View statistics'));

--- a/public_html/lists/admin/mviews.php
+++ b/public_html/lists/admin/mviews.php
@@ -59,8 +59,8 @@ if ($download) {
     ob_start();
 }
 if (empty($start)) {
-    echo '<p>'.PageLinkButton('mviews&dl=true&id='.$id.'&start='.$start,
-            $GLOBALS['I18N']->get('Download as CSV file')).'</p>';
+    echo '<p class="pull-right">'.PageLinkButton('mviews&dl=true&id='.$id.'&start='.$start,
+            $GLOBALS['I18N']->get('Download as CSV file')).'</p><div class="clearfix"></div>';
 }
 
 //print '<h3>'.$GLOBALS['I18N']->get('View Details for a Message').'</h3>';

--- a/public_html/lists/admin/send.php
+++ b/public_html/lists/admin/send.php
@@ -96,7 +96,7 @@ if (!$GLOBALS['commandline']) {
         $GLOBALS['tables']['message'], $ownership));
     $numdraft = Sql_Num_Rows($req);
     if ($numdraft > 0 && !isset($_GET['id']) && !isset($_GET['new'])) {
-        echo '<p>'.PageLinkActionButton('send&amp;new=1', $I18N->get('start a new message'), '', '',
+        echo '<p class="pull-right">'.PageLinkActionButton('send&amp;new=1', $I18N->get('start a new message'), '', '',
                 s('Start a new campaign')).'</p>';
         echo '<p><h3>'.$I18N->get('Choose an existing draft campaign to work on').'</h3></p><br/>';
         $ls = new WebblerListing($I18N->get('Draft campaigns'));

--- a/public_html/lists/admin/spage.php
+++ b/public_html/lists/admin/spage.php
@@ -77,7 +77,8 @@ while ($p = Sql_Fetch_Array($req)) {
         sprintf('<span class="view"><a class="button" href="%s&amp;id=%d" title="'.$GLOBALS['I18N']->get('view').'">%s</a></span>',
             getConfig('subscribeurl'), $p['id'], $GLOBALS['I18N']->get('view')));
 }
+echo '<p class="button pull-right">'.PageLink2('spageedit', s('Add a new subscribe page')).'</p><div class="clearfix"></div>';
+
 echo $ls->display();
-echo '<p class="button">'.PageLink2('spageedit', s('Add a new subscribe page')).'</p>';
 ?>
 </form>

--- a/public_html/lists/admin/statsoverview.php
+++ b/public_html/lists/admin/statsoverview.php
@@ -77,7 +77,7 @@ if (!$id) {
 }
 
 //print '<h3>'.$GLOBALS['I18N']->get('Campaign statistics').'</h3>';
-echo PageLinkButton('statsoverview', s('View all campaigns'));
+echo '<div class="pull-right">'.PageLinkButton('statsoverview', s('View all campaigns')).'</div><div class="clearfix"></div>';
 
 $messagedata = loadMessageData($id);
 //var_dump($messagedata);

--- a/public_html/lists/admin/template.php
+++ b/public_html/lists/admin/template.php
@@ -280,11 +280,11 @@ if ($id) {
 ?>
 
 <p class="information"><?php echo $msg ?></p>
-<?php echo '<p class="button">'.PageLink2('templates', $GLOBALS['I18N']->get('List of Templates')).'</p>'; ?>
+<?php echo '<p class="button pull-right">'.PageLink2('templates', $GLOBALS['I18N']->get('List of Templates')).'</p><div class="clearfix"></div>'; ?>
 
 <?php echo formStart(' enctype="multipart/form-data" class="template2" ') ?>
 <input type="hidden" name="id" value="<?php echo $id ?>"/>
-<div class="panel">
+<div class="panel"><div class="content">
     <table class="templateForm">
         <tr>
 
@@ -347,7 +347,7 @@ if ($id) {
                                    value="<?php echo $GLOBALS['I18N']->get('Save Changes') ?>"/></td>
         </tr>
     </table>
-</div>
+</div></div>
 <?php $sendtest_content = sprintf('<div class="sendTest" id="sendTest">
     ' .$sendtestresult.'
     <input class="submit" type="submit" name="sendtest" value="%s"/>  %s: 

--- a/public_html/lists/admin/templates.php
+++ b/public_html/lists/admin/templates.php
@@ -2,6 +2,8 @@
 
 require_once dirname(__FILE__).'/accesscheck.php';
 
+echo '<p class="button pull-right fright">'.PageLink2('template', $GLOBALS['I18N']->get('Add new Template')).'</p>';
+
 if (isset($_GET['delete'])) {
     // delete the index in delete
     $delete = sprintf('%d', $_GET['delete']);
@@ -53,8 +55,6 @@ while ($row = Sql_fetch_Array($req)) {
 echo $ls->display();
 
 echo '</form>';
-
-echo '<p class="button">'.PageLink2('template', $GLOBALS['I18N']->get('Add new Template')).'</p>';
 
 $exists = Sql_Fetch_Row_Query(sprintf('select * from %s where title = "System Template"',
     $GLOBALS['tables']['template']));

--- a/public_html/lists/admin/uclicks.php
+++ b/public_html/lists/admin/uclicks.php
@@ -72,8 +72,8 @@ if (!$id) {
     }
     if ($some) {
         echo '<p>'.$GLOBALS['I18N']->get('Select URL to view').'</p>';
-        echo '<div class="actions">'.PageLinkButton('uclicks&dl=true',
-                $GLOBALS['I18N']->get('Download as CSV file')).'</div>';
+        echo '<div class="actions pull-right">'.PageLinkButton('uclicks&dl=true',
+                $GLOBALS['I18N']->get('Download as CSV file')).'</div><div class="clearfix"></div>';
         echo $ls->display();
     } else {
         echo '<p class="information">'.$GLOBALS['I18N']->get('There are currently no statistics available').'</p>';

--- a/public_html/lists/admin/userclicks.php
+++ b/public_html/lists/admin/userclicks.php
@@ -161,8 +161,7 @@ if ($fwdid && $msgid) {
         $msgid
     );
 } elseif ($userid) {
-    echo '<h3>'.$GLOBALS['I18N']->get('Clicks of a subscriber').'</h3>';
-    echo s('Subscriber').' '.PageLink2('user&amp;id='.$userid, $userdata['email']);
+    echo '<h3>'.$GLOBALS['I18N']->get('All clicks from').' <small><b>'.PageLink2('user&amp;id='.$userid, $userdata['email']).'</b></small></h3>';
 
     $query = sprintf('
         SELECT SUM(htmlclicked) AS htmlclicked,

--- a/public_html/lists/admin/userclicks.php
+++ b/public_html/lists/admin/userclicks.php
@@ -161,7 +161,7 @@ if ($fwdid && $msgid) {
         $msgid
     );
 } elseif ($userid) {
-    echo '<h3>'.$GLOBALS['I18N']->get('All clicks from').' <small><b>'.PageLink2('user&amp;id='.$userid, $userdata['email']).'</b></small></h3>';
+    echo '<h3>'.$GLOBALS['I18N']->get('All clicks by').' <small><b>'.PageLink2('user&amp;id='.$userid, $userdata['email']).'</b></small></h3>';
 
     $query = sprintf('
         SELECT SUM(htmlclicked) AS htmlclicked,

--- a/public_html/lists/admin/users.php
+++ b/public_html/lists/admin/users.php
@@ -404,10 +404,10 @@ echo $panel->display();
 
 //if (($require_login && isSuperUser()) || !$require_login)
 echo '<div class="actions">';
-echo '<div id="add-csv-button">'.PageLinkButton('dlusers', $GLOBALS['I18N']->get('Download all users as CSV file'),
+echo '<div id="add-csv-button" class="pull-left">'.PageLinkButton('dlusers', $GLOBALS['I18N']->get('Download all users as CSV file'),
         'nocache='.uniqid('')).'</div>';
-echo '<div id="add-user-button">'.PageLinkButton('adduser', $GLOBALS['I18N']->get('Add a User')).'</div>';
-echo '</div>';
+echo '<div id="add-user-button" class="pull-right">'.PageLinkButton('adduser', $GLOBALS['I18N']->get('Add a User')).'</div>';
+echo '</div><div class="clearfix"></div>';
 
 $some = 0;
 


### PR DESCRIPTION
This is answer to this mantis request:
0018788: Use standardised button layout below page heading on Subscriber lists page

Most of the changes only affect Trevelin. Only 2 changes affect Dressprow moving  buttons located at the bottom of the page to the top of the page.

I attaching images with the result of this change in Treveling. 

This commits should be merged before merge https://github.com/phpList/phplist-ui-bootlist/pull/34 in Trevelin.

![screenshot from 2017-11-11 17-36-49](https://user-images.githubusercontent.com/7660111/32694078-b3bfe036-c715-11e7-9b1d-2b53036c2152.png)
![screenshot from 2017-11-11 17-37-09](https://user-images.githubusercontent.com/7660111/32694079-b3e4b0e6-c715-11e7-9be5-e219544d7ad8.png)
![screenshot from 2017-11-11 17-37-25](https://user-images.githubusercontent.com/7660111/32694080-b40db6d0-c715-11e7-8f5f-99bf1e7ff0da.png)
![screenshot from 2017-11-11 17-39-10](https://user-images.githubusercontent.com/7660111/32694081-b43338f6-c715-11e7-8284-f24142f9adfc.png)
![screenshot from 2017-11-11 17-41-42](https://user-images.githubusercontent.com/7660111/32694082-b4576370-c715-11e7-91f7-c2e4477cb015.png)
![screenshot from 2017-11-11 17-44-21](https://user-images.githubusercontent.com/7660111/32694083-b47c36aa-c715-11e7-9d7a-d63fa42d7860.png)
![screenshot from 2017-11-11 17-46-40](https://user-images.githubusercontent.com/7660111/32694084-b49fbd82-c715-11e7-94c9-cd2fb7f6c9fb.png)
![screenshot from 2017-11-11 17-56-41](https://user-images.githubusercontent.com/7660111/32694085-b4c3aa4e-c715-11e7-98bc-7714099f7d9c.png)
![screenshot from 2017-11-11 18-04-44](https://user-images.githubusercontent.com/7660111/32694086-b4e7df40-c715-11e7-8565-a625d9751f64.png)
![screenshot from 2017-11-11 18-13-30](https://user-images.githubusercontent.com/7660111/32694087-b50c9f92-c715-11e7-8f64-2de65d59e5ef.png)
![screenshot from 2017-11-11 19-05-48](https://user-images.githubusercontent.com/7660111/32694088-b530712e-c715-11e7-9857-610777dfe07e.png)
