### PR TITLE
When editing a subscribe page display the plugin section at the end

### DIFF
--- a/public_html/lists/admin/spageedit.php
+++ b/public_html/lists/admin/spageedit.php
@@ -346,11 +346,13 @@ while ($row = Sql_Fetch_Array($req)) {
 $attributesHTML .= '</div>';
 
 //## allow plugins to add tabs
+$pluginsHTML = '';
+
 foreach ($GLOBALS['plugins'] as $pluginname => $plugin) {
     $pluginHTML = $plugin->displaySubscribepageEdit($data);
     if (!empty($pluginHTML)) {
-        echo '<h3><a name="'.$pluginname.'">'.s('Information needed for %s', $plugin->name).'</a></h3>';
-        echo '<div>'.$pluginHTML.'</div>';
+        $pluginsHTML .= '<h3><a name="'.$pluginname.'">'.s('Information needed for %s', $plugin->name).'</a></h3>';
+        $pluginsHTML .= '<div>'.$pluginHTML.'</div>';
     }
 }
 
@@ -394,6 +396,7 @@ if ($hasAttributes) {
     echo $attributesHTML;
 }
 echo $transactionHTML;
+echo $pluginsHTML;
 
 echo '</div>'; // accordion
 


### PR DESCRIPTION
An earlier change https://github.com/phpList/phplist3/pull/348 didn't include the sections for plugins, which are now displayed before other sections.
![image](https://user-images.githubusercontent.com/3147688/49221320-ae6e2000-f3d0-11e8-95ac-2a3826b8774a.png)
This change is to display any plugin sections at the end.