### PR TITLE
Mantis 18435 - sort order on the List Campaigns page

### DIFF
--- a/public_html/lists/admin/messages.php
+++ b/public_html/lists/admin/messages.php
@@ -9,7 +9,9 @@ $filterSelectDefault = ' --- '.s('filter').' --- ';
 
 $messageSortOptions = array(
     'subjectasc'  => array(
+        // caption for drop-down list
         'label' => s('Subject').' - '.s('Ascending'),
+        // sql order by
         'orderby' => 'subject asc'
     ),
     'subjectdesc'  => array(
@@ -51,8 +53,10 @@ $messageSortOptions = array(
 );
 $tabParameters = array(
     'active' => array(
+        // status values to select messages
         'status' => "'inprocess', 'submitted', 'suspended'",
-        'defaultSort' => 'embargodesc'
+        // initial ordering of tab
+        'defaultSort' => 'embargoasc'
     ),
     'draft' => array(
         'status' => "'draft'",
@@ -64,7 +68,7 @@ $tabParameters = array(
     ),
     'static' => array(
         'status' => "'prepared'",
-        'defaultSort' => 'embargodesc'
+        'defaultSort' => 'embargoasc'
     ),
 );
 
@@ -211,14 +215,14 @@ if (!empty($_GET['delete'])) {
 if (isset($_GET['duplicate'])) {
     verifyCsrfGetToken();
 
-    Sql_Query(sprintf('insert into %s (uuid, subject, fromfield, tofield, replyto, message, textmessage, footer, entered, 
+    Sql_Query(sprintf('insert into %s (uuid, subject, fromfield, tofield, replyto, message, textmessage, footer, entered,
         modified, embargo, repeatuntil, repeatinterval, requeueinterval, status, htmlformatted, sendformat, template, rsstemplate, owner)
-        select "%s", subject, fromfield, tofield, replyto, message, textmessage, footer, now(), 
-        now(), now(), now(), repeatinterval, requeueinterval, "draft",  htmlformatted, 
+        select "%s", subject, fromfield, tofield, replyto, message, textmessage, footer, now(),
+        now(), now(), now(), repeatinterval, requeueinterval, "draft",  htmlformatted,
         sendformat, template, rsstemplate, "%d" from %s
         where id = %d',
         $GLOBALS['tables']['message'], (string) Uuid::generate(4), $_SESSION['logindetails']['id'],$GLOBALS['tables']['message'],
-        intval($_GET['duplicate'])));    
+        intval($_GET['duplicate'])));
     if ($newId = Sql_Insert_Id()) {  // if we don't have a newId then the copy failed
 		Sql_Query(sprintf('insert into %s (id,name,data) '.
 			'select %d,name,data from %s where name in ("sendmethod","sendurl","campaigntitle","excludelist","subject") and id = %d',
@@ -226,7 +230,7 @@ if (isset($_GET['duplicate'])) {
 		Sql_Query(sprintf('insert into %s (messageid, listid, entered)  select %d, listid, now() from %s where messageid = %d',
 			$GLOBALS['tables']['listmessage'],$newId,$GLOBALS['tables']['listmessage'],intval($_GET['duplicate'])));
 	}
-	
+
 }
 
 if (isset($_GET['resend'])) {
@@ -540,7 +544,7 @@ END;
         //$bouncedrow = sprintf('<tr><td colspan="%d">%s</td><td>%d</td></tr>',
         //$colspan-1,$GLOBALS['I18N']->get("Bounced"),$msg["bouncecount"]);
         //}
-    
+
         // Calculcate sent statistics for printing
         $sentStats = array(
             'grandTotal' => $msg['astext'] + $msg['ashtml'] + $msg['astextandhtml'] + $msg['aspdf'] + $msg['astextandpdf']

--- a/public_html/lists/admin/messages.php
+++ b/public_html/lists/admin/messages.php
@@ -8,22 +8,64 @@ $access = accessLevel('messages');
 $filterSelectDefault = ' --- '.s('filter').' --- ';
 
 $messageSortOptions = array(
-    'subjectasc'  => array('label' => s('Subject').' - '.s('Ascending'), 'orderby' => 'subject asc'),
-    'subjectdesc'  => array('label' => s('Subject').' - '.s('Descending'), 'orderby' => 'subject desc'),
-    'enteredasc'  => array('label' => s('Entered').' - '.s('Ascending'), 'orderby' => 'entered asc'),
-    'enteredasc'  => array('label' => s('Entered').' - '.s('Descending'), 'orderby' => 'entered desc'),
-    'modifiedasc'  => array('label' => s('Modified').' - '.s('Ascending'), 'orderby' => 'modified asc'),
-    'modifieddesc'  => array('label' => s('Modified').' - '.s('Descending'), 'orderby' => 'modified desc'),
-    'embargoasc'  => array('label' => s('Embargo').' - '.s('Ascending'), 'orderby' => 'embargo asc'),
-    'embargodesc'  => array('label' => s('Embargo').' - '.s('Descending'), 'orderby' => 'embargo desc'),
-    'sentasc'  => array('label' => s('Sent').' - '.s('Ascending'), 'orderby' => 'sent asc'),
-    'sentdesc'  => array('label' => s('Sent').' - '.s('Descending'), 'orderby' => 'sent desc'),
+    'subjectasc'  => array(
+        'label' => s('Subject').' - '.s('Ascending'),
+        'orderby' => 'subject asc'
+    ),
+    'subjectdesc'  => array(
+        'label' => s('Subject').' - '.s('Descending'),
+        'orderby' => 'subject desc'
+    ),
+    'enteredasc'  => array(
+        'label' => s('Entered').' - '.s('Ascending'),
+        'orderby' => 'entered asc'
+    ),
+    'entereddesc'  => array(
+        'label' => s('Entered').' - '.s('Descending'),
+        'orderby' => 'entered desc'
+    ),
+    'modifiedasc'  => array(
+        'label' => s('Modified').' - '.s('Ascending'),
+        'orderby' => 'modified asc'
+    ),
+    'modifieddesc'  => array(
+        'label' => s('Modified').' - '.s('Descending'),
+        'orderby' => 'modified desc'
+    ),
+    'embargoasc'  => array(
+        'label' => s('Embargo').' - '.s('Ascending'),
+        'orderby' => 'embargo asc'
+    ),
+    'embargodesc'  => array(
+        'label' => s('Embargo').' - '.s('Descending'),
+        'orderby' => 'embargo desc'
+    ),
+    'sentasc'  => array(
+        'label' => s('Sent').' - '.s('Ascending'),
+        'orderby' => 'sent asc'
+    ),
+    'sentdesc'  => array(
+        'label' => s('Sent').' - '.s('Descending'),
+        'orderby' => 'sent desc'
+    ),
 );
-$tabSortDefaults = array(
-    'active' => 'embargodesc',
-    'draft' => 'modifieddesc',
-    'sent' => 'sentdesc',
-    'static' => 'embargodesc',
+$tabParameters = array(
+    'active' => array(
+        'status' => "'inprocess', 'submitted', 'suspended'",
+        'defaultSort' => 'embargodesc'
+    ),
+    'draft' => array(
+        'status' => "'draft'",
+        'defaultSort' => 'modifieddesc'
+    ),
+    'sent' => array(
+        'status' => "'sent'",
+        'defaultSort' => 'sentdesc'
+    ),
+    'static' => array(
+        'status' => "'prepared'",
+        'defaultSort' => 'embargodesc'
+    ),
 );
 
 if ($access == 'all') {
@@ -66,7 +108,7 @@ if (isset($_POST['numPP'])) {
     }
 }
 
-if (isset($_GET['tab'])) {
+if (isset($_GET['tab']) && isset($tabParameters[$_GET['tab']])) {
     $currentTab = $_GET['tab'];
 } else {
     if (isset($_SESSION['lastmessagetype'])) {
@@ -84,7 +126,7 @@ if (isset($_POST['sortBy'])) {
 }
 
 if (!isset($_SESSION['messagesortby'][$currentTab])) {
-    $_SESSION['messagesortby'][$currentTab] = $tabSortDefaults[$currentTab];
+    $_SESSION['messagesortby'][$currentTab] = $tabParameters[$currentTab]['defaultSort'];
 }
 $currentSortBy = $_SESSION['messagesortby'][$currentTab];
 
@@ -292,26 +334,7 @@ if (!empty($action_result)) {
 }
 
 $where = array();
-//## Switch tab
-switch ($currentTab) {
-    case 'queued':
-//    $subselect = ' status in ("submitted") and (rsstemplate is NULL or rsstemplate = "") ';
-        $where[] = " status in ('submitted', 'suspended') ";
-        break;
-    case 'static':
-        $where[] = " status in ('prepared') ";
-        break;
-    case 'draft':
-        $where[] = " status in ('draft') ";
-        break;
-    case 'active':
-        $where[] = " status in ('inprocess','submitted', 'suspended') ";
-        break;
-    case 'sent':
-    default:
-        $where[] = " status in ('sent') ";
-        break;
-}
+$where[] = sprintf('status in (%s)', $tabParameters[$currentTab]['status']);
 $url_keep = '&amp;tab='.$currentTab;
 
 if (!empty($_SESSION['messagefilter'])) {


### PR DESCRIPTION
This change covers some of the points raised in the mantis issue

- display the actual sort order when the page is displayed for the first time
- allow each tab to have its own sort order, which is remembered throughout the session

Also, there is some restructuring to hold all tab related fields and all sort-order related fields in structures instead of being spread throughout the code.

I think that there is still a usability issue allowing sorting by a field whose value is not displayed (such as the embargo), but maybe that can be addressed separately. This change doesn't affect that.