### PR TITLE
Use the correct variable for the custom forward footer when forwarding

### DIFF
--- a/public_html/lists/admin/sendemaillib.php
+++ b/public_html/lists/admin/sendemaillib.php
@@ -237,7 +237,7 @@ function sendEmail($messageid, $email, $hash, $htmlpref = 0, $rssitems = array()
     } else {
         //0013076: different content when forwarding 'to a friend'
         if (FORWARD_ALTERNATIVE_CONTENT) {
-            $text['footer'] = stripslashes($messagedata['forwardfooter']);
+            $text['footer'] = stripslashes($cached[$messageid]['footer']);
         } else {
             $text['footer'] = getConfig('forwardfooter');
         }


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->
## Description
<!--- Please provide a general description of your changes in the Pull Request -->
This fixes a problem when forwarding a message that has a custom forward footer. The forwarded message does not include the footer due to the code  using an incorrect/non-existent variable.
See https://discuss.phplist.org/t/missing-footer-when-forwarding-to-a-friend/4696/8 for the discussion.
## Related Issue
<!--- If it fixes an open issue on Mantis , please include a link to the issue here. -->
[Mantis](https://mantis.phplist.org) :

## Screenshots (if appropriate):
Prior to the change, the email does not have the footer
![image](https://user-images.githubusercontent.com/3147688/54498434-2ff5a980-48ff-11e9-9f7b-2bafb97e4188.png)
After the change, the email now does include the footer
![image](https://user-images.githubusercontent.com/3147688/54498449-64696580-48ff-11e9-9878-76275768abcd.png)
