### PR TITLE
Tidy-up usage of PLUGIN_ROOTDIRS and PLUGIN_ROOTDIR

### DIFF
--- a/public_html/lists/admin/pluginlib.php
+++ b/public_html/lists/admin/pluginlib.php
@@ -2,35 +2,29 @@
 
 require_once dirname(__FILE__).'/accesscheck.php';
 require_once dirname(__FILE__).'/EmailSender.php';
+include_once dirname(__FILE__).'/defaultplugin.php';
 
 $GLOBALS['plugins'] = array();
 $GLOBALS['editorplugin'] = false;
 $GLOBALS['authenticationplugin'] = false;
 $GLOBALS['emailsenderplugin'] = false;
 
-if (!defined('PLUGIN_ROOTDIR')) {
-    define('PLUGIN_ROOTDIR', 'notdefined');
-}
-
 $pluginRootDirs = array();
-if (defined('PLUGIN_ROOTDIRS')) {
+if (PLUGIN_ROOTDIRS != '') {
     $pluginRootDirs = explode(';', PLUGIN_ROOTDIRS);
 }
 $pluginRootDirs[] = PLUGIN_ROOTDIR;
-$pluginRootDirs = array_unique($pluginRootDirs);
-
-include_once dirname(__FILE__).'/defaultplugin.php';
+$pluginRootDirs = array_filter(array_unique($pluginRootDirs));
 $pluginFiles = array();
 
 foreach ($pluginRootDirs as $pluginRootDir) {
     //# try to expand to subdir of the admin dir
-    if (!is_dir($pluginRootDir) && !empty($pluginRootDir)) {
+    if (!is_dir($pluginRootDir)) {
         $pluginRootDir = dirname(__FILE__).'/'.$pluginRootDir;
     }
 
 //  print '<h3>'.$pluginRootDir.'</h3>';
-    if (is_dir($pluginRootDir)) {
-        $dh = opendir($pluginRootDir);
+    if (is_dir($pluginRootDir) && ($dh = opendir($pluginRootDir))) {
         while (false !== ($file = readdir($dh))) {
             if ($file != '.' && $file != '..' && !preg_match('/~$/', $file)) {
                 //        print $pluginRootDir.' '.$file.'<br/>';


### PR DESCRIPTION
A few changes following investigation of a problem on a Windows server.

1) Both the constants already have fallback define's in init.php.
2) Using explode() on an empty string gives an array of one entry that is an empty string. On a Windows server I found that is_dir() on an empty string is treated as the current directory.
3) I then found that is_dir('plugins') returned true (it shouldn't as the current directory is "lists" not "lists/admin") when pluginlib.php was included from the public pages. However opendir('plugins') then failed so I suggest that the result of opendir() should be tested.