### PR TITLE
Avoid PHP warning about undefined index

### DIFF
--- a/public_html/lists/admin/connect.php
+++ b/public_html/lists/admin/connect.php
@@ -130,7 +130,7 @@ if (count($THEMES) > 1 && THEME_SWITCH) {
     unset($themeNames['phpList Default']);
 
     $default_config['UITheme'] = array(
-        'value'       => $_SESSION['ui'],
+        'value'       => isset($_SESSION['ui']) ? $_SESSION['ui'] : '',
         'values'      => array_flip($themeNames),
         'description' => s('Theme for phpList'),
         'type'        => 'select',


### PR DESCRIPTION
php issues this warning when phplist is run from the command line

`PHP Notice:  Undefined index: ui in /home/duncan/Development/GitHub/phplist3/public_html/lists/admin/connect.php on line 133
`