### PR TITLE
Avoid php notice re undefined index

### DIFF
--- a/public_html/lists/admin/actions/processqueue.php
+++ b/public_html/lists/admin/actions/processqueue.php
@@ -1057,7 +1057,11 @@ while ($message = Sql_fetch_array($messages)) {
                     $cansend = $plugin->canSend($msgdata, $user);
                     if (!$cansend) {
                         $failure_reason .= 'Sending blocked by plugin '.$plugin->name;
-                        ++$counters['send blocked by '.$plugin->name];
+                        $counterIndex = 'send blocked by '.$plugin->name;
+                        if (!isset($counters[$counterIndex])) {
+                            $counters[$counterIndex] = 0;
+                        }
+                        ++$counters[$counterIndex];
                         if (VERBOSE) {
                             cl_output('Sending blocked by plugin '.$plugin->name);
                         }


### PR DESCRIPTION
Avoid php notice re undefined index when sending is blocked by a plugin

`[Wed Nov 28 12:39:35.992842 2018] [php7:notice] [pid 2323] [client 127.0.0.1:45052] PHP Notice:  Undefined index: send blocked by Segmentation in /home/duncan/Development/GitHub/phplist3/public_html/lists/admin/actions/processqueue.php on line 1060`