### PR TITLE
Correct the values for the updatepassword radio buttons.

### DIFF
--- a/public_html/lists/admin/admin.php
+++ b/public_html/lists/admin/admin.php
@@ -194,7 +194,7 @@ foreach ($struct as $key => $val) {
           <input type="radio" id= "passwordoption0" name="passwordoption" value="0"   >'.s('Create password').'
       </td>
   </tr>
-  
+
   <tr id="passrow">
         <td>
             <label for="adminpassword">'.s('Create password').'</label>
@@ -204,7 +204,7 @@ foreach ($struct as $key => $val) {
             <span id= "shortpassword">'.s('Password must be at least 8 characters').'</span>
         </td>
     </tr>
-    
+
     <tr id="confirmrow">
         <td>
             <label for="confirmpassword">'.s('Confirm password').'</label>
@@ -226,8 +226,8 @@ foreach ($struct as $key => $val) {
                     $checkNo = 'checked="checked"';
                 }
                 if ($addAdmin===false) {
-                    printf('<tr><td>%s (%s)</td><td>%s<input type="radio" name="updatepassword" value="0" %s>%s</input>
-                               <input type="radio" name="updatepassword" value="1" %s>%s</input></td></tr>
+                    printf('<tr><td>%s (%s)</td><td>%s<input type="radio" name="updatepassword" value="1" %s>%s</input>
+                               <input type="radio" name="updatepassword" value="0" %s>%s</input></td></tr>
 ',
                         s('Password'), s('hidden'),
                         s('Update it?'),


### PR DESCRIPTION
I found weird behaviour when trying to send the password reset email on the Admin page.
The confirmation message didn't say that the email had been sent, but after a further change to an admin field it did say that.

An earlier change https://github.com/phpList/phplist3/pull/399/files#diff-151b5aaf0a8d1c46203a572c46ab3746L193 re-ordered the radio button captions from No then Yes to Yes then No but didn't modify the html attribute values, which meant elsewhere checks for Yes are being met when the No button is selected.
