### PR TITLE
Mantis 19122 check for update to plugins

### DIFF
--- a/public_html/lists/admin/defaultplugin.php
+++ b/public_html/lists/admin/defaultplugin.php
@@ -216,6 +216,18 @@ class phplistPlugin
     }
 
     /**
+     * Allows a plugin to override the default check for a new version.
+     *
+     * @param array $pluginDetails
+     *
+     * @returns string|false|null new version, or false if update not available, or null to use the default update check
+     *
+     */
+    public function checkForUpdate(array $pluginDetails)
+    {
+    }
+
+    /**
      * Startup code, all other objects are constructed
      * returns success or failure, false means we cannot start
      */


### PR DESCRIPTION
There are a few changes:

1. for plugins that have been installed from GitHub, query GitHub for the latest tag. If that is greater than the plugin's version then a new version of the plugin is available. 
Allow a plugin to provide its own method to find a new version.
3. Display the number of plugins that are enabled, disabled and have an update available
4. Reduce the number of rows displayed for each plugin by displaying two fields on one row
