### PR TITLE
Mantis 19794 - CONTACT placeholder not replaced correctly

### DIFF
--- a/public_html/lists/admin/lib.php
+++ b/public_html/lists/admin/lib.php
@@ -2162,9 +2162,9 @@ function parseLogoPlaceholders($content)
  * @return mixed
  */
 function parseVCardHTMLPlaceholder($content) {
-    preg_match_all('/\[CONTACT\:?(\d+)?\]/', $content, $contactInstances);
+    preg_match_all('/\[CONTACT\:?(\d+)?\]/i', $content, $contactInstances);
     foreach ($contactInstances[0] as $index => $contactInstance) {
-        $content = str_replace($contactInstance, '<a href="'.htmlentities(getConfig('vcardurl')).' ">'.$GLOBALS['strContactMessage'].'</a>', $content);
+        $content = str_ireplace($contactInstance, '<a href="'.htmlentities(getConfig('vcardurl')).'">'.$GLOBALS['strContactMessage'].'</a>', $content);
     }
 
     return $content;
@@ -2176,9 +2176,9 @@ function parseVCardHTMLPlaceholder($content) {
  * @return mixed
  */
 function parseVCardTextPlaceholder($content) {
-    preg_match_all('/\[CONTACT\:?(\d+)?\]/', $content, $contactInstances);
+    preg_match_all('/\[CONTACT\:?(\d+)?\]/i', $content, $contactInstances);
     foreach ($contactInstances[0] as $index => $contactInstance) {
-        $content = str_replace($contactInstance, $GLOBALS['strContactMessage'].' '.htmlentities(getConfig('vcardurl')), $content);
+        $content = str_ireplace($contactInstance, $GLOBALS['strContactMessage'].' '.htmlentities(getConfig('vcardurl')), $content);
     }
 
     return $content;
@@ -2271,7 +2271,7 @@ function asyncLoadContent($url)
 {
     return '<script type="text/javascript">
         var loadMessage = \'' .sjs('Please wait, your request is being processed. Do not refresh this page.').'\';
-        var loadMessages = new Array(); 
+        var loadMessages = new Array();
         loadMessages[30] = \'' .sjs('Still loading').'\';
         loadMessages[90] = \'' .sjs('It may seem to take a while, but there is a lot of data to crunch<br/>if you have a lot of subscribers and campaigns').'\';
         loadMessages[150] = \'' .sjs('It should be soon now, your page content is almost here.').'\';


### PR DESCRIPTION

<!---Thanks for contributing to phpList!-->

## Description
Remove erroneous space from the CONTACT url
Allow lower case CONTACT placeholder to be used, similarly to other phplist placeholders.


## Related Issue
<!--- If it fixes an open issue on Mantis , please include a link to the issue here. -->
https://mantis.phplist.org/view.php?id=19794

## Screenshots (if appropriate):

