### PR TITLE
Reorder plugins from filesystem -> move CommonPlugin to the top

### DIFF
--- a/public_html/lists/admin/pluginlib.php
+++ b/public_html/lists/admin/pluginlib.php
@@ -67,6 +67,16 @@ if (is_array($disabled_plugins)) {
     }
 }
 
+// Move Common plugin to top as some plugins need it as dependency
+// An example plugin is Autoresponder, which requires the CommonPlugin as a dependency
+// Any better solution is welcome, but the fact is that the order of plugins is important!
+usort(
+    $pluginFiles,
+    function($a, $b) {
+        return ('plugins/CommonPlugin.php' == $b) ? 1 : 0;
+    }
+);
+
 //var_dump($GLOBALS['plugins_disabled']);exit;
 foreach ($pluginFiles as $file) {
     list($className, $ext) = explode('.', basename($file));


### PR DESCRIPTION
An issue can occur if you use the Autoresponder plugin. Php can retrieve the list of plugins in wrong order, so the Autoresponder checks for dependencies before the CommonPlugin gets loaded.
And because it needs the CommonPlugin as a dependency, the Autoresponder plugin will never be enabled.