### PR TITLE
Avoid php notice when converting php memory limit

### DIFF
--- a/public_html/lists/admin/connect.php
+++ b/public_html/lists/admin/connect.php
@@ -1506,16 +1506,17 @@ function phpcfgsize2bytes($val)
 {
     $val = trim($val);
     $last = mb_strtolower($val{strlen($val) - 1});
+    $result = substr($val, 0, -1);
     switch ($last) {
         case 'g':
-            $val *= 1024;
+            $result *= 1024;
         case 'm':
-            $val *= 1024;
+            $result *= 1024;
         case 'k':
-            $val *= 1024;
+            $result *= 1024;
     }
 
-    return $val;
+    return $result;
 }
 
 function Help($topic, $text = '?')


### PR DESCRIPTION
Convert only the numeric part of the php memory limit to avoid php issuing a notice 

`PHP Notice:  A non well formed numeric value encountered in /home/duncan/Development/GitHub/phplist3/public_html/lists/admin/connect.php on line 1514, referer: http://strontian/lists/?p=forward&mid=103&uid=1bbf5b37bbb1df69698c4b89e1429474`