### PR TITLE
Activate plugins in a controlled order

### DIFF
--- a/public_html/lists/admin/defaultplugin.php
+++ b/public_html/lists/admin/defaultplugin.php
@@ -60,6 +60,12 @@ class phplistPlugin
     public $authProvider = false;
 
     /**
+     * The priority of this plugin.
+     * phplist will activate() plugins in descending priority order
+     */
+    public $priority = 10;
+
+    /**
      * Holds tablename -> real table mapping
      */
     public $tables = array();

--- a/public_html/lists/admin/pluginlib.php
+++ b/public_html/lists/admin/pluginlib.php
@@ -120,7 +120,6 @@ foreach ($pluginFiles as $file) {
                             $GLOBALS['tables'][$className.'_'.$tablename] = $GLOBALS['table_prefix'].$className.'_'.$tablename;
                         }
                     }
-                    $pluginInstance->activate();
                 } else {
                     $pluginInstance->enabled = false;
                     dbg($className.' disabled');
@@ -131,6 +130,17 @@ foreach ($pluginFiles as $file) {
             //print "$className = ".$pluginInstance->name."<br/>";
         }
     }
+}
+//  Activate plugins in descending priority order
+uasort(
+    $plugins,
+    function($a, $b) {
+        return $b->priority - $a->priority;
+    }
+);
+
+foreach ($plugins as $pluginInstance) {
+    $pluginInstance->activate();
 }
 
 $GLOBALS['pluginsendformats'] = array();


### PR DESCRIPTION
Currently plugins are created in an indeterminate order, and made active in that order. It will be useful to apply some control to this, so that one plugin can validly assume that another has already been activated. One example is to activate the Common Plugin first.

There are two changes:
Add priority field to a plugin.
Sort active plugins in descending priority order before activating.