### PR TITLE
Improvements to List Templates page

### DIFF
--- a/public_html/lists/admin/templates.php
+++ b/public_html/lists/admin/templates.php
@@ -28,7 +28,7 @@ if (!Sql_Affected_Rows()) {
 $defaulttemplate = getConfig('defaultmessagetemplate');
 $systemtemplate = getConfig('systemmessagetemplate');
 echo formStart('name="templates" class="templatesEdit" ');
-$ls = new WebblerListing(s('Existing templates'));
+$ls = new WebblerListing(s('Campaign templates'));
 while ($row = Sql_fetch_Array($req)) {
     $img_template = '<img src="images/no-image-template.png" />';
     if (file_exists('templates/'.$row['id'].'.jpg')) {

--- a/public_html/lists/admin/templates.php
+++ b/public_html/lists/admin/templates.php
@@ -36,11 +36,18 @@ while ($row = Sql_fetch_Array($req)) {
     }
     $element = $row['title'];
     $ls->addElement($element, PageUrl2('template&amp;id='.$row['id']));
-    $ls->setClass($element, 'row1');
-    $ls->addRow(
-        $element
-        , $img_template
-        , PageLinkDialogOnly(
+//  $imgcount = Sql_Fetch_Row_query(sprintf('select count(*) from %s where template = %d',
+//    $GLOBALS['tables']['templateimage'],$row['id']));
+//  $ls->addColumn($element,s('# imgs'),$imgcount[0]);
+//  $ls->addColumn($element,s('View'),);
+    $ls->addColumn($element, s('Campaign Default'),
+        sprintf('<input type=radio name="defaulttemplate" value="%d" %s onchange="document.templates.submit();">',
+            $row['id'], $row['id'] == $defaulttemplate ? 'checked' : ''));
+    $ls->addColumn($element, s('System').Help('systemmessage'),
+        sprintf('<input type=radio name="systemtemplate" value="%d" %s onchange="document.templates.submit();">',
+            $row['id'], $row['id'] == $systemtemplate ? 'checked' : ''));
+    $ls->addColumn($element, s('Action'), 
+        PageLinkDialogOnly(
             'viewtemplate&amp;id='.$row['id']
             , $GLOBALS['img_view']
         ).
@@ -53,16 +60,7 @@ while ($row = Sql_fetch_Array($req)) {
             .'</a>
         </span>'
     );
-//  $imgcount = Sql_Fetch_Row_query(sprintf('select count(*) from %s where template = %d',
-//    $GLOBALS['tables']['templateimage'],$row['id']));
-//  $ls->addColumn($element,s('# imgs'),$imgcount[0]);
-//  $ls->addColumn($element,s('View'),);
-    $ls->addColumn($element, s('Campaign Default'),
-        sprintf('<input type=radio name="defaulttemplate" value="%d" %s onchange="document.templates.submit();">',
-            $row['id'], $row['id'] == $defaulttemplate ? 'checked' : ''));
-    $ls->addColumn($element, s('System').Help('systemmessage'),
-        sprintf('<input type=radio name="systemtemplate" value="%d" %s onchange="document.templates.submit();">',
-            $row['id'], $row['id'] == $systemtemplate ? 'checked' : ''));
+    
 }
 echo $ls->display();
 

--- a/public_html/lists/admin/templates.php
+++ b/public_html/lists/admin/templates.php
@@ -41,11 +41,18 @@ while ($row = Sql_fetch_Array($req)) {
     $ls->addRow(
         $element
         , $img_template
-        , '<span class="button">'.PageLinkDialogOnly('viewtemplate&amp;id='.$row['id']
-        , $GLOBALS['img_view']).'</span>'.sprintf(
-            '<span class="delete"><a class="button" href="javascript:deleteRec(\'%s\');" title="'.s('delete').'">%s</a>'
-            , PageUrl2('templates', '', 'delete='.$row['id']), s('delete')
-        )
+        , PageLinkDialogOnly(
+            'viewtemplate&amp;id='.$row['id']
+            , $GLOBALS['img_view']
+        ).
+        '<span class="edit">'.
+            PageLinkButton('template', $GLOBALS['I18N']->get('Edit'), $row['id'], '', s('Edit'))
+        .'</span>
+        <span class="delete">
+            <a class="button" href="javascript:deleteRec(\''.PageUrl2('templates', '', 'delete='.$row['id']).'\')" title="'.s('delete').'">'.
+                s('delete')
+            .'</a>
+        </span>'
     );
 //  $imgcount = Sql_Fetch_Row_query(sprintf('select count(*) from %s where template = %d',
 //    $GLOBALS['tables']['templateimage'],$row['id']));

--- a/public_html/lists/admin/templates.php
+++ b/public_html/lists/admin/templates.php
@@ -29,6 +29,7 @@ $defaulttemplate = getConfig('defaultmessagetemplate');
 $systemtemplate = getConfig('systemmessagetemplate');
 echo formStart('name="templates" class="templatesEdit" ');
 $ls = new WebblerListing(s('Campaign templates'));
+$ls->setElementHeading('Template');
 while ($row = Sql_fetch_Array($req)) {
     $img_template = '<img src="images/no-image-template.png" />';
     if (file_exists('templates/'.$row['id'].'.jpg')) {

--- a/public_html/lists/admin/templates.php
+++ b/public_html/lists/admin/templates.php
@@ -38,10 +38,15 @@ while ($row = Sql_fetch_Array($req)) {
     $ls->addElement($element, PageUrl2('template&amp;id='.$row['id']));
     $ls->setClass($element, 'row1');
     $ls->addColumn($element, s('ID'), $row['id']);
-    $ls->addRow($element, $img_template,
-        '<span class="button">'.PageLinkDialogOnly('viewtemplate&amp;id='.$row['id'],
-            $GLOBALS['img_view']).'</span>'.sprintf('<span class="delete"><a class="button" href="javascript:deleteRec(\'%s\');" title="'.s('delete').'">%s</a>',
-            PageUrl2('templates', '', 'delete='.$row['id']), s('delete')));
+    $ls->addRow(
+        $element
+        , $img_template
+        , '<span class="button">'.PageLinkDialogOnly('viewtemplate&amp;id='.$row['id']
+        , $GLOBALS['img_view']).'</span>'.sprintf(
+            '<span class="delete"><a class="button" href="javascript:deleteRec(\'%s\');" title="'.s('delete').'">%s</a>'
+            , PageUrl2('templates', '', 'delete='.$row['id']), s('delete')
+        )
+    );
 //  $imgcount = Sql_Fetch_Row_query(sprintf('select count(*) from %s where template = %d',
 //    $GLOBALS['tables']['templateimage'],$row['id']));
 //  $ls->addColumn($element,s('# imgs'),$imgcount[0]);

--- a/public_html/lists/admin/templates.php
+++ b/public_html/lists/admin/templates.php
@@ -37,7 +37,6 @@ while ($row = Sql_fetch_Array($req)) {
     $element = $row['title'];
     $ls->addElement($element, PageUrl2('template&amp;id='.$row['id']));
     $ls->setClass($element, 'row1');
-    $ls->addColumn($element, s('ID'), $row['id']);
     $ls->addRow(
         $element
         , $img_template


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description

- Add explicit edit button for each template to the 'list templates' page
- Move edit buttons to same line, right side
- Remove unnecessary ID column
- Change table title
- Add unique title for first column

## Related Issue
<!--- If it fixes an open issue on Mantis , please include a link to the issue here. -->
[Mantis](https://mantis.phplist.org) :

![Selection_561](https://user-images.githubusercontent.com/695422/56380522-a6ddd500-6212-11e9-89e9-206fb77197b0.png)


