### PR TITLE
Copy to draft feature

### DIFF
--- a/public_html/lists/admin/messages.php
+++ b/public_html/lists/admin/messages.php
@@ -159,15 +159,15 @@ if (!empty($_GET['delete'])) {
 
 if (isset($_GET['duplicate'])) {
     verifyCsrfGetToken();
-    
+
     Sql_Query(sprintf('insert into %s (subject, fromfield, tofield, replyto, message, textmessage, footer, entered, 
-        modified, embargo, repeatinterval, repeatuntil, requeueuntil, requeueinterval, status,  htmlformatted, 
-        sendformat, template, processed, astext, ashtml, astextandhtml,aspdf, astextandpdf, rsstemplate, owner)
+        modified, embargo, repeatuntil, status, htmlformatted, sendformat, template, rsstemplate, owner)
         select subject, fromfield, tofield, replyto, message, textmessage, footer, now(), 
-        now(), now(), repeatinterval, repeatuntil, requeueuntil, requeueinterval, "draft",  htmlformatted, 
-        sendformat, template, processed, astext, ashtml, astextandhtml,aspdf, astextandpdf, rsstemplate, "%d" from %s
+        now(), now(), now(), "draft",  htmlformatted, 
+        sendformat, template, rsstemplate, "%d" from %s
         where id = %d',
-        $GLOBALS['tables']['message'],$_SESSION['logindetails']['id'],$GLOBALS['tables']['message'],intval($_GET['duplicate'])));
+        $GLOBALS['tables']['message'],$_SESSION['logindetails']['id'],$GLOBALS['tables']['message'],intval($_GET['duplicate'])));    
+
 }
 
 if (isset($_GET['resend'])) {

--- a/public_html/lists/admin/messages.php
+++ b/public_html/lists/admin/messages.php
@@ -157,6 +157,19 @@ if (!empty($_GET['delete'])) {
     $action_result .= "<hr /><br />\n";
 }
 
+if (isset($_GET['duplicate'])) {
+    verifyCsrfGetToken();
+    
+    Sql_Query(sprintf('insert into %s (subject, fromfield, tofield, replyto, message, textmessage, footer, entered, 
+        modified, embargo, repeatinterval, repeatuntil, requeueuntil, requeueinterval, status,  htmlformatted, 
+        sendformat, template, processed, astext, ashtml, astextandhtml,aspdf, astextandpdf, rsstemplate, owner)
+        select subject, fromfield, tofield, replyto, message, textmessage, footer, now(), 
+        now(), now(), repeatinterval, repeatuntil, requeueuntil, requeueinterval, "draft",  htmlformatted, 
+        sendformat, template, processed, astext, ashtml, astextandhtml,aspdf, astextandpdf, rsstemplate, "%d" from %s
+        where id = %d',
+        $GLOBALS['tables']['message'],$_SESSION['logindetails']['id'],$GLOBALS['tables']['message'],intval($_GET['duplicate'])));
+}
+
 if (isset($_GET['resend'])) {
     verifyCsrfGetToken();
     $resend = sprintf('%d', $_GET['resend']);
@@ -568,6 +581,11 @@ if ($total) {
             if (empty($clicks[0])) { //# disallow deletion when there are stats
                 $actionbuttons .= '<span class="delete">'.$deletebutton->show().'</span>';
             }
+        }
+
+        if ($msg['status'] == 'sent') {
+            $actionbuttons .= '<span class="edit">'.PageLinkButton('messages', s('Copy to Draft'),
+                    'tab=draft&duplicate='.$msg['id'], '', s('Copy to Draft')).'</span>';
         }
 
         $ls->addColumn($listingelement, $GLOBALS['I18N']->get('Action'),

--- a/public_html/lists/admin/messages.php
+++ b/public_html/lists/admin/messages.php
@@ -160,14 +160,22 @@ if (!empty($_GET['delete'])) {
 if (isset($_GET['duplicate'])) {
     verifyCsrfGetToken();
 
-    Sql_Query(sprintf('insert into %s (subject, fromfield, tofield, replyto, message, textmessage, footer, entered, 
-        modified, embargo, repeatuntil, status, htmlformatted, sendformat, template, rsstemplate, owner)
-        select subject, fromfield, tofield, replyto, message, textmessage, footer, now(), 
-        now(), now(), now(), "draft",  htmlformatted, 
+    Sql_Query(sprintf('insert into %s (uuid, subject, fromfield, tofield, replyto, message, textmessage, footer, entered, 
+        modified, embargo, repeatuntil, repeatinterval, requeueinterval, status, htmlformatted, sendformat, template, rsstemplate, owner)
+        select "%s", subject, fromfield, tofield, replyto, message, textmessage, footer, now(), 
+        now(), now(), now(), repeatinterval, requeueinterval, "draft",  htmlformatted, 
         sendformat, template, rsstemplate, "%d" from %s
         where id = %d',
-        $GLOBALS['tables']['message'],$_SESSION['logindetails']['id'],$GLOBALS['tables']['message'],intval($_GET['duplicate'])));    
-
+        $GLOBALS['tables']['message'], (string) Uuid::generate(4), $_SESSION['logindetails']['id'],$GLOBALS['tables']['message'],
+        intval($_GET['duplicate'])));    
+    if ($newId = Sql_Insert_Id()) {  // if we don't have a newId then the copy failed
+		Sql_Query(sprintf('insert into %s (id,name,data) '.
+			'select %d,name,data from %s where name in ("sendmethod","sendurl","campaigntitle","excludelist","subject") and id = %d',
+			$GLOBALS['tables']['messagedata'],$newId,$GLOBALS['tables']['messagedata'],intval($_GET['duplicate'])));
+		Sql_Query(sprintf('insert into %s (messageid, listid, entered)  select %d, listid, now() from %s where messageid = %d',
+			$GLOBALS['tables']['listmessage'],$newId,$GLOBALS['tables']['listmessage'],intval($_GET['duplicate'])));
+	}
+	
 }
 
 if (isset($_GET['resend'])) {


### PR DESCRIPTION
The request comes up every now and then for the ability to copy a previously sent message into draft.
This adds a button in the "Sent" campaign list to do so.

https://forums.phplist.com/viewtopic.php?p=39364

Updated the patch to work with the latest version.

Would be nice if this could be coded as a plugin, but there isn't a hook for it yet.


https://mantis.phplist.org/view.php?id=19263