### PR TITLE
Public page footer Update for v3.4.0

### DIFF
--- a/public_html/lists/admin/upgrade.php
+++ b/public_html/lists/admin/upgrade.php
@@ -175,8 +175,6 @@ if ($dbversion == VERSION && !$force) {
     // Update jQuery version referenced in public page HTML stored in the database
     if (version_compare($dbversion, '3.4.1', '<')) {
 
-
-
         $replacement = "jquery.min.js";
 
         // Replace jQuery version in config table.
@@ -184,9 +182,11 @@ if ($dbversion == VERSION && !$force) {
         $matches = null;
 
         preg_match('/jquery-3.3.1.min.js/', $oldConfigFooter, $matches);
-        if ($matches[0] == "jquery-3.3.1.min.js"){
+        if ($matches[0] == "jquery-3.3.1.min.js") {
             $pattern = "jquery-3.3.1.min.js";
-        } else $pattern = "jquery-1.12.1.min.js";
+        } else {
+            $pattern = "jquery-1.12.1.min.js";
+        }
 
         $newConfigFooter = str_replace($pattern, $replacement, $oldConfigFooter);
         SaveConfig('pagefooter', $newConfigFooter);
@@ -199,10 +199,11 @@ if ($dbversion == VERSION && !$force) {
         }
         foreach ($footersArray as $key => $value) {
             preg_match('/jquery-3.3.1.min.js/', $value, $matches);
-            if ($matches[0] == "jquery-3.3.1.min.js"){
+            if ($matches[0] == "jquery-3.3.1.min.js") {
                 $pattern = "jquery-3.3.1.min.js";
-            } else $pattern = "jquery-1.12.1.min.js";
-
+            } else {
+                $pattern = "jquery-1.12.1.min.js";
+            }
             $newFooter = str_replace($pattern, $replacement, $value);
             Sql_Query(sprintf('update %s set data = "%s" where data = "%s" ', $GLOBALS['tables']['subscribepage_data'], sql_escape($newFooter), addslashes($value)));
         }

--- a/public_html/lists/admin/upgrade.php
+++ b/public_html/lists/admin/upgrade.php
@@ -175,11 +175,19 @@ if ($dbversion == VERSION && !$force) {
     // Update jQuery version referenced in public page HTML stored in the database
     if (version_compare($dbversion, '3.4.1', '<')) {
 
-        $pattern = "jquery-1.12.1.min.js";
+
+
         $replacement = "jquery.min.js";
 
         // Replace jQuery version in config table.
         $oldConfigFooter = getConfig('pagefooter');
+        $matches = null;
+
+        preg_match('/jquery-3.3.1.min.js/', $oldConfigFooter, $matches);
+        if ($matches[0] == "jquery-3.3.1.min.js"){
+            $pattern = "jquery-3.3.1.min.js";
+        } else $pattern = "jquery-1.12.1.min.js";
+
         $newConfigFooter = str_replace($pattern, $replacement, $oldConfigFooter);
         SaveConfig('pagefooter', $newConfigFooter);
 
@@ -190,6 +198,11 @@ if ($dbversion == VERSION && !$force) {
             $footersArray[] = $row['data'];
         }
         foreach ($footersArray as $key => $value) {
+            preg_match('/jquery-3.3.1.min.js/', $value, $matches);
+            if ($matches[0] == "jquery-3.3.1.min.js"){
+                $pattern = "jquery-3.3.1.min.js";
+            } else $pattern = "jquery-1.12.1.min.js";
+
             $newFooter = str_replace($pattern, $replacement, $value);
             Sql_Query(sprintf('update %s set data = "%s" where data = "%s" ', $GLOBALS['tables']['subscribepage_data'], sql_escape($newFooter), addslashes($value)));
         }

--- a/public_html/lists/admin/upgrade.php
+++ b/public_html/lists/admin/upgrade.php
@@ -175,12 +175,14 @@ if ($dbversion == VERSION && !$force) {
     // Update jQuery version referenced in public page HTML stored in the database
     if (version_compare($dbversion, '3.4.1', '<')) {
 
+        // The new filename does not hard-code the jQuery version number  
         $replacement = "jquery.min.js";
 
-        // Replace jQuery version in config table.
+        // Replace jQuery version public page footers in config table
         $oldConfigFooter = getConfig('pagefooter');
         $matches = null;
 
+        // Find and replace all references to version-specific jQuery files
         preg_match('/jquery-3.3.1.min.js/', $oldConfigFooter, $matches);
         if ($matches[0] == "jquery-3.3.1.min.js") {
             $pattern = "jquery-3.3.1.min.js";
@@ -197,6 +199,8 @@ if ($dbversion == VERSION && !$force) {
         while ($row = Sql_Fetch_Assoc($req)) {
             $footersArray[] = $row['data'];
         }
+
+        // Find and replace all references to version-specific jQuery files
         foreach ($footersArray as $key => $value) {
             preg_match('/jquery-3.3.1.min.js/', $value, $matches);
             if ($matches[0] == "jquery-3.3.1.min.js") {


### PR DESCRIPTION
Update footer of users that upgrade from 3.4.0 to 3.4.1, to prevent having blank subscribe pages due to "not found" file of jQuery.