### PR TITLE
Encode text message in editor

### DIFF
--- a/public_html/lists/admin/send_core.php
+++ b/public_html/lists/admin/send_core.php
@@ -905,7 +905,7 @@ date('H:i, l j F Y', strtotime($currentTime[0])) . '</span>' . '</div>';
     <label for="textmessage">' .$GLOBALS['I18N']->get('Plain text version of message').Help('plaintextversion').'</label>'.'
     <div id="generatetextversion">' .PageLinkAjax('send&tab=Text&id='.$id.'&action=generatetext',
                 $GLOBALS['I18N']->get('generate from HTML')).'</a> '.Help('generatetext').'</div>
-    <textarea id="textmessage" name="textmessage" cols="65" rows="20">' .$messagedata['textmessage'].'</textarea>
+    <textarea id="textmessage" name="textmessage" cols="65" rows="20">' .htmlentities($messagedata['textmessage']).'</textarea>
   </div>';
     }
 //var_dump($messagedata);


### PR DESCRIPTION
The text message in the editor was not properly encoded, when the data was rendered a second time (and edited) this resulted in the browser transmitting HTML special characters instead of the encoded versions. Thus breaking stuff that relied on special characters such as URLs containing `&curren`.

To reproduce this:

1. Enable the manual text editor (define('USE_MANUAL_TEXT_PART',1);)
2. Enter the following message as text: "https://www.paypal.com/cgi-bin/webscr?business=hbeer@ability1group.eu&cmd=_donations&amount=0&item_name=DEEPclearing&lc=en_US&currency_code=DKK"3. Go to the next section
4. Go back to "Text" and see it broken (since it's double encoded)

Fixes https://discuss.phplist.org/t/url-for-paypal-donation-destroyed-in-text-message-window/3517

Signed-off-by: Xheni Myrtaj <myrtajxheni@gmail.com>