### PR TITLE
Fix system template title name 

### DIFF
--- a/public_html/lists/admin/defaultsystemtemplate.php
+++ b/public_html/lists/admin/defaultsystemtemplate.php
@@ -416,7 +416,7 @@ if (isset($_POST['Submit'])) {
         Sql_Query(sprintf('insert into %s (title,template,listorder) values("%s","%s",0)',
             $GLOBALS['tables']['template'], $title, addslashes($content)));
         $newid = Sql_Insert_Id();
-        if ($title === 'System Template') {
+        if ($title === 'System template') {
             saveConfig('systemmessagetemplate', $newid);
         }
         $messages = '<div class="actionresult alert alert-success">';


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
System template should be checked as "system" by default when loaded. Fixed the title name that caused the issue.
## Related Issue
https://mantis.phplist.org/view.php?id=19866

