### PR TITLE
Display list names on the messages page

### DIFF
--- a/public_html/lists/admin/message.php
+++ b/public_html/lists/admin/message.php
@@ -160,11 +160,12 @@ if (ALLOW_ATTACHMENTS) {
     // print '</table>';
 }
 
-if (empty($msgdata['sent'])) {
-    $content .= '<tr><td colspan="2"><h4>' . s('This campaign will be sent to subscribers who are member of the following lists') . ':</h4></td></tr>';
-} else {
-    $content .= '<tr><td colspan="2"><h4>' . $GLOBALS['I18N']->get('This campaign has been sent to subscribers who are members of the following lists') . ':</h4></td></tr>';
-}
+$content .= sprintf(
+    '<tr id="targetlists"><td colspan="2"><h4>%s:</h4></td></tr>',
+    empty($msgdata['sent'])
+        ? s('This campaign will be sent to subscribers who are member of the following lists')
+        : s('This campaign has been sent to subscribers who are members of the following lists')
+);
 
 $lists_done = array();
 $result = Sql_Query(sprintf('select l.name, l.id from %s lm, %s l where lm.messageid = %d and lm.listid = l.id',

--- a/public_html/lists/admin/messages.php
+++ b/public_html/lists/admin/messages.php
@@ -396,6 +396,9 @@ if ($total) {
         }
         $ls->addColumn($listingelement, $GLOBALS['I18N']->get('Status'), $statusdiv);
 
+        /*
+         * Display the lists that have been selected for the campaign
+         */
         $maxListsDisplayed = 3;
         $namesQuery = <<<END
     SELECT SQL_CALC_FOUND_ROWS l.name
@@ -418,7 +421,11 @@ END;
 
             if ($numberOfLists > $maxListsDisplayed) {
                 array_pop($listNames);
-                $listNames[] = s('and %d more', $numberOfLists - ($maxListsDisplayed - 1));
+                $listNames[] = sprintf(
+                    '<a href="%s">%s</a>',
+                    PageURL2('message', '', "id={$msg['id']}").'#targetlists',
+                    htmlspecialchars(s('and %d more', $numberOfLists - ($maxListsDisplayed - 1)))
+                );
             }
             $ls->addRow($listingelement, s('Lists'), implode('<br/>', $listNames), '', 'left');
         }

--- a/public_html/lists/admin/messages.php
+++ b/public_html/lists/admin/messages.php
@@ -396,6 +396,33 @@ if ($total) {
         }
         $ls->addColumn($listingelement, $GLOBALS['I18N']->get('Status'), $statusdiv);
 
+        $maxListsDisplayed = 3;
+        $namesQuery = <<<END
+    SELECT SQL_CALC_FOUND_ROWS l.name
+    FROM {$tables['list']} l
+    JOIN {$tables['listmessage']} lm  ON l.id = lm.listid
+    WHERE lm.messageid = {$msg['id']}
+    ORDER BY l.name
+    LIMIT $maxListsDisplayed
+END;
+        $namesResult = Sql_Query($namesQuery);
+        $row = Sql_Fetch_Row_Query('SELECT FOUND_ROWS()');
+        $numberOfLists = $row[0];
+
+        if ($numberOfLists > 0) {
+            $listNames = array();
+
+            while ($row = Sql_Fetch_Assoc($namesResult)) {
+                $listNames[] = htmlspecialchars($row['name']);
+            }
+
+            if ($numberOfLists > $maxListsDisplayed) {
+                array_pop($listNames);
+                $listNames[] = s('and %d more', $numberOfLists - ($maxListsDisplayed - 1));
+            }
+            $ls->addRow($listingelement, s('Lists'), implode('<br/>', $listNames), '', 'left');
+        }
+
         if ($msg['status'] != 'draft') {
             //    $ls->addColumn($listingelement,$GLOBALS['I18N']->get("total"), $msg['astext'] + $msg['ashtml'] + $msg['astextandhtml'] + $msg['aspdf'] + $msg['astextandpdf']);
 //    $ls->addColumn($listingelement,$GLOBALS['I18N']->get("text"), $msg['astext']);


### PR DESCRIPTION
Display the names of the lists to which a campaign has been or will be sent.

I have added a row to show the list names but there might be a better way of doing that. To avoid the "Lists" label, maybe append the list names to the campaign subject

![image](https://user-images.githubusercontent.com/3147688/41034490-a72edad4-6981-11e8-9c87-01424a44461c.png)
