### PR TITLE
Do not enable a plugin that does not meet its dependencies

### DIFF
--- a/public_html/lists/admin/pluginlib.php
+++ b/public_html/lists/admin/pluginlib.php
@@ -86,6 +86,11 @@ foreach ($pluginFiles as $file) {
                     $plugin_initialised = getConfig(md5('plugin-'.$className.'-initialised'));
 
                     if (!empty($plugin_initialised)) {
+                        if (!pluginCanEnable($className)) {
+                            // an already enabled plugin now does not meet its dependencies, do not enable it
+                            $pluginInstance->enabled = false;
+                            continue;
+                        }                            
                         $GLOBALS['plugins'][$className] = $pluginInstance;
                         $pluginInstance->enabled = true;
                     } elseif (in_array($className, $auto_enable_plugins)) {


### PR DESCRIPTION
There is a problem when a plugin is updated and then does not meet its dependencies.

On the Plugins page it is correctly shown as disabled due to dependency checks, but the processing in pluginlib.php, on each page load, treats it as still being enabled and the plugin's menu items etc are still displayed. Depending on what the dependencies actually are, this can cause a failure that can be difficult to diagnose.

This change adds a test of whether each plugin can be enabled and ignores plugins that are already enabled but fail the test.