### PR TITLE
Add preferences link to /lists homepage

### DIFF
--- a/public_html/lists/admin/init.php
+++ b/public_html/lists/admin/init.php
@@ -257,6 +257,9 @@ if (!defined('UNSUBSCRIBE_REQUIRES_PASSWORD')) {
 if (!defined('UNSUBSCRIBE_JUMPOFF')) {
     define('UNSUBSCRIBE_JUMPOFF', 1);
 }
+if (!defined('SHOW_PREFERENCESLINK')) {
+    define('SHOW_PREFERENCESLINK', true);
+}
 if (!defined('SHOW_UNSUBSCRIBELINK')) {
     define('SHOW_UNSUBSCRIBELINK', true);
 }

--- a/public_html/lists/config/config_extended.php
+++ b/public_html/lists/config/config_extended.php
@@ -440,6 +440,15 @@ define('ALLOW_NON_LIST_SUBSCRIBE', 0);
 // see also https://mantis.phplist.com/view.php?id=15274
 define('PREFERENCEPAGE_SHOW_PRIVATE_LISTS', 0);
 
+// Show the link(s) to subscribe page(s) on the phpList public homepage (lists/)
+define('SHOW_SUBSCRIBELINK', true);
+
+// Show link to the preferences page on the phpList public homepage (lists/)
+define('SHOW_PREFERENCESLINK', true);
+
+// Show link to the unsubscribe page on the phpList public homepage (lists/)
+define('SHOW_UNSUBSCRIBELINK', true);
+
 // Show 'All Subscribers' section on Subscriber Lists page
 // This flag enabled will show a list called “All subscribers” on the 
 // Subscriber Lists page that has all subscribers in the system as members. 

--- a/public_html/lists/index.php
+++ b/public_html/lists/index.php
@@ -333,9 +333,12 @@ if ($login_required && empty($_SESSION['userloggedin']) && !$canlogin) {
         FileNotFound();
     }
 } else {
+    // If no particular page was requested then show the default
     echo '<title>'.$GLOBALS['strSubscribeTitle'].'</title>';
     echo $pagedata['header'];
     $req = Sql_Query(sprintf('select * from %s where active', $tables['subscribepage']));
+        
+    // If active subscribe pages exist then list them
     if (Sql_Affected_Rows()) {
         while ($row = Sql_Fetch_Array($req)) {
             $intro = Sql_Fetch_Row_Query(sprintf('select data from %s where id = %d and name = "intro"',
@@ -346,12 +349,14 @@ if ($login_required && empty($_SESSION['userloggedin']) && !$canlogin) {
                     strip_tags(stripslashes($row['title'])));
             }
         }
+    // If no active subscribe page exist then print link to default
     } else {
         if (SHOW_SUBSCRIBELINK) {
             printf('<p><a href="'.getConfig('subscribeurl').'">%s</a></p>', $strSubscribeTitle);
         }
     }
 
+    // Print unsubscribe link
     if (SHOW_UNSUBSCRIBELINK) {
         printf('<p><a href="'.getConfig('unsubscribeurl').'">%s</a></p>', $strUnsubscribeTitle);
     }

--- a/public_html/lists/index.php
+++ b/public_html/lists/index.php
@@ -356,7 +356,12 @@ if ($login_required && empty($_SESSION['userloggedin']) && !$canlogin) {
         }
     }
 
-    // Print unsubscribe link
+    // Print preferences page link
+    if (SHOW_PREFERENCESLINK) {
+        printf('<p><a href="'.getConfig('preferencesurl').'">%s</a></p>', $strPreferencesTitle);
+    }
+
+    // Print unsubscribe page link
     if (SHOW_UNSUBSCRIBELINK) {
         printf('<p><a href="'.getConfig('unsubscribeurl').'">%s</a></p>', $strUnsubscribeTitle);
     }


### PR DESCRIPTION
https://mantis.phplist.org/view.php?id=19228

This adds a link to the generic public preferences page from the default homepage of the phpList installation. E.g. alongside the existing links from /lists to the default subscribe page and default unsubscribe pages, a link to the preferences page (which takes either the subscriber UID or their email address to send them their personal link) is included.
This is to make it easier for subscribers to manage their preferences even if they do not have a campaign link available.