### PR TITLE
Adding (more) graceful failure when phplist does not have access to r…

### DIFF
--- a/public_html/lists/admin/checkprerequisites.php
+++ b/public_html/lists/admin/checkprerequisites.php
@@ -1,0 +1,30 @@
+<?php
+/*******************************************************************************
+ * File:    checkprerequisites.php
+ * Version: 1.0
+ * Purpose: Check that some basic prerequisites to running phplist are met. If
+ *          not, fail gracefully
+ * Created: 2018-09-15
+ * Updated: 2018-09-15
+ ******************************************************************************/
+
+// make sure we're running a recent version of php
+if (!defined('PHP_VERSION_ID') || PHP_VERSION_ID < 50303) {
+    die('Your PHP version is too old. Please upgrade PHP before continuing.');
+}
+
+// make sure we have access to a cryptographically secure pseudorandom number
+// generator (CSPNRG)
+try {
+    require_once dirname(__FILE__).'/inc/random_compat/random.php';
+    random_bytes(1);
+} catch (Exception $e) {
+    error_log( "Caught Exception: " . $e->getMessage() );
+    die (
+     "phpList requires a random_bytes function. For more information, please "
+    ."see \r\n\r\n<br/><br/>"
+    .'* https://tech.michaelaltfield.net/2018/08/25/fix-phplist-500-error-due-to-random_compat/'
+    );
+} 
+
+?>

--- a/public_html/lists/admin/index.php
+++ b/public_html/lists/admin/index.php
@@ -1,8 +1,7 @@
 <?php
 
-if (!defined('PHP_VERSION_ID') || PHP_VERSION_ID < 50303) {
-    die('Your PHP version is too old. Please upgrade PHP before continuing.');
-}
+// check for basic prerequisites
+require_once dirname(__FILE__).'/checkprerequisites.php';
 
 if (ob_get_level() == 0) {
     @ob_start();


### PR DESCRIPTION
…andom_bytes() from some cryptographically secure pseudorandom number generator (CSPRNG). For more info, please see:

 * https://discuss.phplist.org/t/common-installation-errors-manual-chapter-feedback-and-discussion/217/4
 * https://mantis.phplist.org/view.php?id=18546
 * https://tech.michaelaltfield.net/2018/08/25/fix-phplist-500-error-due-to-random_compat/