### PR TITLE
added better logging when 'hack attempt is encountered', and fixed a …

### DIFF
--- a/public_html/lists/admin/subscribelib2.php
+++ b/public_html/lists/admin/subscribelib2.php
@@ -258,6 +258,7 @@ if (isset($_POST['subscribe']) && is_email($_POST['email']) && $listsok && $allt
                     addSubscriberStatistics('subscribe', 1, $key);
                 } else {
                     //# hack attempt...
+                    throw new Exception( "ERROR: Unexpected input error: empty element in \$_POST['list'] array. Exiting." );
                     exit;
                 }
             }

--- a/public_html/lists/index.php
+++ b/public_html/lists/index.php
@@ -245,7 +245,9 @@ if ($login_required && empty($_SESSION['userloggedin']) && !$canlogin) {
                     $_POST['email'] = $_GET['email'];
                 }
                 foreach (explode(',', $GLOBALS['pagedata']['lists']) as $listid) {
-                    $_POST['list'][$listid] = 'signup';
+                    if( $listid != ''){ //# do not add an empty element
+                        $_POST['list'][$listid] = 'signup';
+                    }
                 }
                 $_POST['htmlemail'] = 1; //# @@ should actually be taken from the subscribe page data
 


### PR DESCRIPTION
…logic bug that resulted in a false-positive of the "hack attempt" exit when a phplist subscribe page had 0 lists selected. For more info, see:

 * https://discuss.phplist.org/t/purpose-of-hack-attempt-exit-in-subscribelib2-php/4578/