### PR TITLE
Mantis 17649 Click tracking decoding urlencoded characters

### DIFF
--- a/public_html/lists/admin/lib.php
+++ b/public_html/lists/admin/lib.php
@@ -1385,6 +1385,12 @@ function parseQueryString($str)
 
 function cleanUrl($url, $disallowed_params = array('PHPSESSID'))
 {
+    // process url only if it contains a disallowed parameter
+    $pattern = sprintf('/(%s)=/', implode('|', $disallowed_params));
+
+    if (!preg_match($pattern, $url)) {
+        return htmlspecialchars_decode($url);
+    }
     $parsed = @parse_url($url);
     $params = array();
     if (empty($parsed['query'])) {


### PR DESCRIPTION
This is a quick fix for Mantis 17649 https://mantis.phplist.org/view.php?id=17649

The problem is that, when trying to remove some specific query parameters from a url, the url can get changed or corrupted. The current processing breaks a url into its constituent parts then reassembles those, even when there is no need for that.

This change is simply to leave alone urls that do not contain any of the disallowed parameters.

A better, but larger, solution is to rework and simplify the processing of urls for link tracking.