### PR TITLE
Added link to contact the administrator on public homepage

### DIFF
--- a/public_html/lists/index.php
+++ b/public_html/lists/index.php
@@ -355,6 +355,14 @@ if ($login_required && empty($_SESSION['userloggedin']) && !$canlogin) {
     if (SHOW_UNSUBSCRIBELINK) {
         printf('<p><a href="'.getConfig('unsubscribeurl').'">%s</a></p>', $strUnsubscribeTitle);
     }
+    // Print link to contact admin using HTML entities for email obfuscation
+    echo 
+        '<p class=""><a href="'.
+            preg_replace_callback('/./', function($m) {
+                return '&#'.ord($m[0]).';';
+            }
+            , 'mailto:'.getConfig('admin_address')).
+        '">'.s('Contact the administrator').'</a></p>';
     echo $PoweredBy;
     echo $pagedata['footer'];
 }


### PR DESCRIPTION
https://mantis.phplist.org/view.php?id=19232

Adds a 'Contact the administrator' link to the public homepage (/lists) to make it easier for subscribers to request copies of their data, rectify or erase it.

Uses simple email HTML entities-based email address obfuscation.