### PR TITLE
Get style from  $defaultheader and $defaultfooter

### DIFF
--- a/public_html/lists/admin/spage.php
+++ b/public_html/lists/admin/spage.php
@@ -52,12 +52,12 @@ if (isset($_REQUEST['reset'])) {
 
 if ($reset) {
     $valuesToUpdate =  array(
-        'header' => 'pageheader',
-        'footer' => 'pagefooter',
+        'header' => $defaultheader,
+        'footer' => $defaultfooter,
     );
 
     foreach ($valuesToUpdate as $key => $value){
-        $query = sprintf('update %s set data = "%s" where name = "%s" and id = %d', $tables['subscribepage_data'], sql_escape(getConfig($value)), $key, $reset);
+        $query = sprintf('update %s set data = "%s" where name = "%s" and id = %d', $tables['subscribepage_data'], sql_escape($value), $key, $reset);
         Sql_Query($query);
     }
 }


### PR DESCRIPTION
Before it was getting the style from config table, but since this table is not updated when you upgrade from 3.3.1 to 3.3.4, I had to change the values to $defaultheader and $defaultfooter which hold the values of the default theme on 3.3.4. 