### PR TITLE
Mantis 18478 Unable to delete unidentified bounces > 2 months old

### DIFF
--- a/public_html/lists/admin/bounces.php
+++ b/public_html/lists/admin/bounces.php
@@ -40,7 +40,7 @@ if (ALLOW_DELETEBOUNCE && isset($_GET['action']) && $_GET['action']) {
     verifyCsrfGetToken();
     switch ($_GET['action']) {
         case 'deleteunidentified':
-            $req = Sql_Query(sprintf('delete from %s where comment = "unidentified bounce" and date_add(date,interval 2 month) < now()',
+            $req = Sql_Query(sprintf('delete from %s where status = "unidentified bounce" and date_add(date,interval 2 month) < now()',
                 $tables['bounce']));
             $count = Sql_Num_Rows($req);
             $actionresult = s('%d unidentified bounces older than 2 months have been deleted', $count);


### PR DESCRIPTION
I grep'd the source and the status column is always used elsewhere to hold "unidentified bounce" not the comment column.

See https://mantis.phplist.org/view.php?id=18478
