### PR TITLE
Remote processing validation

### DIFF
--- a/public_html/lists/admin/actions/processqueue.php
+++ b/public_html/lists/admin/actions/processqueue.php
@@ -9,26 +9,17 @@ if (isset($_GET['login']) || isset($_GET['password'])) {
 
     return;
 }
-$inRemoteCall = false;
 
-if (isset($_GET['secret'])) {
-    $ourSecret = getConfig('remote_processing_secret');
-    if ($ourSecret != $_GET['secret']) {
-        echo Error(s('Incorrect processing secret'));
-
-        return;
-    } else {
-        $inRemoteCall = true;
-        //# check that we actually still want remote queue processing
-        $pqChoice = getConfig('pqchoice');
-        if (SHOW_PQCHOICE && $pqChoice != 'phplistdotcom') {
-            $counters['campaigns'] = 0;
-            echo outputCounters();
-            exit;
-        }
+if ($inRemoteCall) {
+    // check that we actually still want remote queue processing
+    $pqChoice = getConfig('pqchoice');
+    if (SHOW_PQCHOICE && $pqChoice != 'phplistdotcom') {
+        $counters['campaigns'] = 0;
+        echo outputCounters();
+        exit;
     }
 } else {
-    //# we're in a normal session, so the csrf token should work
+    // we're in a normal session, so the csrf token should work
     verifyCsrfGetToken();
 }
 

--- a/public_html/lists/admin/processbounces.php
+++ b/public_html/lists/admin/processbounces.php
@@ -76,6 +76,10 @@ function outputProcessBounce($message, $reset = 0)
     $message = html_entity_decode($message, ENT_QUOTES, 'UTF-8');
     if ($GLOBALS['commandline']) {
         cl_output($message);
+    } elseif ($GLOBALS['inRemoteCall']) {
+        ob_end_clean();
+        echo $message, "\n";
+        ob_start();
     } else {
         if ($reset) {
             echo '<script language="Javascript" type="text/javascript">

--- a/public_html/lists/admin/processbounces.php
+++ b/public_html/lists/admin/processbounces.php
@@ -1,9 +1,9 @@
 <?php
 
 require_once dirname(__FILE__).'/accesscheck.php';
-$inRemoteCall = false;
 
-if (!$GLOBALS['commandline']) {
+if (!$GLOBALS['commandline'] && !$GLOBALS['inRemoteCall']) {
+    // browser session
     ob_end_flush();
     if (!MANUALLY_PROCESS_BOUNCES) {
         echo $GLOBALS['I18N']->get('This page can only be called from the commandline');
@@ -15,21 +15,9 @@ if (!$GLOBALS['commandline']) {
 
         return;
     }
-    $inRemoteCall = false;
 
-    if (isset($_GET['secret'])) {
-        $ourSecret = getConfig('remote_processing_secret');
-        if ($ourSecret != $_GET['secret']) {
-            echo Error(s('Incorrect processing secret'));
-
-            return;
-        } else {
-            $inRemoteCall = true;
-        }
-    } else {
-        //# we're in a normal session, so the csrf token should work
-        verifyCsrfGetToken();
-    }
+    //# we're in a normal session, so the csrf token should work
+    verifyCsrfGetToken();
 }
 
 flush();


### PR DESCRIPTION
As discussed in #440 the validation of the remote processing secret is duplicated. This PR has four parts

- removes the validation from processbounces
- removes the validation from processqueue
- allows remote processing for processbounces when MANUALLY_PROCESS_BOUNCES is set to false (which makes it similar to processqueue and MANUALLY_PROCESS_QUEUE). The benefit is that process bounces is removed from the admin interface.
- makes the output of processbounces with remote processing simpler by outputting only text, not html. So the output is then similar to that for command line.

I have tested these changes using remote processing, but not with processing the queue by the phplist hosted service. That doesn't appear to be running or at least is not responding to my account.