### PR TITLE
Get hover text using page name

### DIFF
--- a/public_html/lists/admin/connect.php
+++ b/public_html/lists/admin/connect.php
@@ -1143,7 +1143,7 @@ function PageLink2($name, $desc = '', $url = '', $no_plugin = false, $title = ''
         $desc = $name;
     }
     if (empty($title)) {
-        $title = $GLOBALS['I18N']->pageTitleHover($name);
+        $title = $GLOBALS['I18N']->pageTitleHover($page);
         if (empty($title)) {
             $title = $desc;
         }


### PR DESCRIPTION
Currently the function PageLink2() tries to get any hover text using the $name parameter, but that can include additional query parameters, e.g. importsimple&list=3, which means that the hover text is not found. 
This change is to use only the page name to get hover text.