### PR TITLE
mantis #0018940: Reformat campaign table... on 'View opens' page

### DIFF
--- a/public_html/lists/admin/mviews.php
+++ b/public_html/lists/admin/mviews.php
@@ -82,11 +82,12 @@ $messagedata = Sql_Fetch_Array_query(
     WHERE 
         id = $id $subselect"
 );
-echo '<table class="mviewsDetails">
-<tr><td>' .s('Subject').'<td><td>'.$messagedata['subject'].'</td></tr>
-<tr><td>' .s('Entered').'<td><td>'.$messagedata['entered'].'</td></tr>
-<tr><td>' .s('Sent').'<td><td>'.$messagedata['sent'].'</td></tr>
-</table><hr/>';
+echo '<table class="mviewsDetails table table-bordered"><tr><td>' .
+'<div class="twelve columns col-sm-12 col-lg-6"><b>'.s('Subject').': </b><i>'.$messagedata['subject'].'</i></div>'.
+'<div class="clearfix hidden-lg"></div>'.
+'<div class="six columns col-sm-8 col-lg-3"><b>'.s('Entered').': </b>'.$messagedata['entered'].'</div>'.
+'<div class="six columns col-sm-4 col-lg-3"><b>'.s('Sent').': </b>'.$messagedata['sent'].'</div>'.
+'</td></tr></table>';
 
 if ($download) {
     header('Content-disposition:  attachment; filename="phpList Message open statistics for '.$messagedata['subject'].'.csv"');


### PR DESCRIPTION
result on dressprow:
![screenshot from 2018-01-31 01-02-06](https://user-images.githubusercontent.com/7660111/35604943-ff25587e-0623-11e8-9188-aabb0edfadde.png)

result on trevelin:
![screenshot from 2018-01-31 01-02-28](https://user-images.githubusercontent.com/7660111/35604947-0e85e68a-0624-11e8-8ae8-58de05867da9.png)
