### PR TITLE
#19209: Horizontally align 'Campaign statistics' button on 'View opens"

### DIFF
--- a/public_html/lists/admin/mviews.php
+++ b/public_html/lists/admin/mviews.php
@@ -68,6 +68,9 @@ if ($download) {
     header('Content-type: text/csv');
     ob_start();
 }
+echo '<p class="pull-left">'.PageLinkButton('statsoverview&id='.$id,
+            s('Campaign statistics')).'</p>';
+
 if (empty($start)) {
     echo '<p class="pull-right">'.PageLinkButton('mviews&dl=true&id='.$id.'&start='.$start,
             s('Download as CSV file')).'</p><div class="clearfix"></div>';
@@ -89,8 +92,6 @@ echo '<table class="mviewsDetails table table-bordered"><tr><td>' .
 '<div class="six columns col-sm-4 col-lg-3"><b>'.s('Sent').': </b>'.formatDateTime($messagedata['sent']).'</div>'.
 '</td></tr></table>';
 
-echo '<p class="pull-right">'.PageLinkButton('statsoverview&id='.$id,
-            s('Campaign statistics')).'</p><div class="clearfix"></div>';
 
 if ($download) {
     header('Content-disposition:  attachment; filename="phpList Message open statistics for '.$messagedata['subject'].'.csv"');


### PR DESCRIPTION
BEFORE;
![screenshot from 2018-05-25 23-28-20](https://user-images.githubusercontent.com/7660111/40571658-7a6bc6ea-6073-11e8-8332-5ca6ee12e188.png)

AFTER:
![screenshot from 2018-05-25 23-27-55](https://user-images.githubusercontent.com/7660111/40571661-8680df1a-6073-11e8-9b7f-468be24d95c3.png)

