### PR TITLE
Mantis 19792 - Subscriber page ignores list order if categories are used

### DIFF
--- a/public_html/lists/admin/subscribelib2.php
+++ b/public_html/lists/admin/subscribelib2.php
@@ -97,17 +97,17 @@ if (isset($subscribepagedata['showcategories']) && $subscribepagedata['showcateg
 if (!empty($_POST['VerificationCodeX'])) {
     if (NOTIFY_SPAM) {
         $msg = $GLOBALS['I18N']->get('
--------------------------------------------------------------------------------- 
+--------------------------------------------------------------------------------
     This is a notification of a possible spam attack to your phplist subscribe page.
     The data submitted has been copied below, so you can check whether this was actually the case.
     The submitted data has been converted into non-html characters, for security reasons.
-    If you want to stop receiving this message, set 
-    
-     define("NOTIFY_SPAM",0);  
-     
-     in your phplist config file.  
-     
-     This subscriber has NOT been added to the database. 
+    If you want to stop receiving this message, set
+
+     define("NOTIFY_SPAM",0);
+
+     in your phplist config file.
+
+     This subscriber has NOT been added to the database.
      If there is an error, you will need to  add them manually.
 --------------------------------------------------------------------------------  ');
         foreach ($_REQUEST as $key => $val) {
@@ -749,7 +749,7 @@ function ListAvailableLists($userid = 0, $lists_to_show = '')
     if (isset($GLOBALS['showCat'])&& $GLOBALS['showCat']===true){
         $listspercategory = array();
         $categories = array();
-        $catresult = Sql_query(sprintf('select * from %s %s order by category',
+        $catresult = Sql_query(sprintf('select * from %s %s order by category, listorder, name',
             $GLOBALS['tables']['list'], $subselect));
 
 


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
Ensure that lists are ordered by the list order field when displayed within categories.
There are also a few removals of trailing white space, which is done automatically by my editor.
## Related Issue
<!--- If it fixes an open issue on Mantis , please include a link to the issue here. -->
https://mantis.phplist.org/view.php?id=19792
## Screenshots (if appropriate):
The specified list order
![image](https://user-images.githubusercontent.com/3147688/53721871-2890c380-3e5c-11e9-9e25-8d748e6ade2b.png)

Subscribe page prior to the change
![image](https://user-images.githubusercontent.com/3147688/53721793-fd0dd900-3e5b-11e9-9ad8-c8d2a44b4b5d.png)
Subscribe page after the change
![image](https://user-images.githubusercontent.com/3147688/53721817-0f881280-3e5c-11e9-8f76-16ab6eaef670.png)

