### PR TITLE
Mantis 19403 - Use of mysql "replace into" with the listuser table

### DIFF
--- a/public_html/lists/admin/actions/import1.php
+++ b/public_html/lists/admin/actions/import1.php
@@ -155,9 +155,9 @@ foreach ($user_list as $email => $data) {
         $isBlackListed = isBlackListed($email);
         if (!$isBlackListed) {
             foreach ($importdata['importlists'] as $key => $listid) {
-                $query = 'replace INTO '.$tables['listuser']." (userid,listid,entered) values($userid,$listid,now())";
+                $query = 'insert ignore INTO '.$tables['listuser']." (userid,listid,entered) values($userid,$listid,now())";
                 $result = Sql_query($query);
-                // if the affected rows is 2, the user was already subscribed
+                // if the affected rows is 0, the user was already subscribed
                 $addition = $addition || Sql_Affected_Rows() == 1;
                 if (!empty($importdata['listname'][$key])) {
                     $listoflists .= '  * '.$importdata['listname'][$key]."\n";

--- a/public_html/lists/admin/actions/import2.php
+++ b/public_html/lists/admin/actions/import2.php
@@ -438,9 +438,9 @@ if (count($email_list)) {
                     $addition = 0;
                     $listoflists = '';
                     foreach ($_SESSION['lists'] as $key => $listid) {
-                        $query = 'replace INTO '.$tables['listuser']." (userid,listid,entered) values($userid,$listid,now())";
+                        $query = 'insert ignore INTO '.$tables['listuser']." (userid,listid,entered) values($userid,$listid,now())";
                         $result = Sql_query($query, 1);
-                        // if the affected rows is 2, the user was already subscribed
+                        // if the affected rows is 0, the user was already subscribed
                         $addition = $addition || Sql_Affected_Rows() == 1;
                         $listoflists .= '  * '.listName($key)."\n"; // $_SESSION["listname"][$key] . "\n";
                     }

--- a/public_html/lists/admin/importsimple.php
+++ b/public_html/lists/admin/importsimple.php
@@ -75,10 +75,14 @@ if (!empty($_POST['importcontent'])) {
             //# do not add them to the list(s) when blacklisted
             $isBlackListed = isBlackListed($line);
             if (!$isBlackListed) {
-                ++$count['addedtolist'];
+                $addition = false;
                 foreach ($selected_lists as $k => $listid) {
-                    $query = 'replace into '.$tables['listuser']." (userid,listid,entered) values($userid,$listid,now())";
+                    $query = 'insert ignore into '.$tables['listuser']." (userid,listid,entered) values($userid,$listid,now())";
                     $result = Sql_query($query);
+                    $addition = $addition || Sql_Affected_Rows() == 1;
+                }
+                if ($addition) {
+                    ++$count['addedtolist'];
                 }
             } else {
                 //# mark blacklisted, just in case ##17288

--- a/public_html/lists/admin/members.php
+++ b/public_html/lists/admin/members.php
@@ -94,9 +94,9 @@ if (isset($_REQUEST['processtags']) && $access != 'view') {
                 foreach ($_POST['user'] as $key => $val) {
                     Sql_query(sprintf('delete from %s where listid = %d and userid = %d', $tables['listuser'], $id,
                         $key));
-                    Sql_query(sprintf('replace into %s (listid,userid) values(%d,%d)', $tables['listuser'],
+                    Sql_query(sprintf('insert ignore into %s (listid,userid, entered) values(%d,%d, now())', $tables['listuser'],
                         $_POST['movedestination'], $key));
-                    if (Sql_Affected_rows() == 1) { // 2 means they were already on the list
+                    if (Sql_Affected_rows() == 1) { // 0 means they were already on the list
                         ++$cnt;
                     }
                 }
@@ -105,9 +105,11 @@ if (isset($_REQUEST['processtags']) && $access != 'view') {
             case 'copy':
                 $cnt = 0;
                 foreach ($_POST['user'] as $key => $val) {
-                    Sql_query(sprintf('replace into %s (listid,userid)
-            values(%d,%d);', $tables['listuser'], $_POST['copydestination'], $key));
-                    ++$cnt;
+                    Sql_query(sprintf('insert ignore into %s (listid,userid, entered)
+            values(%d,%d, now());', $tables['listuser'], $_POST['copydestination'], $key));
+                    if (Sql_Affected_rows() == 1) {
+                        ++$cnt;
+                    }
                 }
                 $msg = $cnt.' '.$GLOBALS['I18N']->get('subscribers were copied to').' '.listName($_POST['copydestination']);
                 break;
@@ -139,9 +141,9 @@ if (isset($_REQUEST['processtags']) && $access != 'view') {
                 while ($user = Sql_Fetch_Row($req)) {
                     Sql_query(sprintf('delete from %s where listid = %d and userid = %d', $tables['listuser'], $id,
                         $user[0]));
-                    Sql_query(sprintf('replace into %s (listid,userid) values(%d,%d)', $tables['listuser'],
+                    Sql_query(sprintf('insert ignore into %s (listid,userid, entered) values(%d,%d, now())', $tables['listuser'],
                         $_POST['movedestination_all'], $user[0]));
-                    if (Sql_Affected_rows() == 1) { // 2 means they were already on the list
+                    if (Sql_Affected_rows() == 1) { // 0 means they were already on the list
                         ++$cnt;
                     }
                 }
@@ -150,9 +152,11 @@ if (isset($_REQUEST['processtags']) && $access != 'view') {
             case 'copy':
                 $cnt = 0;
                 while ($user = Sql_Fetch_Row($req)) {
-                    Sql_query(sprintf('replace into %s (listid,userid) values(%d,%d)', $tables['listuser'],
+                    Sql_query(sprintf('insert ignore into %s (listid,userid, entered) values(%d,%d, now())', $tables['listuser'],
                         $_POST['copydestination_all'], $user[0]));
-                    ++$cnt;
+                    if (Sql_Affected_rows() == 1) {
+                        ++$cnt;
+                    }
                 }
                 $msg = $cnt.' '.$GLOBALS['I18N']->get('subscribers were copied to').' '.listName($_POST['copydestination_all']);
                 break;


### PR DESCRIPTION
Use "insert ignore" instead of "replace into" when adding records to the listuser table.
For simple import, count insertions in the same way as for import1 and import2.

On the list membership page, make all the options count insertions in the same way, and ensure that the entered field is populated.