### PR TITLE
Make "Omit Invalid" option checked by default on  CSV import page

### DIFF
--- a/public_html/lists/admin/import2.php
+++ b/public_html/lists/admin/import2.php
@@ -721,7 +721,7 @@ if (count($email_list)) {
             </tr>
             <tr>
                 <td><?php echo $GLOBALS['I18N']->get('Omit Invalid') ?>:</td>
-                <td><input type="checkbox" name="omit_invalid" value="yes"/><?php echo Help('omitinvalid'); ?></td>
+                <td><input type="checkbox" name="omit_invalid" value="yes" checked="checked"/><?php echo Help('omitinvalid'); ?></td>
             </tr>
             <tr>
                 <td><?php echo $GLOBALS['I18N']->get('Assign Invalid') ?>:</td>


### PR DESCRIPTION
## Related Issue
<!--- If it fixes an open issue on Mantis, please include a link to the issue here. -->
Fix https://mantis.phplist.org/view.php?id=19862


