### PR TITLE
Allow PHP 7.2 and higher

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: php
 php:
+- 7.2
 - 7.1
 - 7.0
 - 5.6

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   },
   "minimum-stability": "dev",
   "require": {
-    "php": ">= 5.3.3, <= 7.1.99"
+    "php": "^5.3.3 || ^7.0"
   },
   "require-dev": {
     "behat/mink": "~1.4",

--- a/public_html/lists/admin/PHPMailer/PHPMailerAutoload.php
+++ b/public_html/lists/admin/PHPMailer/PHPMailerAutoload.php
@@ -32,21 +32,8 @@ function PHPMailerAutoload($classname)
     }
 }
 
-if (version_compare(PHP_VERSION, '5.1.2', '>=')) {
-    //SPL autoloading was introduced in PHP 5.1.2
-    if (version_compare(PHP_VERSION, '5.3.0', '>=')) {
-        spl_autoload_register('PHPMailerAutoload', true, true);
-    } else {
-        spl_autoload_register('PHPMailerAutoload');
-    }
+if (version_compare(PHP_VERSION, '5.3.0', '>=')) {
+    spl_autoload_register('PHPMailerAutoload', true, true);
 } else {
-    /**
-     * Fall back to traditional autoload for old PHP versions.
-     *
-     * @param string $classname The name of the class to load
-     */
-    function __autoload($classname)
-    {
-        PHPMailerAutoload($classname);
-    }
+    spl_autoload_register('PHPMailerAutoload');
 }


### PR DESCRIPTION
Closes #253 

The requirement notation is semver compatible and avoid unbound constraint. In other terms, it prevent installing with future PHP 8.