### PR TITLE
Fix miscalculation of percentages on statistics overview page

### DIFF
--- a/public_html/lists/admin/statsoverview.php
+++ b/public_html/lists/admin/statsoverview.php
@@ -144,7 +144,7 @@ $viewed = Sql_Fetch_Row_Query(sprintf('select count(userid) from %s where messag
 // Number of unique views 
 $element = ucfirst(s('Opened '));
 $ls->addElement($element);
-$ls->addColumn($element, '', !empty($viewed[0]) ? PageLink2('mviews&id='.$id, $viewed[0]) : '0');
+$ls->addColumn($element, '', !empty($viewed[0]) ? PageLink2('mviews&id='.$id, number_format($viewed[0])) : '0');
 
 // Opened Rate 
 $perc = sprintf('%0.2f', $viewed[0] / ($totalSent - $totalBounced) * 100);
@@ -158,7 +158,7 @@ $clicked = Sql_Fetch_Row_Query(sprintf('select count(userid) from %s where messa
 // Number of Total Clicks
 $element = ucfirst(s('Clicked'));
 $ls->addElement($element);
-$ls->addColumn($element, '', !empty($clicked[0]) ? PageLink2('mclicks&id='.$id, $clicked[0]) : '0');
+$ls->addColumn($element, '', !empty($clicked[0]) ? PageLink2('mclicks&id='.$id, number_format($clicked[0])) : '0');
 
 // Clicked Rate  
 $perc = sprintf('%0.2f', $clicked[0] / ($totalSent - $totalBounced) * 100);

--- a/public_html/lists/admin/statsoverview.php
+++ b/public_html/lists/admin/statsoverview.php
@@ -122,7 +122,7 @@ while ($row = Sql_Fetch_Assoc($sentQ)) {
     $ls->addElement($element);
     $ls->addColumn($element, '',  number_format($row['num']));
     if ($row['status'] == 'sent') {
-        $totalSent = ( $row['num'] );
+        $totalSent = $row['num'];
     }
 }
 /*

--- a/public_html/lists/admin/statsoverview.php
+++ b/public_html/lists/admin/statsoverview.php
@@ -141,16 +141,12 @@ $totalBounced = $bounced[0];
 $viewed = Sql_Fetch_Row_Query(sprintf('select count(userid) from %s where messageid = %d and status = "sent" and viewed is not null',
     $tables['usermessage'], $id));
 
-// Number of unique views 
+// Number of views 
 $element = ucfirst(s('Opened '));
 $ls->addElement($element);
-$ls->addColumn($element, '', !empty($viewed[0]) ? PageLink2('mviews&id='.$id, number_format($viewed[0])) : '0');
-
 // Opened Rate 
 $perc = sprintf('%0.2f', $viewed[0] / ($totalSent - $totalBounced) * 100);
-$element = ucfirst(s('Opened Rate'));
-$ls->addElement($element);
-$ls->addColumn($element, '', $perc.' %');
+$ls->addColumn($element, '', !empty($viewed[0]) ? PageLink2('mviews&id='.$id, number_format($viewed[0])).'('. $perc .' %)' : '0');
 
 $clicked = Sql_Fetch_Row_Query(sprintf('select count(userid) from %s where messageid = %d',
     $tables['linktrack_uml_click'], $id));
@@ -158,19 +154,24 @@ $clicked = Sql_Fetch_Row_Query(sprintf('select count(userid) from %s where messa
 // Number of Total Clicks
 $element = ucfirst(s('Clicked'));
 $ls->addElement($element);
-$ls->addColumn($element, '', !empty($clicked[0]) ? PageLink2('mclicks&id='.$id, number_format($clicked[0])) : '0');
-
 // Clicked Rate  
 $perc = sprintf('%0.2f', $clicked[0] / ($totalSent - $totalBounced) * 100);
-$element = ucfirst(s('Clicked Rate'));
+$ls->addColumn($element, '', !empty($clicked[0]) ? PageLink2('mclicks&id='.$id, number_format($clicked[0])).'('. $perc .' %)': '0');
+
+// Number of Unique Clicks
+$uniqueclicked = Sql_Fetch_Row_Query(sprintf('select count( distinct userid) from %s where messageid = %d',
+    $tables['linktrack_uml_click'], $id));
+$element = ucfirst(s('Unique Clicks'));
+// Unique Clicked Rate  
+$perc = sprintf('%0.2f', $uniqueclicked[0] / ($totalSent - $totalBounced) * 100);
 $ls->addElement($element);
-$ls->addColumn($element, '', $perc.' %');
+$ls->addColumn($element,'' , !empty($uniqueclicked[0]) ? PageLink2('mclicks&id='.$id, number_format($uniqueclicked[0])).'('. $perc .' %)' : '0');
 
 // Click per view rate
 $element = ucfirst(s('Click Per View Rate'));
 $ls->addElement($element); 
 if ($viewed[0]!=0) {
-    $perc = sprintf('%0.2f', $clicked[0] / $viewed[0] * 100);
+    $perc = sprintf('%0.2f', $uniqueclicked[0] / $viewed[0] * 100);
     $ls->addColumn($element, '', $perc.' %');
 
 } else {

--- a/public_html/lists/admin/statsoverview.php
+++ b/public_html/lists/admin/statsoverview.php
@@ -110,6 +110,7 @@ $element = ucfirst(s('Sent as HTML'));
 $ls->addElement($element);
 $ls->addColumn($element, '', number_format($messagedata['astextandhtml']));
 
+
 $element = ucfirst(s('Sent as text'));
 $ls->addElement($element);
 $ls->addColumn($element, '', number_format($messagedata['astext']));
@@ -120,11 +121,12 @@ $sentQ = Sql_Query(sprintf('select status,count(userid) as num from %s where mes
 while ($row = Sql_Fetch_Assoc($sentQ)) {
     $element = ucfirst($row['status']);
     $ls->addElement($element);
-    $ls->addColumn($element, '', number_format( $row['num'] ));
+    $ls->addColumn($element, '',  $row['num'] );
     if ($row['status'] == 'sent') {
-        $totalSent = number_format( $row['num'] );
+        $totalSent = ( $row['num'] );
     }
 }
+
 /*
 $element = ucfirst(s('Bounced'));
 $ls->addElement($element);
@@ -135,32 +137,40 @@ $bounced = Sql_Fetch_Row_Query(sprintf('select count(distinct user) from %s wher
     $tables['user_message_bounce'], $id));
 $element = ucfirst(s('Bounced'));
 $ls->addElement($element);
-$ls->addColumn($element, '', number_format( $bounced[0] ));
+$ls->addColumn($element, '',  $bounced[0] );
 $totalBounced = $bounced[0];
 
 $viewed = Sql_Fetch_Row_Query(sprintf('select count(userid) from %s where messageid = %d and status = "sent" and viewed is not null',
     $tables['usermessage'], $id));
-$element = ucfirst(s('Opened'));
+
+// Number of unique views 
+$element = ucfirst(s('Opened '));
 $ls->addElement($element);
 $ls->addColumn($element, '', !empty($viewed[0]) ? PageLink2('mviews&id='.$id, $viewed[0]) : '0');
 
+// Opened Rate 
 $perc = sprintf('%0.2f', $viewed[0] / ($totalSent - $totalBounced) * 100);
-$element = ucfirst(s('Opened'));
+$element = ucfirst(s('Opened Rate'));
 $ls->addElement($element);
 $ls->addColumn($element, '', $perc.' %');
 
 $clicked = Sql_Fetch_Row_Query(sprintf('select count(userid) from %s where messageid = %d',
     $tables['linktrack_uml_click'], $id));
+
+// Number of Total Clicks
 $element = ucfirst(s('Clicked'));
 $ls->addElement($element);
 $ls->addColumn($element, '', !empty($clicked[0]) ? PageLink2('mclicks&id='.$id, $clicked[0]) : '0');
 
+// Clicked Rate  
 $perc = sprintf('%0.2f', $clicked[0] / ($totalSent - $totalBounced) * 100);
-$element = ucfirst(s('Clicked'));
+$element = ucfirst(s('Clicked Rate'));
 $ls->addElement($element);
 $ls->addColumn($element, '', $perc.' %');
 
-$element = ucfirst(s('Click Ratio'));
+
+// Click per view rate
+$element = ucfirst(s('Click Per View Rate'));
 $ls->addElement($element); 
 if ($viewed[0]!=0) {
     $perc = sprintf('%0.2f', $clicked[0] / $viewed[0] * 100);
@@ -169,6 +179,8 @@ if ($viewed[0]!=0) {
 } else {
     $ls->addColumn($element, '','0');
 }
+
+
 
 $fwded = Sql_Fetch_Row_Query(sprintf('select count(id) from %s where message = %d',
     $GLOBALS['tables']['user_message_forward'], $id));

--- a/public_html/lists/admin/statsoverview.php
+++ b/public_html/lists/admin/statsoverview.php
@@ -121,7 +121,7 @@ $sentQ = Sql_Query(sprintf('select status,count(userid) as num from %s where mes
 while ($row = Sql_Fetch_Assoc($sentQ)) {
     $element = ucfirst($row['status']);
     $ls->addElement($element);
-    $ls->addColumn($element, '',  $row['num'] );
+    $ls->addColumn($element, '',  number_format($row['num']));
     if ($row['status'] == 'sent') {
         $totalSent = ( $row['num'] );
     }
@@ -137,7 +137,7 @@ $bounced = Sql_Fetch_Row_Query(sprintf('select count(distinct user) from %s wher
     $tables['user_message_bounce'], $id));
 $element = ucfirst(s('Bounced'));
 $ls->addElement($element);
-$ls->addColumn($element, '',  $bounced[0] );
+$ls->addColumn($element, '', number_format ($bounced[0]) );
 $totalBounced = $bounced[0];
 
 $viewed = Sql_Fetch_Row_Query(sprintf('select count(userid) from %s where messageid = %d and status = "sent" and viewed is not null',

--- a/public_html/lists/admin/statsoverview.php
+++ b/public_html/lists/admin/statsoverview.php
@@ -110,7 +110,6 @@ $element = ucfirst(s('Sent as HTML'));
 $ls->addElement($element);
 $ls->addColumn($element, '', number_format($messagedata['astextandhtml']));
 
-
 $element = ucfirst(s('Sent as text'));
 $ls->addElement($element);
 $ls->addColumn($element, '', number_format($messagedata['astext']));
@@ -126,13 +125,12 @@ while ($row = Sql_Fetch_Assoc($sentQ)) {
         $totalSent = ( $row['num'] );
     }
 }
-
 /*
 $element = ucfirst(s('Bounced'));
 $ls->addElement($element);
 $ls->addColumn($element,'&nbsp;',$messagedata['bouncecount']);
 */
-
+//Bounced
 $bounced = Sql_Fetch_Row_Query(sprintf('select count(distinct user) from %s where message = %d',
     $tables['user_message_bounce'], $id));
 $element = ucfirst(s('Bounced'));
@@ -168,7 +166,6 @@ $element = ucfirst(s('Clicked Rate'));
 $ls->addElement($element);
 $ls->addColumn($element, '', $perc.' %');
 
-
 // Click per view rate
 $element = ucfirst(s('Click Per View Rate'));
 $ls->addElement($element); 
@@ -180,8 +177,7 @@ if ($viewed[0]!=0) {
     $ls->addColumn($element, '','0');
 }
 
-
-
+//Forwarded
 $fwded = Sql_Fetch_Row_Query(sprintf('select count(id) from %s where message = %d',
     $GLOBALS['tables']['user_message_forward'], $id));
 $element = ucfirst(s('Forwarded'));


### PR DESCRIPTION
https://mantis.phplist.org/view.php?id=19045
![photo_2018-01-22_16-13-29](https://user-images.githubusercontent.com/9008509/35227797-565f00fe-ff8f-11e7-986a-04ef08c628b2.jpg)

- The number_format() was causing the issue
- The total views and the total clicks rows  are now displayed.

TO DO:
- [x] Since the total clicks are not unique clicks, the clicks per views rate now  is >100%,  which means that I need to calculate the uniqueclicked / viewed * 100



