### PR TITLE
Repeated html input fields on the Send a Campaign page

### DIFF
--- a/public_html/lists/admin/send_core.php
+++ b/public_html/lists/admin/send_core.php
@@ -1348,9 +1348,9 @@ if ($allReady) {
 $saveDraftButton = '<div class="sendSubmit">
     <input class="submit" type="submit" name="savedraft" value="' .s('Save as draft').'"/>
     <input type="hidden" name="id" value="' .$id.'"/>
-    <input type="hidden" name="status" value="draft"/> <input class="submit" type="submit" name="save" value="' .s('Save and continue editing').'"/>
-    <input type="hidden" name="id" value="' .$id.'"/>
-    <input type="hidden" name="status" value="draft"/></div>
+    <input type="hidden" name="status" value="draft"/>
+    <input class="submit" type="submit" name="save" value="' .s('Save and continue editing').'"/>
+  </div>
 ';
 
 $titleInput = '<label for="campaigntitle">'.s('Campaign Title').Help('campaigntitle').'</label>'.


### PR DESCRIPTION
When using the Firefox web console tool to see what was sent when submitting a campaign I noticed that two hidden fields were duplicated, the message id and the message status. This change removes those.