### PR TITLE
Add credit and license in docblock for 3rd party email template

### DIFF
--- a/public_html/lists/admin/defaultsystemtemplate.php
+++ b/public_html/lists/admin/defaultsystemtemplate.php
@@ -16,6 +16,36 @@ $systemTemplate = <<<EOD
 <br /></div>
 EOD;
 
+/**
+ * Really Simple Free Responsive HTML Email Template
+ * @author Lee Munroe
+ * @author Angel Gonzalez
+ * @link https://github.com/algzb/responsive-html-email-template-for-PHPLIST
+ * @link https://github.com/leemunroe/responsive-html-email-template
+ * @license
+ * 
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) [2013] [Lee Munroe]
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 $simpleResponsiveTemplate = <<<EOD
 <!doctype html>
 <html>


### PR DESCRIPTION
## Description
Add license and attribution info for recently added email template

## Related Issue
<!--- If it fixes an open issue on Mantis , please include a link to the issue here. -->
[Mantis](https://mantis.phplist.org) : https://mantis.phplist.org/view.php?id=19820

