### PR TITLE
Mantis 19453 - Some plugins were disabled after upgrading to release 3.3.5

### DIFF
--- a/public_html/lists/admin/pluginlib.php
+++ b/public_html/lists/admin/pluginlib.php
@@ -86,11 +86,6 @@ foreach ($pluginFiles as $file) {
                     $plugin_initialised = getConfig(md5('plugin-'.$className.'-initialised'));
 
                     if (!empty($plugin_initialised)) {
-                        if (!pluginCanEnable($className)) {
-                            // an already enabled plugin now does not meet its dependencies, do not enable it
-                            $pluginInstance->enabled = false;
-                            continue;
-                        }                            
                         $GLOBALS['plugins'][$className] = $pluginInstance;
                         $pluginInstance->enabled = true;
                     } elseif (in_array($className, $auto_enable_plugins)) {
@@ -144,7 +139,13 @@ uasort(
     }
 );
 
-foreach ($plugins as $pluginInstance) {
+foreach ($plugins as $className => $pluginInstance) {
+    if (!pluginCanEnable($className)) {
+        // an already enabled plugin now does not meet its dependencies, do not enable it
+        $pluginInstance->enabled = false;
+        unset($plugins[$className]);
+        continue;
+    }                            
     $pluginInstance->activate();
 }
 


### PR DESCRIPTION
Move the test of whether a plugin can be enabled to where all plugins have been created.