### PR TITLE
Plugin adding attachments does not work

### DIFF
--- a/public_html/lists/admin/sendemaillib.php
+++ b/public_html/lists/admin/sendemaillib.php
@@ -762,7 +762,7 @@ function sendEmail($messageid, $email, $hash, $htmlpref = 0, $rssitems = array()
     foreach ($GLOBALS['plugins'] as $pluginname => $plugin) {
         $plugin_attachments = $plugin->getMessageAttachment($messageid, $mail->Body);
         if (!empty($plugin_attachments[0]['content'])) {
-            foreach ($plugins_attachments as $plugin_attachment) {
+            foreach ($plugin_attachments as $plugin_attachment) {
                 $mail->add_attachment($plugin_attachment['content'],
                     basename($plugin_attachment['filename']),
                     $plugin_attachment['mimetype']);


### PR DESCRIPTION
Correct misspelt variable name that stopped a plugin adding an attachment to an email.

Can this be added to the pending 3.3.4 release in addition to master?