### PR TITLE
Mantis 19347 - command line signature is displayed twice

### DIFF
--- a/public_html/lists/admin/connect.php
+++ b/public_html/lists/admin/connect.php
@@ -442,14 +442,12 @@ function ClineSignature()
 function ClineError($msg)
 {
     ob_end_clean();
-    echo ClineSignature();
     echo "\nError: $msg\n";
     exit;
 }
 
 function clineUsage($line = '')
 {
-    cl_output(clineSignature());
     cl_output( 'Usage: '.$_SERVER['SCRIPT_FILENAME']." -p page $line".PHP_EOL);
 }
 

--- a/public_html/lists/admin/convertstats.php
+++ b/public_html/lists/admin/convertstats.php
@@ -6,13 +6,10 @@ if (!$GLOBALS['commandline']) {
     echo '<p class="information">'.$GLOBALS['I18N']->get('Hint: this page also works from commandline').'</p>';
     $limit = 10000;
 } else {
-    @ob_end_clean();
-    echo ClineSignature();
     //# when on cl, doit immediately
     $_GET['doit'] = 'yes';
     //# on commandline handle more
     $limit = 50000;
-    ob_start();
 }
 
 function output($message)

--- a/public_html/lists/admin/cron.php
+++ b/public_html/lists/admin/cron.php
@@ -18,9 +18,6 @@ if (!$GLOBALS['commandline']) {
 
     return;
 }
-
-cl_output(ClineSignature());
-
 $cronJobs = array(
 
     // at a later stage, these should be added

--- a/public_html/lists/admin/import.php
+++ b/public_html/lists/admin/import.php
@@ -58,7 +58,6 @@ if ($GLOBALS['commandline']) {
     if (!$cline['l']) {
         echo ClineError('Specify lists to import users to');
     }
-    echo clineSignature();
 
     ob_start();
     $_FILES['import_file'] = array(

--- a/public_html/lists/admin/index.php
+++ b/public_html/lists/admin/index.php
@@ -182,6 +182,7 @@ if (isset($GLOBALS['pageheader'])) {
 
 $GLOBALS['require_login'] = 1; ## this is no longer configurable and should never have been
 if ($GLOBALS['commandline']) {
+    cl_output(ClineSignature());
     if (!isset($_SERVER['USER']) && count($GLOBALS['commandline_users'])) {
         clineError('USER environment variable is not defined, cannot do access check. Please make sure USER is defined.');
         exit;
@@ -206,7 +207,6 @@ if ($GLOBALS['commandline']) {
         } elseif (isset($cline['p'])) {
             $_GET['page'] = $cline['p'];
         }
-        cl_output( ClineSignature());
         cl_processtitle('core-'.$_GET['page']);
     } elseif ($cline['p'] && $IsCommandlinePlugin) {
         if (empty($GLOBALS['developer_email']) && isset($cline['p']) && !in_array($cline['p'],
@@ -216,7 +216,6 @@ if ($GLOBALS['commandline']) {
         } elseif (isset($cline['p'])) {
             $_GET['page'] = $cline['p'];
             $_GET['pi'] = $cline['m'];
-            cl_output( ClineSignature());
             cl_processtitle($_GET['pi'].'-'.$_GET['page']);
         }
     } else {

--- a/public_html/lists/admin/initlanguages.php
+++ b/public_html/lists/admin/initlanguages.php
@@ -9,10 +9,6 @@ if (empty($GLOBALS['commandline'])) {
 
     return;
 }
-ob_end_clean();
-echo ClineSignature();
-ob_start();
-
 $locale_root = dirname(__FILE__).'/locale/';
 
 $force = isset($cline['f']);

--- a/public_html/lists/admin/processbounces.php
+++ b/public_html/lists/admin/processbounces.php
@@ -30,10 +30,6 @@ if (!$GLOBALS['commandline']) {
         //# we're in a normal session, so the csrf token should work
         verifyCsrfGetToken();
     }
-} else {
-    ob_end_clean();
-    echo ClineSignature();
-    ob_start();
 }
 
 flush();

--- a/public_html/lists/admin/processqueue.php
+++ b/public_html/lists/admin/processqueue.php
@@ -19,9 +19,6 @@ if (!$GLOBALS['commandline']) {
         return;
     }
 } else {
-    @ob_end_clean();
-    echo ClineSignature();
-    ob_start();
     include dirname(__FILE__).'/actions/processqueue.php';
 
     return;

--- a/public_html/lists/admin/send.php
+++ b/public_html/lists/admin/send.php
@@ -124,7 +124,6 @@ include 'send_core.php';
 if ($done) {
     if ($GLOBALS['commandline']) {
         ob_end_clean();
-        echo clineSignature();
         echo 'Message with subject '.$_POST['subject'].' was sent to '.$lists."\n";
         exit;
     }

--- a/public_html/lists/admin/updatetlds.php
+++ b/public_html/lists/admin/updatetlds.php
@@ -4,8 +4,6 @@ if (!$GLOBALS['commandline']) {
     @ob_end_flush();
     echo '<p class="information">'.s('This page only works from commandline').'</p>';
     return;
-} else {
-    cl_output(ClineSignature());
 }
 
 if (isset($cline['f'])) {

--- a/public_html/lists/admin/upgrade.php
+++ b/public_html/lists/admin/upgrade.php
@@ -5,11 +5,8 @@ require_once dirname(__FILE__).'/accesscheck.php';
 if (!$GLOBALS['commandline']) {
     @ob_end_flush();
 } else {
-    @ob_end_clean();
-    echo ClineSignature();
     //# when on cl, doit immediately
     $_GET['doit'] = 'yes';
-    ob_start();
 }
 $force = isset($cline['f']) || isset($_GET['force']);
 


### PR DESCRIPTION
Output the command line signature in only one place in index.php, allowing all other calls to ClineSignature() to be removed

```
before for page initlanguages
======
phpList - phpList version 3.3.7 (c) 2000-2018 phpList Ltd, https://www.phplist.com

Try automatic updater here (beta)
phpList version 3.3.7 (c) 2000-2018 phpList Ltd, https://www.phplist.comphpList - pt
phpList - Up to date
phpList - de
phpList - Up to date

after
=====
phpList - phpList version 3.3.7-dev (c) 2000-2018 phpList Ltd, https://www.phplist.com

Running DEV version, but developer email is not set
phpList - pt
phpList - Up to date
phpList - de
phpList - Up to date

```