### PR TITLE
Add empty images folder to avoid error from CKEditor

### DIFF
--- a/public_html/images/.gitignore
+++ b/public_html/images/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
By default CKEditor and FCKEditor expect an images folder to exist and be writable in order to accept image uploads. This adds an empty folder (except for .gitignore) so that the editors load without errors by default. 