### PR TITLE
Shorten API calls

### DIFF
--- a/public_html/lists/.htaccess
+++ b/public_html/lists/.htaccess
@@ -29,7 +29,7 @@ DirectoryIndex index.php
 <IfModule mod_rewrite.c>
     Options -MultiViews
     RewriteEngine On
-    RewriteRule api/ api.php [L]
+    RewriteRule api/v2/ api.php [L]
 </IfModule>
 
 

--- a/public_html/lists/.htaccess
+++ b/public_html/lists/.htaccess
@@ -14,7 +14,7 @@ DirectoryIndex index.php
 	</IfModule>
 </FilesMatch>
 # app.php is the entrypoint for phpList4
-<FilesMatch "(index.php|dl.php|ut.php|lt.php|download.php|connector.php|app.php)$">
+<FilesMatch "(index.php|dl.php|ut.php|lt.php|download.php|connector.php|api.php)$">
 	# Apache < 2.3
 	<IfModule !mod_authz_core.c>
 		Order allow,deny

--- a/public_html/lists/.htaccess
+++ b/public_html/lists/.htaccess
@@ -1,4 +1,3 @@
-
 DirectoryIndex index.php
 
 <FilesMatch "\.(php|inc)$">
@@ -26,6 +25,13 @@ DirectoryIndex index.php
 		Require all granted
 	</IfModule>
 </FilesMatch>
+
+<IfModule mod_rewrite.c>
+    Options -MultiViews
+    RewriteEngine On
+    RewriteRule api/ api.php [L]
+</IfModule>
+
 
 # if you want more than this for attachments, you can increase these values
 # but you really, really should consider uploading them somewhere

--- a/public_html/lists/api.php
+++ b/public_html/lists/api.php
@@ -1,8 +1,10 @@
 <?php
-declare(strict_types=1);
 
 use PhpList\Core\Core\Bootstrap;
 
+if (version_compare(phpversion(), '7.0.0', '<')) {
+  die('API is not supported on this PHP version.');
+}
 require_once __DIR__ . '/base/vendor/autoload.php';
 
 Bootstrap::getInstance()

--- a/public_html/lists/api.php
+++ b/public_html/lists/api.php
@@ -1,0 +1,10 @@
+<?php
+declare(strict_types=1);
+
+use PhpList\Core\Core\Bootstrap;
+
+require_once __DIR__ . '/base/vendor/autoload.php';
+
+Bootstrap::getInstance()
+    ->configure()
+    ->dispatch();


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
Added api.php in lists which is needed to create shorters API calls.
The new base url will be : http://example.com/lists/api.php/
Example: http://example.com/lists/api.php/sessions

Will push changes to core repo too.
To do: Fix the tests. Remove  strict_types as it's not supported in old versions of PHP and add a PHP version check.

## Related Issue
<!--- If it fixes an open issue on Mantis , please include a link to the issue here. -->
https://mantis.phplist.org/view.php?id=19847


