### PR TITLE
Don’t remove useful anchor links

### DIFF
--- a/public_html/lists/admin/inc/maillib.php
+++ b/public_html/lists/admin/inc/maillib.php
@@ -44,7 +44,7 @@ function HTML2Text($text)
             $linkreplace = $linkurl;
         } else {
             //# if link is an anchor only, take it out
-            if (strpos($linkurl, '#') !== false) {
+            if (strpos($linkurl, '#') === 0) {
                 $linkreplace = $linktext;
             } else {
                 $linkreplace = $linktext.' <'.$linkurl.'>';


### PR DESCRIPTION
Still removes "#anchor" but not "https://www.exameple.com/#anchor".