### PR TITLE
README.md: fix "personalisaton" typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Fully functional Open Source email marketing manager for creating, sending, integrating, and analysing email campaigns and newsletters: https://www.phplist.org
 
-phpList includes analytics, segmentation, content personalisaton, bounce processing, plugin-based architecture, and multiple APIs. Used in 95 countries, available in 20 languages, and used to send more than 25 billion campaign messages in 2015.
+phpList includes analytics, segmentation, content personalisation, bounce processing, plugin-based architecture, and multiple APIs. Used in 95 countries, available in 20 languages, and used to send more than 25 billion campaign messages in 2015.
 
 Deploy it on your own server, or get a hosted account at http://phplist.com.
 


### PR DESCRIPTION
Missing "i" in personalisation:
personalisaton -> personalisation