### PR TITLE
Webbler listing row value of 0 is not displayed

### DIFF
--- a/public_html/lists/admin/inc/interfacelib.php
+++ b/public_html/lists/admin/inc/interfacelib.php
@@ -309,16 +309,9 @@ class WebblerListing
         }
         $html .= '</tr>';
         foreach ($element['rows'] as $row) {
-            if ($row['value']) {
-                $value = $row['value'];
-            } else {
-                $value = '';
-            }
-            if (isset($row['align'])) {
-                $align = $row['align'];
-            } else {
-                $align = 'left';
-            }
+            $value = $row['value'];
+            $align = $row['align'];
+
             if (!empty($row['url'])) {
                 $html .= sprintf('<tr class="rowelement %s"><td class="listingrowname">
           <span class="listingrowname"><a href="%s" class="listinghdname" title="%s">%s</a></span>


### PR DESCRIPTION
Testing $row['value'] for true is incorrect because it means that a value of 0 is not displayed.

But $row['value'] and $row['align'] will always have a value as they are set in the addRow() method, so there is no need to test for true or being set.

