### PR TITLE
Mantis 19178 - In php 7.2 the each() function is deprecated

### DIFF
--- a/public_html/lists/admin/actions/export.php
+++ b/public_html/lists/admin/actions/export.php
@@ -87,7 +87,7 @@ if (EXPORT_EXCEL) {
 $row_delim = "\n";
 
 if (is_array($_SESSION['export']['cols'])) {
-    while (list($key, $val) = each($DBstruct['user'])) {
+    foreach ($DBstruct['user'] as $key => $val) {
         if (in_array($key, $_SESSION['export']['cols'])) {
             if (strpos($val[1], 'sys') === false) {
                 fwrite($exportfile, $val[1].$col_delim);
@@ -168,11 +168,11 @@ while ($user = Sql_fetch_array($result)) {
     }
     ++$done;
     reset($_SESSION['export']['cols']);
-    while (list($key, $val) = each($_SESSION['export']['cols'])) {
+    foreach ($_SESSION['export']['cols'] as $key => $val) {
         fwrite($exportfile, strtr($user[$val], $col_delim, ',').$col_delim);
     }
     reset($attributes);
-    while (list($key, $val) = each($attributes)) {
+    foreach ($attributes as $key => $val) {
         $value = UserAttributeValue($user['id'], $val['id']);
         fwrite($exportfile, quoteEnclosed($value, $col_delim, $row_delim).$col_delim);
     }

--- a/public_html/lists/admin/actions/import1.php
+++ b/public_html/lists/admin/actions/import1.php
@@ -88,7 +88,7 @@ while ($row = Sql_Fetch_Array($res)) {
     }
 }
 
-while (list($email, $data) = each($user_list)) {
+foreach ($user_list as $email => $data) {
     //# a lot of spreadsheet include those annoying quotes
     $email = str_replace('"', '', $email);
     set_time_limit(60);

--- a/public_html/lists/admin/actions/import2.php
+++ b/public_html/lists/admin/actions/import2.php
@@ -116,7 +116,7 @@ if (count($email_list)) {
             $user['systemvalues'] = $system_values;
             reset($_SESSION['import_attribute']);
             $replace = array();
-            while (list($key, $val) = each($_SESSION['import_attribute'])) {
+            foreach ($_SESSION['import_attribute'] as $key => $val) {
                 if (!empty($values[$val['index']])) {
                     $user[$val['index']] = addslashes($values[$val['index']]);
                     $replace[$key] = addslashes($values[$val['index']]);
@@ -437,7 +437,7 @@ if (count($email_list)) {
                     reset($_SESSION['lists']);
                     $addition = 0;
                     $listoflists = '';
-                    while (list($key, $listid) = each($_SESSION['lists'])) {
+                    foreach ($_SESSION['lists'] as $key => $listid) {
                         $query = 'replace INTO '.$tables['listuser']." (userid,listid,entered) values($userid,$listid,now())";
                         $result = Sql_query($query, 1);
                         // if the affected rows is 2, the user was already subscribed
@@ -475,7 +475,7 @@ if (count($email_list)) {
                     //add this user to the groups identified
                     reset($groups);
                     $groupaddition = 0;
-                    while (list($key, $groupid) = each($groups)) {
+                    foreach ($groups as $key => $groupid) {
                         if ($groupid) {
                             $query = sprintf('replace INTO user_group (userid,groupid,type) values(%d,%d,%d)', $userid,
                                 $groupid, $_SESSION['grouptype']);

--- a/public_html/lists/admin/addprefix.php
+++ b/public_html/lists/admin/addprefix.php
@@ -13,7 +13,7 @@ if (!$GLOBALS['table_prefix']) {
 
 include 'structure.php';
 
-while (list($table, $value) = each($DBstruct)) {
+foreach ($DBstruct as $table => $value) {
     if ($table != $tables[$table]) {
         Sql_Verbose_Query("drop table if exists $tables[$table]", 0);
         Sql_Verbose_Query("alter table $table rename $tables[$table]", 0);

--- a/public_html/lists/admin/admin.php
+++ b/public_html/lists/admin/admin.php
@@ -83,7 +83,7 @@ if (!empty($_POST['change'])) {
     if ($id) {
         echo '<div class="actionresult">';
         reset($struct);
-        while (list($key, $val) = each($struct)) {
+        foreach ($struct as $key => $val) {
             $a = $b = '';
             if (strstr($val[1], ':')) {
                 list($a, $b) = explode(':', $val[1]);
@@ -100,7 +100,7 @@ if (!empty($_POST['change'])) {
             //  Sql_Query("update {$tables["admin"]} set password = \"".sql_escape($_POST['password'])."\" where id = $id");
         }
         if (isset($_POST['attribute']) && is_array($_POST['attribute'])) {
-            while (list($key, $val) = each($_POST['attribute'])) {
+            foreach ($_POST['attribute'] as $key => $val) {
                 Sql_Query(sprintf('replace into %s (adminid,adminattributeid,value)
           values(%d,%d,"%s")', $tables['admin_attribute'], $id, $key, addslashes($val)));
             }
@@ -165,7 +165,7 @@ if (isset($data['privileges'])) {
 }
 
 reset($struct);
-while (list($key, $val) = each($struct)) {
+foreach ($struct as $key => $val) {
     $a = $b = '';
     if (empty($data[$key])) {
         $data[$key] = '';

--- a/public_html/lists/admin/adminattributes.php
+++ b/public_html/lists/admin/adminattributes.php
@@ -7,7 +7,7 @@ if (isset($_POST['action']) && $_POST['action'] == $GLOBALS['I18N']->get('Save C
         echo '<script language="Javascript" type="text/javascript"> document.write(progressmeter); start();</script>';
     }
     flush();
-    while (list($id, $val) = each($_POST['name'])) {
+    foreach ($_POST['name'] as $id => $val) {
         if (!$id && isset($_POST['name'][0]) && $_POST['name'][0] != '') {
             // it is a new one
             $lc_name = substr(preg_replace("/\W/", '', strtolower($_POST['name'][0])), 0, 10);
@@ -59,7 +59,7 @@ if (isset($_POST['action']) && $_POST['action'] == $GLOBALS['I18N']->get('Save C
         }
     }
     if (isset($_POST['delete'])) {
-        while (list($id, $val) = each($_POST['delete'])) {
+        foreach ($_POST['delete'] as $id => $val) {
             $res = Sql_Query("select tablename,type from {$tables['adminattribute']} where id = $id");
             $row = Sql_Fetch_Row($res);
             if ($row[1] != 'hidden' && $row[1] != 'textline') {
@@ -135,7 +135,7 @@ while ($row = Sql_Fetch_array($res)) {
         <td colspan="2"><select name="type[0]">
                 <?php
                 $types = array('textline', 'hidden'); //'radio','select','checkbox',
-                while (list($key, $val) = each($types)) {
+                foreach ($types as $key => $val) {
                     printf('<option value="%s" %s>%s</option>', $val, '', $val);
                 }
                 ?>

--- a/public_html/lists/admin/attributes.php
+++ b/public_html/lists/admin/attributes.php
@@ -19,7 +19,7 @@ $formtable_exists = Sql_Table_exists('formfield');
 echo '<div class="panel"><div class="header"></div><div class="content">';
 if (isset($_POST['action'])) {
     if (isset($_POST['name'])) {
-        while (list($id, $val) = each($_POST['name'])) {
+        foreach ($_POST['name'] as $id => $val) {
             if (!$id && isset($_POST['name'][0]) && $_POST['name'][0] != '') {
                 // it is a new one
                 $lc_name = getNewAttributeTablename($_POST['name'][0]);
@@ -173,7 +173,7 @@ if (isset($_POST['action'])) {
 } elseif (isset($_POST['tagaction']) && is_array($_POST['tag'])) {
     ksort($_POST['tag']);
     if (isset($_POST['tagaction']['delete'])) {
-        while (list($k, $id) = each($_POST['tag'])) {
+        foreach ($_POST['tag'] as $k => $id) {
             // check for dependencies
             $id = sprintf('%d', $id);
             if ($formtable_exists) {

--- a/public_html/lists/admin/class.image.inc
+++ b/public_html/lists/admin/class.image.inc
@@ -63,7 +63,7 @@ class imageUpload
         $result = array();
         $req = Sql_Query(sprintf('select * from image where id = %d', $fielddata[data]));
         $att = Sql_Fetch_Array($req);
-        while (list($key, $val) = each($att)) {
+        foreach ($att as $key => $val) {
             $result[$fielddata[name] . "." . $key] = $val;
         }
         return $result;

--- a/public_html/lists/admin/connect.php
+++ b/public_html/lists/admin/connect.php
@@ -470,7 +470,7 @@ function Error($msg, $documentationURL = '')
     ++$GLOBALS['mail_error_count'];
     if (is_array($_POST) && count($_POST)) {
         $GLOBALS['mail_error'] .= "\nPost vars:\n";
-        while (list($key, $val) = each($_POST)) {
+        foreach ($_POST as $key => $val) {
             if ($key != 'password') {
                 if (is_array($val)) {
                     $GLOBALS['mail_error'] .= $key.'='.serialize($val)."\n";
@@ -1788,7 +1788,7 @@ function delimited($data)
 {
     $delimitedData = '';
     reset($data);
-    while (list($key, $val) = each($data)) {
+    foreach ($data as $key => $val) {
         $delimitedData .= $key.'KEYVALSEP'.$val.'ITEMSEP';
     }
     $length = strlen($delimitedData);
@@ -2044,7 +2044,7 @@ function phplist_shutdown()
             .$GLOBALS['mail_error'];
         $message .= "\n==== debugging information\n\nSERVER Vars\n";
         if (is_array($_SERVER)) {
-            while (list($key, $val) = each($_SERVER)) {
+            foreach ($_SERVER as $key => $val) {
                 if (stripos($key, 'password') === false) {
                     $message .= $key.'='.serialize($val)."\n";
                 }
@@ -2171,7 +2171,7 @@ function printarray($array)
     if (!is_array($array)) {
         return;
     }
-    while (list($key, $value) = each($array)) {
+    foreach ($array as $key => $value) {
         if (is_array($value)) {
             echo $key.'(array):<blockquote>';
             printarray($value); //recursief!!

--- a/public_html/lists/admin/date.php
+++ b/public_html/lists/admin/date.php
@@ -150,7 +150,7 @@ if (!defined('IN_WEBBLER') && !defined('WEBBLER')) {
       </select>
       <select name="' .$name.'[month]">';
             reset($this->months);
-            while (list($key, $val) = each($this->months)) {
+            foreach ($this->months as $key => $val) {
                 $sel = '';
                 if ($key == $month) {
                     $sel = 'selected="selected"';

--- a/public_html/lists/admin/dbcheck.php
+++ b/public_html/lists/admin/dbcheck.php
@@ -12,7 +12,7 @@ $pass = true;
 
 $ls = new WebblerListing(s('Database structure'));
 $ls->setElementHeading(s('Table'));
-while (list($table, $tablename) = each($GLOBALS['tables'])) {
+foreach ($GLOBALS['tables'] as $table => $tablename) {
     $createlink = '';
     $indexes = $uniques = $engine = $category = '';
 

--- a/public_html/lists/admin/defaultconfig.php
+++ b/public_html/lists/admin/defaultconfig.php
@@ -767,7 +767,7 @@ if (!function_exists('getconfig')) {
     }
 } else {
     reset($default_config);
-    while (list($item, $values) = each($default_config)) {
+    foreach ($default_config as $item => $values) {
         $val = getConfig($item);
         saveConfig($item, $values[0], 0);
     }

--- a/public_html/lists/admin/defaults.php
+++ b/public_html/lists/admin/defaults.php
@@ -38,7 +38,7 @@ foreach ($files as $file) {
 
 if (!empty($_POST['selected']) && is_array($_POST['selected'])) {
     $selected = $_POST['selected'];
-    while (list($key, $val) = each($selected)) {
+    foreach ($selected as $key => $val) {
         $entry = readentry("data/$val");
         list($name, $desc) = explode(':', $entry);
         echo '<br/><br/>'.$GLOBALS['I18N']->get('Loading')." $desc<br/>\n";
@@ -87,7 +87,7 @@ if (!empty($_POST['selected']) && is_array($_POST['selected'])) {
     <?php echo formStart(' class="defaultsAdd"') ?>
     <?php
     reset($attributes);
-    while (list($key, $attribute) = each($attributes)) {
+    foreach ($attributes as $key => $attribute) {
         if (strstr($key, ':')) {
             list($name, $desc) = explode(':', $key);
             if ($name && $desc) {

--- a/public_html/lists/admin/editattributes.php
+++ b/public_html/lists/admin/editattributes.php
@@ -70,7 +70,7 @@ switch ($data['type']) {
             } else {
                 $listorder = $maxitem[0] + 1; // One more than the maximum
             }
-            while (list($key, $val) = each($items)) {
+            foreach ($items as $key => $val) {
                 $val = clean($val);
                 if ($val != '') {
                     $query = sprintf('insert into %s (name,listorder) values("%s","%s")', $table, $val, $listorder);

--- a/public_html/lists/admin/export.php
+++ b/public_html/lists/admin/export.php
@@ -133,7 +133,7 @@ if (empty($list)) {
 
 <?php
 $cols = array();
-while (list($key, $val) = each($DBstruct['user'])) {
+foreach ($DBstruct['user'] as $key => $val) {
     if (strpos($val[1], 'sys') === false) {
         printf("\n".'<br/><input type="checkbox" name="cols[]" value="%s" checked="checked" /> %s ', $key, $val[1]);
     } elseif (preg_match('/sysexp:(.*)/', $val[1], $regs)) {

--- a/public_html/lists/admin/import1.php
+++ b/public_html/lists/admin/import1.php
@@ -140,7 +140,7 @@ if (isset($_REQUEST['import'])) {
         <p><strong>'.$GLOBALS['I18N']->get('Test output:').'</strong></p>
         <hr/>';
         $i = 1;
-        while (list($email, $data) = each($user_list)) {
+        foreach ($user_list as $email => $data) {
             $email = trim($email);
             if (strlen($email) > 4) {
                 echo "<b>$email</b><br/>";

--- a/public_html/lists/admin/import2.php
+++ b/public_html/lists/admin/import2.php
@@ -542,7 +542,7 @@ if (count($email_list)) {
             $user['systemvalues'] = $system_values;
             reset($_SESSION['import_attribute']);
             $replace = array();
-            while (list($key, $val) = each($_SESSION['import_attribute'])) {
+            foreach ($_SESSION['import_attribute'] as $key => $val) {
                 if (!empty($values[$val['index']])) {
                     $user[$val['index']] = addslashes($values[$val['index']]);
                     $replace[$key] = addslashes($values[$val['index']]);

--- a/public_html/lists/admin/import3.php
+++ b/public_html/lists/admin/import3.php
@@ -333,7 +333,7 @@ if (!$_POST['server'] || !$_POST['user'] || !$_POST['password'] || !is_array($_P
     while (count($folderdone) < count($folders) && $level < 10) {
         reset($folders);
         asort($folders);
-        while (list($key, $val) = each($folders)) {
+        foreach ($folders as $key => $val) {
             $delim = $val->delimiter;
             $name = str_replace('{'.$server.'}INBOX', '', imap_utf7_decode($val->name));
             $parent = mailBoxParent($name, $delim, $level);
@@ -361,7 +361,7 @@ if (!$_POST['server'] || !$_POST['user'] || !$_POST['password'] || !is_array($_P
     echo '<p class="submit"><input type="submit" value="'.$GLOBALS['I18N']->get('Process Selected Folders').'"></p></form>';
 } else {
     $all_emails = array();
-    while (list($key, $folder) = each($_POST['checkfolder'])) {
+    foreach ($_POST['checkfolder'] as $key => $folder) {
         echo '<br/>';
         flush();
 
@@ -485,7 +485,7 @@ if (!$_POST['server'] || !$_POST['user'] || !$_POST['password'] || !is_array($_P
                 reset($lists);
                 $addition = 0;
                 $listoflists = '';
-                while (list($key, $listid) = each($lists)) {
+                foreach ($lists as $key => $listid) {
                     $query = 'replace INTO '.$tables['listuser']." (userid,listid,entered) values($userid,$listid,now())";
                     $result = Sql_query($query);
                     // if the affected rows is 2, the user was already subscribed

--- a/public_html/lists/admin/importadmin.php
+++ b/public_html/lists/admin/importadmin.php
@@ -160,7 +160,7 @@ if (!empty($_POST['import'])) {
     if ($test_import) {
         echo $GLOBALS['I18N']->get('Test output: If the output looks ok, go Back to resubmit for real').'<br/><br/>';
         $i = 1;
-        while (list($email, $data) = each($user_list)) {
+        foreach ($user_list as $email => $data) {
             $email = trim($email);
             if (strlen($email) > 4) {
                 echo "<br/><b>$email</b><br/>";
@@ -190,7 +190,7 @@ if (!empty($_POST['import'])) {
         $some = 0;
 
         if (is_array($user_list)) {
-            while (list($email, $data) = each($user_list)) {
+            foreach ($user_list as $email => $data) {
                 if (strlen($email) > 4) {
                     $loginname = $data['loginname'];
                     if (!$loginname && $email) {

--- a/public_html/lists/admin/inc/importlib.php
+++ b/public_html/lists/admin/inc/importlib.php
@@ -49,7 +49,7 @@ function clearImport()
 //# identify system values from the database structure
 $system_attributes = array();
 reset($DBstruct['user']);
-while (list($key, $val) = each($DBstruct['user'])) {
+foreach ($DBstruct['user'] as $key => $val) {
     if (strpos($val[1], 'sys') === false && is_array($val)) {
         $system_attributes[strtolower($key)] = $val[1];  //# allow columns like "htmlemail" and "foreignkey"
         $system_attributes_nicename[strtolower($val[1])] = $key; //# allow columns like "Send this user HTML emails" and "Foreign Key"

--- a/public_html/lists/admin/inc/userlib.php
+++ b/public_html/lists/admin/inc/userlib.php
@@ -1248,7 +1248,7 @@ function saveUserAttribute($userid, $attid, $data)
 function saveUserByID($userid, $data)
 {
     dbg("Saving user by id $userid");
-    while (list($key, $val) = each($data)) {
+    foreach ($data as $key => $val) {
         if (preg_match("/^attribute(\d+)/", $key, $regs)) {
             $attid = $regs[1];
         } else {
@@ -1268,7 +1268,7 @@ function saveUser($loginname, $data)
     $id_req = Sql_Fetch_Row_Query("select id from user where email = \"$loginname\"");
     if ($id_req[0]) {
         $userid = $id_req[0];
-        while (list($key, $val) = each($data)) {
+        foreach ($data as $key => $val) {
             if (preg_match("/^attribute(\d+)/", $key, $regs)) {
                 $attid = $regs[1];
             }
@@ -1386,7 +1386,7 @@ function saveUserData($username, $fields)
 
     dbg('Checking required fields');
     reset($required_fields);
-    while (list($index, $field) = each($required_fields)) {
+    foreach ($required_fields as $index => $field) {
         $type = $fields[$field]['type'];
         // dbg("$field of type $type");
         if ($type != 'userfield' && $type != '') { //## @@@ need to check why type is not set

--- a/public_html/lists/admin/initialise.php
+++ b/public_html/lists/admin/initialise.php
@@ -37,7 +37,7 @@ if (!isset($_REQUEST['adminemail'])) {
 $force = !empty($_GET['force']) && $_GET['force'] == 'yes';
 
 if ($force) {
-    while (list($table, $val) = each($DBstruct)) {
+    foreach ($DBstruct as $table => $val) {
         if ($table == 'attribute') {
             $req = Sql_Query("select tablename from {$tables['attribute']}");
             while ($row = Sql_Fetch_Row($req)) {
@@ -89,7 +89,7 @@ if (empty($_SESSION['hasconf']) && !empty($_REQUEST['firstinstall']) && (empty($
 //var_dump($GLOBALS['plugins']);exit;
 
 output('<h3>'.s('Creating tables')."</h3><br />");
-while (list($table, $val) = each($DBstruct)) {
+foreach ($DBstruct as $table => $val) {
     if ($force) {
         if ($table == 'attribute') {
             $req = Sql_Query("select tablename from {$tables['attribute']}");
@@ -100,7 +100,7 @@ while (list($table, $val) = each($DBstruct)) {
         Sql_query("drop table if exists $tables[$table]");
     }
     $query = "CREATE TABLE $tables[$table] (\n";
-    while (list($column, $struct) = each($DBstruct[$table])) {
+    foreach ($DBstruct[$table] as $column => $struct) {
         if (preg_match('/index_\d+/', $column)) {
             $query .= 'index '.$struct[0].',';
         } elseif (preg_match('/unique_\d+/', $column)) {
@@ -150,7 +150,7 @@ while (list($table, $val) = each($DBstruct)) {
                 $adminid = Sql_Insert_Id();
                 */
             } elseif ($table == 'task') {
-                while (list($type, $pages) = each($system_pages)) {
+                foreach ($system_pages as $type => $pages) {
                     foreach ($pages as $page => $access_level) {
                         Sql_Query(sprintf('replace into %s (page,type) values("%s","%s")',
                             $tables['task'], $page, $type));

--- a/public_html/lists/admin/mysqli.inc
+++ b/public_html/lists/admin/mysqli.inc
@@ -373,7 +373,7 @@ function createTable($table)
 function Sql_create_Table($table, $structure)
 {
     $query = "CREATE TABLE $table (\n";
-    while (list($column, $val) = each($structure)) {
+    foreach ($structure as $column => $val) {
         if (preg_match('/index_\d+/', $column)) {
             $query .= "index " . $structure[$column][0] . ",";
         } elseif (preg_match('/unique_\d+/', $column)) {

--- a/public_html/lists/admin/sendprepared.php
+++ b/public_html/lists/admin/sendprepared.php
@@ -31,7 +31,7 @@ if ($message && $list) {
                 }
             }
         } else {
-            while (list($key, $val) = each($list)) {
+            foreach ($list as $key => $val) {
                 if ($val == 'signup') {
                     array_push($lists, $key);
                 }
@@ -47,7 +47,7 @@ if ($message && $list) {
         array_push($listowners[$owner], $list);
     }
 
-    while (list($owner, $lists) = each($listowners)) {
+    foreach ($listowners as $owner => $lists) {
         $query = sprintf('insert into %s
       (subject,fromfield,tofield,replyto,message,footer,status,
       entered,userselection,htmlformatted,sendformat,template,owner)

--- a/public_html/lists/admin/spageedit.php
+++ b/public_html/lists/admin/spageedit.php
@@ -81,7 +81,7 @@ if (isset($_POST['save'])) {
     $attributes = '';
     if (isset($_POST['attr_use']) && is_array($_POST['attr_use'])) {
         $cnt = 0;
-        while (list($att, $val) = each($_POST['attr_use'])) {
+        foreach ($_POST['attr_use'] as $att => $val) {
             //BUGFIX 15285 - note 50677 (part 1: Attribute order) - by tipichris - mantis.phplist.com/view.php?id=15285
             // $default = $attr_default[$att];
             // $order = $attr_listorder[$att];

--- a/public_html/lists/admin/stresstest.php
+++ b/public_html/lists/admin/stresstest.php
@@ -68,7 +68,7 @@ function fill($prefix, $listid)
     for ($i = 0; $i < $total; ++$i) {
         $data = array();
         reset($attributes);
-        while (list($key, $val) = each($attributes)) {
+        foreach ($attributes as $key => $val) {
             $data[$val] = current($values[$val]);
             if (!$data[$val]) {
                 reset($values[$val]);
@@ -85,7 +85,7 @@ function fill($prefix, $listid)
         if ($userid) {
             $result = Sql_query("replace into $tables[listuser] (userid,listid,entered) values($userid,$listid,now())");
             reset($data);
-            while (list($key, $val) = each($data)) {
+            foreach ($data as $key => $val) {
                 if ($key && $val) {
                     Sql_query("replace into $tables[user_attribute] (attributeid,userid,value) values(".$key.",$userid,".$val.')');
                 }
@@ -116,7 +116,7 @@ if (!count($testlists)) {
         set_time_limit(60);
         flush();
         reset($testlists);
-        while (list($key, $val) = each($testlists)) {
+        foreach ($testlists as $key => $val) {
             if (!fill(getmypid().$i, $val)) {
                 return;
             }

--- a/public_html/lists/admin/subscribelib2.php
+++ b/public_html/lists/admin/subscribelib2.php
@@ -241,7 +241,7 @@ if (isset($_POST['subscribe']) && is_email($_POST['email']) && $listsok && $allt
     $subscriptions = array(); //# used to keep track of which admins to alert
 
     if (isset($_POST['list']) && is_array($_POST['list'])) {
-        while (list($key, $val) = each($_POST['list'])) {
+        foreach ($_POST['list'] as $key => $val) {
             if ($val == 'signup') {
                 $key = sprintf('%d', $key);
                 if (!empty($key)) {
@@ -355,7 +355,7 @@ if (isset($_POST['subscribe']) && is_email($_POST['email']) && $listsok && $allt
     $user_att = getUserAttributeValues($email);
 
     if (count($user_att)) {
-        while (list($att_name, $att_value) = each($user_att)) {
+        foreach ($user_att as $att_name => $att_value) {
             $thankyoupage = str_ireplace('['.$att_name.']', $att_value, $thankyoupage);
         }
     }
@@ -521,7 +521,7 @@ if (isset($_POST['subscribe']) && is_email($_POST['email']) && $listsok && $allt
 
     $lists = '';
     if (is_array($_POST['list'])) {
-        while (list($key, $val) = each($_POST['list'])) {
+        foreach ($_POST['list'] as $key => $val) {
             if ($val == 'signup') {
                 $result = Sql_query(sprintf('replace into %s (userid,listid,entered) values(%d,%d,now())',$GLOBALS['tables']['listuser'],$userid,$key));
 //        $lists .= "  * ".$_POST["listname"][$key]."\n";

--- a/public_html/lists/admin/template.php
+++ b/public_html/lists/admin/template.php
@@ -23,7 +23,6 @@ if (isset($_REQUEST['id'])) {
 
 function getTemplateImages($content)
 {
-    $html_images = array();
     $image_types = array(
         'gif'  => 'image/gif',
         'jpg'  => 'image/jpeg',
@@ -35,20 +34,10 @@ function getTemplateImages($content)
         'tiff' => 'image/tiff',
         'swf'  => 'application/x-shockwave-flash',
     );
-    // Build the list of image extensions
-    while (list($key) = each($image_types)) {
-        $extensions[] = $key;
-    }
-    preg_match_all('/"([^"]+\.('.implode('|', $extensions).'))"/Ui', stripslashes($content), $images);
-    while (list($key, $val) = each($images[1])) {
-        if (isset($html_images[$val])) {
-            ++$html_images[$val];
-        } else {
-            $html_images[$val] = 1;
-        }
-    }
+    $regexp = sprintf('/"([^"]+\.(%s))"/Ui', implode('|', array_keys($image_types)));
+    preg_match_all($regexp, stripslashes($content), $images);
 
-    return $html_images;
+    return array_count_values($images[1]);
 }
 
 function getTemplateLinks($content)
@@ -74,7 +63,7 @@ if (!empty($_POST['action']) && $_POST['action'] == 'addimages') {
         if (count($images)) {
             include 'class.image.inc';
             $image = new imageUpload();
-            while (list($key, $val) = each($images)) {
+            foreach ($images as $key => $val) {
                 // printf('Image name: <b>%s</b> (%d times used)<br />',$key,$val);
                 $image->uploadImage($key, $id);
             }
@@ -154,7 +143,7 @@ if (!empty($_POST['action']) && $_POST['action'] == 'addimages') {
 
         //# ##17419 don't prompt for remote images that exist
         $missingImages = array();
-        while (list($key, $val) = each($images)) {
+        foreach ($images as $key => $val) {
             $key = trim($key);
             if (preg_match('~^https?://~i', $key)) {
                 $imageFound = testUrl($key);
@@ -175,7 +164,7 @@ if (!empty($_POST['action']) && $_POST['action'] == 'addimages') {
             echo '<input type="hidden" name="id" value="'.$id.'" />';
             ksort($images);
             reset($images);
-            while (list($key, $val) = each($images)) {
+            foreach ($images as $key => $val) {
                 $key = trim($key);
                 if (preg_match('~^https?://~i', $key)) {
                     $missingImage = true;

--- a/public_html/lists/admin/upgrade.php
+++ b/public_html/lists/admin/upgrade.php
@@ -88,7 +88,7 @@ if ($dbversion == VERSION && !$force) {
     ignore_user_abort(1);
     // rename tables if we are using the prefix
     include dirname(__FILE__).'/structure.php';
-    while (list($table, $value) = each($DBstruct)) {
+    foreach ($DBstruct as $table => $value) {
         set_time_limit(500);
         if (isset($table_prefix)) {
             if (Sql_Table_exists($table) && !Sql_Table_Exists($tables[$table])) {

--- a/public_html/lists/admin/user.php
+++ b/public_html/lists/admin/user.php
@@ -108,7 +108,7 @@ if (!empty($_POST['change']) && ($access == 'owner' || $access == 'all')) {
         $old_listmembership[$row['listid']] = listName($row['listid']);
     }
 
-    while (list($key, $val) = each($struct)) {
+    foreach ($struct as $key => $val) {
         if (is_array($val)) {
             if (isset($val[1]) && strpos($val[1], ':')) {
                 list($a, $b) = explode(':', $val[1]);
@@ -172,7 +172,7 @@ if (!empty($_POST['change']) && ($access == 'owner' || $access == 'all')) {
     }
 
     if (isset($_POST['cbattribute']) && is_array($_POST['cbattribute'])) {
-        while (list($key, $val) = each($_POST['cbattribute'])) {
+        foreach ($_POST['cbattribute'] as $key => $val) {
             if (isset($_POST['attribute'][$key]) && $_POST['attribute'][$key] == 'on') {
                 Sql_Query(sprintf('replace into %s (userid,attributeid,value)
          values(%d,%d,"on")', $tables['user_attribute'], $id, $key));
@@ -184,7 +184,7 @@ if (!empty($_POST['change']) && ($access == 'owner' || $access == 'all')) {
     }
 
     if (isset($_POST['cbgroup']) && is_array($_POST['cbgroup'])) {
-        while (list($key, $val) = each($_POST['cbgroup'])) {
+        foreach ($_POST['cbgroup'] as $key => $val) {
             $field = 'cbgroup'.$val;
             if (isset($_POST[$field]) && is_array($_POST[$field])) {
                 $newval = array();
@@ -382,7 +382,7 @@ if (isBlackListed($user['email'])) {
 }
 $userdetailsHTML .= '<table class="userAdd" border="1">';
 
-while (list($key, $val) = each($struct)) {
+foreach ($struct as $key => $val) {
     @list($a, $b) = explode(':', $val[1]);
 
     if (!isset($user[$key])) {


### PR DESCRIPTION
Replace `while (list($key, $value)  = each(...))` by an equivalent foreach() construct.

There was one instance of list($key) instead of list($key, $value) in template.php but that processing has been simplified by avoiding it completely.
