### PR TITLE
Display more admin fields on the admins page

### DIFF
--- a/public_html/lists/admin/admins.php
+++ b/public_html/lists/admin/admins.php
@@ -18,41 +18,7 @@ if (!empty($find)) {
     $remember_find = '';
 }
 
-echo '<div class="button">'.PageLink2('importadmin', s('Import list of admins')).'</div>';
-
 // with external admins we simply display information
-if (!$external) {
-    echo '<div class="pull-right fright">'.PageLinkActionButton('admin', s('Add new admin'), "start=$start".$remember_find).'</div><div class="clearfix"></div>';
-
-    if (isset($_GET['delete']) && $_GET['delete']) {
-        // delete the index in delete
-        if ($_GET['delete'] == $_SESSION['logindetails']['id']) {
-            echo s('You cannot delete yourself')."\n";
-        } else {
-            echo s('Deleting')." $delete ..\n";
-            Sql_query(sprintf('delete from %s where id = %d', $GLOBALS['tables']['admin'], $_GET['delete']));
-            Sql_query(sprintf('delete from %s where adminid = %d', $GLOBALS['tables']['admin_attribute'],
-                $_GET['delete']));
-            Sql_query(sprintf('delete from %s where adminid = %d', $GLOBALS['tables']['admin_task'], $_GET['delete']));
-            echo '..'.s('Done')."<br /><hr><br />\n";
-            Redirect("admins&start=$start");
-        }
-    }
-
-    ob_end_flush();
-
-    if (isset($add)) {
-        if (isset($new)) {
-            $query = 'insert into '.$tables['admin']." (email,entered) values(\"$new\",now())";
-            $result = Sql_query($query);
-            $userid = Sql_insert_id();
-            $query = 'insert into '.$tables['listuser']." (userid,listid,entered) values($userid,$id,now())";
-            $result = Sql_query($query);
-        }
-        echo '<br/>'.s('Admin added').'<br/>';
-    }
-}
-
 if ($external) {
     $admins = $GLOBALS['admin_auth']->listAdmins();
     $total = count($admins);
@@ -64,15 +30,46 @@ if ($external) {
     echo $ls->display();
 
     return;
-} else {
-    if (!$find) {
-        $result = Sql_query('SELECT count(*) FROM '.$tables['admin']);
-    } else {
-        $result = Sql_query('SELECT count(*) FROM '.$tables['admin']." where loginname like \"%$find%\" or email like \"%$find%\"");
-    }
-    $totalres = Sql_fetch_Row($result);
-    $total = $totalres[0];
 }
+
+echo '<div class="button">'.PageLink2('importadmin', s('Import list of admins')).'</div>';
+echo '<div class="pull-right fright">'.PageLinkActionButton('admin', s('Add new admin'), "start=$start".$remember_find).'</div><div class="clearfix"></div>';
+
+if (isset($_GET['delete']) && $_GET['delete']) {
+    // delete the index in delete
+    if ($_GET['delete'] == $_SESSION['logindetails']['id']) {
+        echo s('You cannot delete yourself')."\n";
+    } else {
+        echo s('Deleting')." $delete ..\n";
+        Sql_query(sprintf('delete from %s where id = %d', $GLOBALS['tables']['admin'], $_GET['delete']));
+        Sql_query(sprintf('delete from %s where adminid = %d', $GLOBALS['tables']['admin_attribute'],
+            $_GET['delete']));
+        Sql_query(sprintf('delete from %s where adminid = %d', $GLOBALS['tables']['admin_task'], $_GET['delete']));
+        echo '..'.s('Done')."<br /><hr><br />\n";
+        Redirect("admins&start=$start");
+    }
+}
+
+ob_end_flush();
+
+if (isset($add)) {
+    if (isset($new)) {
+        $query = 'insert into '.$tables['admin']." (email,entered) values(\"$new\",now())";
+        $result = Sql_query($query);
+        $userid = Sql_insert_id();
+        $query = 'insert into '.$tables['listuser']." (userid,listid,entered) values($userid,$id,now())";
+        $result = Sql_query($query);
+    }
+    echo '<br/>'.s('Admin added').'<br/>';
+}
+
+if (!$find) {
+    $result = Sql_query('SELECT count(*) FROM '.$tables['admin']);
+} else {
+    $result = Sql_query('SELECT count(*) FROM '.$tables['admin']." where loginname like \"%$find%\" or email like \"%$find%\"");
+}
+$totalres = Sql_fetch_Row($result);
+$total = $totalres[0];
 
 echo '<p class="info">'.$total.' '.s('Administrators');
 echo $find ? ' '.s('found').'</p>' : '</p>';
@@ -121,11 +118,9 @@ while ($admin = Sql_fetch_array($result)) {
     $ls->addColumn($admin['loginname'], s('email'), $admin['email']);
     $ls->addColumn($admin['loginname'], s('Super Admin'), $admin['superuser'] ? s('Yes') : s('No'));
     $ls->addColumn($admin['loginname'], s('Disabled'), $admin['disabled'] ? s('Yes') : s('No'));
-    if (!$external && $_SESSION['logindetails']['superuser'] && $admin['id'] != $_SESSION['logindetails']['id']) {
+    if ($_SESSION['logindetails']['superuser'] && $admin['id'] != $_SESSION['logindetails']['id']) {
         $ls->addColumn($admin['loginname'], s('Del'), $delete_url);
     }
 }
 echo $ls->display();
 echo '<br/><hr class="hidden-lg hidden-md hidden-sm hidden-xs" />';
-
-?>

--- a/public_html/lists/admin/admins.php
+++ b/public_html/lists/admin/admins.php
@@ -75,18 +75,11 @@ echo '<p class="info">'.$total.' '.s('Administrators');
 echo $find ? ' '.s('found').'</p>' : '</p>';
 
 $paging = '';
-if ($total > MAX_USER_PP) {
-    $paging = simplePaging("admins$remember_find", $start, $total, MAX_USER_PP,
-        s('Administrators'));
-}
 $limit = '';
+
 if ($total > MAX_USER_PP) {
-    if (isset($start) && $start) {
-        $limit = "limit $start,".MAX_USER_PP;
-    } else {
-        $limit = 'limit 0,50';
-        $start = 0;
-    }
+    $paging = simplePaging("admins$remember_find", $start, $total, MAX_USER_PP, s('Administrators'));
+    $limit = "limit $start,".MAX_USER_PP;
 }
 if ($find) {
     $result = Sql_query('SELECT id,loginname,email, superuser, disabled FROM '.$tables['admin'].' where loginname like "%'.sql_escape($find).'%" or email like "%'.sql_escape($find)."%\" order by loginname $limit");

--- a/public_html/lists/admin/admins.php
+++ b/public_html/lists/admin/admins.php
@@ -92,9 +92,9 @@ if ($total > MAX_USER_PP) {
     }
 }
 if ($find) {
-    $result = Sql_query('SELECT id,loginname,email FROM '.$tables['admin'].' where loginname like "%'.sql_escape($find).'%" or email like "%'.sql_escape($find)."%\" order by loginname $limit");
+    $result = Sql_query('SELECT id,loginname,email, superuser, disabled FROM '.$tables['admin'].' where loginname like "%'.sql_escape($find).'%" or email like "%'.sql_escape($find)."%\" order by loginname $limit");
 } else {
-    $result = Sql_query('SELECT id,loginname,email FROM '.$tables['admin']." order by loginname $limit");
+    $result = Sql_query('SELECT id,loginname,email, superuser, disabled FROM '.$tables['admin']." order by loginname $limit");
 }
 
 ?>
@@ -111,11 +111,16 @@ if ($find) {
 <?php
 $ls = new WebblerListing($GLOBALS['I18N']->get('Administrators'));
 $ls->usePanel($paging);
+$ls->setElementHeading('Login name');
 while ($admin = Sql_fetch_array($result)) {
     $delete_url = sprintf("<a href=\"javascript:deleteRec('%s');\">".$GLOBALS['I18N']->get('del').'</a>',
         PageURL2('admins', 'Delete', "start=$start&amp;delete=".$admin['id']));
     $ls->addElement($admin['loginname'],
         PageUrl2('admin', $GLOBALS['I18N']->get('Show'), "start=$start&amp;id=".$admin['id'].$remember_find));
+    $ls->addColumn($admin['loginname'], $GLOBALS['I18N']->get('Id'), $admin['id']);
+    $ls->addColumn($admin['loginname'], $GLOBALS['I18N']->get('email'), $admin['email']);
+    $ls->addColumn($admin['loginname'], $GLOBALS['I18N']->get('Super Admin'), $admin['superuser'] ? s('Yes') : s('No'));
+    $ls->addColumn($admin['loginname'], $GLOBALS['I18N']->get('Disabled'), $admin['disabled'] ? s('Yes') : s('No'));
     if (!$external && $_SESSION['logindetails']['superuser'] && $admin['id'] != $_SESSION['logindetails']['id']) {
         $ls->addColumn($admin['loginname'], $GLOBALS['I18N']->get('Del'), $delete_url);
     }

--- a/public_html/lists/admin/admins.php
+++ b/public_html/lists/admin/admins.php
@@ -116,7 +116,7 @@ while ($admin = Sql_fetch_array($result)) {
         PageURL2('admins', 'Delete', "start=$start&amp;delete=".$admin['id']));
     $ls->addElement($admin['loginname'],
         PageUrl2('admin', $GLOBALS['I18N']->get('Show'), "start=$start&amp;id=".$admin['id'].$remember_find));
-    if (!$external && $admin['id'] != $_SESSION['logindetails']['id']) {
+    if (!$external && $_SESSION['logindetails']['superuser'] && $admin['id'] != $_SESSION['logindetails']['id']) {
         $ls->addColumn($admin['loginname'], $GLOBALS['I18N']->get('Del'), $delete_url);
     }
 }

--- a/public_html/lists/admin/admins.php
+++ b/public_html/lists/admin/admins.php
@@ -18,23 +18,23 @@ if (!empty($find)) {
     $remember_find = '';
 }
 
-echo '<div class="button">'.PageLink2('importadmin', $GLOBALS['I18N']->get('Import list of admins')).'</div>';
+echo '<div class="button">'.PageLink2('importadmin', s('Import list of admins')).'</div>';
 
 // with external admins we simply display information
 if (!$external) {
-    echo '<div class="pull-right fright">'.PageLinkActionButton('admin', $GLOBALS['I18N']->get('Add new admin'), "start=$start".$remember_find).'</div><div class="clearfix"></div>';
+    echo '<div class="pull-right fright">'.PageLinkActionButton('admin', s('Add new admin'), "start=$start".$remember_find).'</div><div class="clearfix"></div>';
 
     if (isset($_GET['delete']) && $_GET['delete']) {
         // delete the index in delete
         if ($_GET['delete'] == $_SESSION['logindetails']['id']) {
-            echo $GLOBALS['I18N']->get('You cannot delete yourself')."\n";
+            echo s('You cannot delete yourself')."\n";
         } else {
-            echo $GLOBALS['I18N']->get('Deleting')." $delete ..\n";
+            echo s('Deleting')." $delete ..\n";
             Sql_query(sprintf('delete from %s where id = %d', $GLOBALS['tables']['admin'], $_GET['delete']));
             Sql_query(sprintf('delete from %s where adminid = %d', $GLOBALS['tables']['admin_attribute'],
                 $_GET['delete']));
             Sql_query(sprintf('delete from %s where adminid = %d', $GLOBALS['tables']['admin_task'], $_GET['delete']));
-            echo '..'.$GLOBALS['I18N']->get('Done')."<br /><hr><br />\n";
+            echo '..'.s('Done')."<br /><hr><br />\n";
             Redirect("admins&start=$start");
         }
     }
@@ -49,7 +49,7 @@ if (!$external) {
             $query = 'insert into '.$tables['listuser']." (userid,listid,entered) values($userid,$id,now())";
             $result = Sql_query($query);
         }
-        echo '<br/>'.$GLOBALS['I18N']->get('Admin added').'<br/>';
+        echo '<br/>'.s('Admin added').'<br/>';
     }
 }
 
@@ -57,9 +57,9 @@ if ($external) {
     $admins = $GLOBALS['admin_auth']->listAdmins();
     $total = count($admins);
     $found = $total;
-    $ls = new WebblerListing($GLOBALS['I18N']->get('Administrators'));
+    $ls = new WebblerListing(s('Administrators'));
     foreach ($admins as $adminid => $adminname) {
-        $ls->addElement($adminname); //,PageUrl2("admin",$GLOBALS['I18N']->get('Show'),"id=".$adminid));
+        $ls->addElement($adminname); //,PageUrl2("admin",s('Show'),"id=".$adminid));
     }
     echo $ls->display();
 
@@ -74,13 +74,13 @@ if ($external) {
     $total = $totalres[0];
 }
 
-echo '<p class="info">'.$total.' '.$GLOBALS['I18N']->get('Administrators');
-echo $find ? ' '.$GLOBALS['I18N']->get('found').'</p>' : '</p>';
+echo '<p class="info">'.$total.' '.s('Administrators');
+echo $find ? ' '.s('found').'</p>' : '</p>';
 
 $paging = '';
 if ($total > MAX_USER_PP) {
     $paging = simplePaging("admins$remember_find", $start, $total, MAX_USER_PP,
-        $GLOBALS['I18N']->get('Administrators'));
+        s('Administrators'));
 }
 $limit = '';
 if ($total > MAX_USER_PP) {
@@ -101,28 +101,28 @@ if ($find) {
 <table>
     <tr>
         <td colspan=4><?php echo formStart('action=""') ?><input type="hidden" name="id" value="<?php echo $listid ?>">
-            <?php echo $GLOBALS['I18N']->get('Find an admin') ?>: <input type=text name="find"
+            <?php echo s('Find an admin') ?>: <input type=text name="find"
                                                                          value="<?php echo htmlspecialchars($find) ?>"
                                                                          size="40"><input type="submit"
-                                                                                          value="<?php echo $GLOBALS['I18N']->get('Go') ?>">
+                                                                                          value="<?php echo s('Go') ?>">
             </form></td>
     </tr>
 </table>
 <?php
-$ls = new WebblerListing($GLOBALS['I18N']->get('Administrators'));
+$ls = new WebblerListing(s('Administrators'));
 $ls->usePanel($paging);
 $ls->setElementHeading('Login name');
 while ($admin = Sql_fetch_array($result)) {
-    $delete_url = sprintf("<a href=\"javascript:deleteRec('%s');\">".$GLOBALS['I18N']->get('del').'</a>',
+    $delete_url = sprintf("<a href=\"javascript:deleteRec('%s');\">".s('del').'</a>',
         PageURL2('admins', 'Delete', "start=$start&amp;delete=".$admin['id']));
     $ls->addElement($admin['loginname'],
-        PageUrl2('admin', $GLOBALS['I18N']->get('Show'), "start=$start&amp;id=".$admin['id'].$remember_find));
-    $ls->addColumn($admin['loginname'], $GLOBALS['I18N']->get('Id'), $admin['id']);
-    $ls->addColumn($admin['loginname'], $GLOBALS['I18N']->get('email'), $admin['email']);
-    $ls->addColumn($admin['loginname'], $GLOBALS['I18N']->get('Super Admin'), $admin['superuser'] ? s('Yes') : s('No'));
-    $ls->addColumn($admin['loginname'], $GLOBALS['I18N']->get('Disabled'), $admin['disabled'] ? s('Yes') : s('No'));
+        PageUrl2('admin', s('Show'), "start=$start&amp;id=".$admin['id'].$remember_find));
+    $ls->addColumn($admin['loginname'], s('Id'), $admin['id']);
+    $ls->addColumn($admin['loginname'], s('email'), $admin['email']);
+    $ls->addColumn($admin['loginname'], s('Super Admin'), $admin['superuser'] ? s('Yes') : s('No'));
+    $ls->addColumn($admin['loginname'], s('Disabled'), $admin['disabled'] ? s('Yes') : s('No'));
     if (!$external && $_SESSION['logindetails']['superuser'] && $admin['id'] != $_SESSION['logindetails']['id']) {
-        $ls->addColumn($admin['loginname'], $GLOBALS['I18N']->get('Del'), $delete_url);
+        $ls->addColumn($admin['loginname'], s('Del'), $delete_url);
     }
 }
 echo $ls->display();


### PR DESCRIPTION
A few separate commits so that each can be reviewed individually but I can squash if necessary. 

The main change is to display more fields for each admin on the admins page. 
A second change is to allow only a super admin to delete another admin. Currently an ordinary admin is able to delete other admins, which doesn't sound right. The other changes are just tidying-up bits of the code. The commit messages should explain what each is doing.