### PR TITLE
Add email validation on import via txt file

### DIFF
--- a/public_html/lists/admin/actions/import1.php
+++ b/public_html/lists/admin/actions/import1.php
@@ -5,7 +5,7 @@ verifyCsrfGetToken();
 @ob_end_flush();
 
 $file = $_GET['file'];
-if (!file_exists($GLOBALS['tmpdir'].'/'.$file) || !file_exists($GLOBALS['tmpdir'].'/'.$file.'.data')) {
+if (!file_exists($GLOBALS['tmpdir'] . '/' . $file) || !file_exists($GLOBALS['tmpdir'] . '/' . $file . '.data')) {
     echo s('File not found');
 
     return;
@@ -15,10 +15,10 @@ if ($_GET['omitinvalid']) {
     $omit_invalid = true;
 }
 
-$importdata = unserialize(file_get_contents($GLOBALS['tmpdir'].'/'.$file.'.data'));
+$importdata = unserialize(file_get_contents($GLOBALS['tmpdir'] . '/' . $file . '.data'));
 
-$email_list = file_get_contents($GLOBALS['tmpdir'].'/'.$file);
-include_once dirname(__FILE__).'/../inc/userlib.php';
+$email_list = file_get_contents($GLOBALS['tmpdir'] . '/' . $file);
+include_once dirname(__FILE__) . '/../inc/userlib.php';
 
 // Clean up email file
 $email_list = trim($email_list);
@@ -50,7 +50,7 @@ foreach ($email_list as $line) {
         list($email, $info) = explode(' ', $email);
     }
 
-    if (!is_email($email) && $omit_invalid){
+    if (!is_email($email) && $omit_invalid) {
         unset($email, $info);
         $count_invalid_emails++;
     }
@@ -73,7 +73,7 @@ $done = 0;
 $report = '';
 if ($hasinfo) {
     // we need to add an info attribute if it does not exist
-    $req = Sql_Query('select id from '.$tables['attribute'].' where name = "info"');
+    $req = Sql_Query('select id from ' . $tables['attribute'] . ' where name = "info"');
     if (!Sql_Affected_Rows()) {
         // it did not exist
         Sql_Query(sprintf('insert into %s (name,type,listorder,default_value,required,tablename)
@@ -82,10 +82,10 @@ if ($hasinfo) {
 }
 
 // which attributes were chosen, apply to all users
-$res = Sql_Query('select * from '.$tables['attribute']);
+$res = Sql_Query('select * from ' . $tables['attribute']);
 $attributes = array();
 while ($row = Sql_Fetch_Array($res)) {
-    $fieldname = 'attribute'.$row['id'];
+    $fieldname = 'attribute' . $row['id'];
     if (isset($importdata[$fieldname])) {
         if (is_array($importdata[$fieldname])) {
             $attributes[$row['id']] = implode(',', $importdata[$fieldname]);
@@ -105,7 +105,7 @@ foreach ($user_list as $email => $data) {
         //  print "$done / $todo<br/>";
         echo '<script type="text/javascript">
       var parentJQuery = window.parent.jQuery;
-      parentJQuery("#progressbar").updateProgress("' .$done.','.$todo.'");
+      parentJQuery("#progressbar").updateProgress("' . $done . ',' . $todo . '");
       </script>';
         flush();
     }
@@ -113,7 +113,7 @@ foreach ($user_list as $email => $data) {
     if (strlen($email) > 4) {
         $email = addslashes($email);
         // Annoying hack => Much too time consuming. Solution => Set email in users to UNIQUE()
-        $result = Sql_query('SELECT id,uniqid FROM '.$tables['user']." WHERE email = '$email'");
+        $result = Sql_query('SELECT id,uniqid FROM ' . $tables['user'] . " WHERE email = '$email'");
         if (Sql_affected_rows()) {
             // Email exist, remember some values to add them to the lists
             $user = Sql_fetch_array($result);
@@ -140,7 +140,7 @@ foreach ($user_list as $email => $data) {
 
             $query = sprintf('INSERT INTO %s (email,entered,confirmed,uniqid,htmlemail,uuid) values("%s",now(),%d,"%s","%s", "%s")',
                 $tables['user'], $email, $importdata['notify'] != 'yes', $uniqid,
-                isset($importdata['htmlemail']) ? '1' : '0', (string) uuid::generate(4));
+                isset($importdata['htmlemail']) ? '1' : '0', (string)uuid::generate(4));
             $result = Sql_query($query);
             $userid = Sql_Insert_Id($tables['user'], 'id');
 
@@ -164,12 +164,12 @@ foreach ($user_list as $email => $data) {
         $isBlackListed = isBlackListed($email);
         if (!$isBlackListed) {
             foreach ($importdata['importlists'] as $key => $listid) {
-                $query = 'insert ignore INTO '.$tables['listuser']." (userid,listid,entered) values($userid,$listid,now())";
+                $query = 'insert ignore INTO ' . $tables['listuser'] . " (userid,listid,entered) values($userid,$listid,now())";
                 $result = Sql_query($query);
                 // if the affected rows is 0, the user was already subscribed
                 $addition = $addition || Sql_Affected_Rows() == 1;
                 if (!empty($importdata['listname'][$key])) {
-                    $listoflists .= '  * '.$importdata['listname'][$key]."\n";
+                    $listoflists .= '  * ' . $importdata['listname'][$key] . "\n";
                 }
             }
             if ($addition) {
@@ -199,7 +199,7 @@ foreach ($user_list as $email => $data) {
             }
         }
         if (!$history_entry) {
-            $history_entry = "\n".$GLOBALS['I18N']->get('No data changed');
+            $history_entry = "\n" . $GLOBALS['I18N']->get('No data changed');
         }
         // check lists
         $listmembership = array();
@@ -207,18 +207,18 @@ foreach ($user_list as $email => $data) {
         while ($row = Sql_Fetch_Array($req)) {
             $listmembership[$row['listid']] = listName($row['listid']);
         }
-        $history_entry .= "\n".$GLOBALS['I18N']->get('List subscriptions:')."\n";
+        $history_entry .= "\n" . $GLOBALS['I18N']->get('List subscriptions:') . "\n";
         foreach ($old_listmembership as $key => $val) {
-            $history_entry .= $GLOBALS['I18N']->get('Was subscribed to:')." $val\n";
+            $history_entry .= $GLOBALS['I18N']->get('Was subscribed to:') . " $val\n";
         }
         foreach ($listmembership as $key => $val) {
-            $history_entry .= $GLOBALS['I18N']->get('Is now subscribed to:')." $val\n";
+            $history_entry .= $GLOBALS['I18N']->get('Is now subscribed to:') . " $val\n";
         }
         if (!count($listmembership)) {
-            $history_entry .= $GLOBALS['I18N']->get('Not subscribed to any lists')."\n";
+            $history_entry .= $GLOBALS['I18N']->get('Not subscribed to any lists') . "\n";
         }
 
-        addUserHistory($email, $GLOBALS['I18N']->get('Import by ').adminName(), $history_entry);
+        addUserHistory($email, $GLOBALS['I18N']->get('Import by ') . adminName(), $history_entry);
     } // end if
 } // end while
 
@@ -228,33 +228,33 @@ $dispemail = ($count_email_add == 1) ? $GLOBALS['I18N']->get('new email was') : 
 $dispemail2 = ($additional_emails == 1) ? $GLOBALS['I18N']->get('email was') : $GLOBALS['I18N']->get('emails were');
 
 if ($count_email_exist) {
-    $report .= '<br/> '.s('%d emails already existed in the database', $count_email_exist);
+    $report .= '<br/> ' . s('%d emails already existed in the database', $count_email_exist);
 }
-if ($count_invalid_emails !== 0 ) {
-    $report .= '<br/> '.s('%d invalid emails', $count_invalid_emails);
+if ($count_invalid_emails !== 0) {
+    $report .= '<br/> ' . s('%d invalid emails', $count_invalid_emails);
 }
 if (!$some && !$additional_emails) {
-    $report .= '<br/>'.s('All the emails already exist in the database.');
+    $report .= '<br/>' . s('All the emails already exist in the database.');
 } else {
-    $report .= "<br/>$count_email_add $dispemail ".s('succesfully imported to the database and added to')." $num_lists $displists.<br/>$additional_emails $dispemail2 ".$GLOBALS['I18N']->get('subscribed to the')." $displists";
+    $report .= "<br/>$count_email_add $dispemail " . s('succesfully imported to the database and added to') . " $num_lists $displists.<br/>$additional_emails $dispemail2 " . $GLOBALS['I18N']->get('subscribed to the') . " $displists";
 }
 if ($foundBlacklisted) {
-    $report .= '<br/>'.s('%d emails were found on the do-not-send-list and have not been added to the lists',
+    $report .= '<br/>' . s('%d emails were found on the do-not-send-list and have not been added to the lists',
             $foundBlacklisted);
 }
 
-$htmlupdate = $report.'<br/>'.PageLinkButton('import1', s('Import some more emails'));
+$htmlupdate = $report . '<br/>' . PageLinkButton('import1', s('Import some more emails'));
 $htmlupdate = str_replace("'", "\'", $htmlupdate);
 
 $status = '<script type="text/javascript">
       var parentJQuery = window.parent.jQuery;
       parentJQuery("#progressbar").progressbar("destroy");
       parentJQuery("#busyimage").hide();
-      parentJQuery("#progresscount").html(\'' .$htmlupdate.'\');
+      parentJQuery("#progresscount").html(\'' . $htmlupdate . '\');
       </script>';
 
-@unlink($GLOBALS['tmpdir'].'/'.$file);
-@unlink($GLOBALS['tmpdir'].'/'.$file.'.data');
+@unlink($GLOBALS['tmpdir'] . '/' . $file);
+@unlink($GLOBALS['tmpdir'] . '/' . $file . '.data');
 
 //  print ActionResult($report);
 foreach ($GLOBALS['plugins'] as $pluginname => $plugin) {

--- a/public_html/lists/admin/actions/import1.php
+++ b/public_html/lists/admin/actions/import1.php
@@ -10,6 +10,10 @@ if (!file_exists($GLOBALS['tmpdir'].'/'.$file) || !file_exists($GLOBALS['tmpdir'
 
     return;
 }
+$omit_invalid = false;
+if ($_GET['omitinvalid']) {
+    $omit_invalid = true;
+}
 
 $importdata = unserialize(file_get_contents($GLOBALS['tmpdir'].'/'.$file.'.data'));
 
@@ -45,7 +49,8 @@ foreach ($email_list as $line) {
     if (strpos($email, ' ')) {
         list($email, $info) = explode(' ', $email);
     }
-    if (!is_email($email)){
+
+    if (!is_email($email) && $omit_invalid){
         unset($email, $info);
         $count_invalid_emails++;
     }

--- a/public_html/lists/admin/actions/import1.php
+++ b/public_html/lists/admin/actions/import1.php
@@ -38,13 +38,17 @@ $email_list = explode("\n", $email_list);
 
 // Parse the lines into records
 $hasinfo = 0;
+$count_invalid_emails = 0;
 foreach ($email_list as $line) {
     $info = '';
     $email = trim($line); //# just take the entire line up to the first space to be the email
     if (strpos($email, ' ')) {
         list($email, $info) = explode(' ', $email);
     }
-
+    if (!is_email($email)){
+        unset($email, $info);
+        $count_invalid_emails++;
+    }
     //# actually looks like the "info" bit will get lost, but
     //# in a way, that doesn't matter
     $user_list[$email] = array(
@@ -220,6 +224,9 @@ $dispemail2 = ($additional_emails == 1) ? $GLOBALS['I18N']->get('email was') : $
 
 if ($count_email_exist) {
     $report .= '<br/> '.s('%d emails already existed in the database', $count_email_exist);
+}
+if ($count_invalid_emails !== 0 ) {
+    $report .= '<br/> '.s('%d invalid emails', $count_invalid_emails);
 }
 if (!$some && !$additional_emails) {
     $report .= '<br/>'.s('All the emails already exist in the database.');

--- a/public_html/lists/admin/import1.php
+++ b/public_html/lists/admin/import1.php
@@ -36,6 +36,8 @@ if (isset($_REQUEST['import'])) {
 
     $test_import = (isset($_POST['import_test']) && $_POST['import_test'] == 'yes');
 
+    $omit_invalid = (isset($_POST['omit_invalid']) && $_POST['omit_invalid'] == 'yes');
+
     if (empty($_FILES['import_file'])) {
         Fatal_Error($GLOBALS['I18N']->get('No file was specified. Maybe the file is too big?'));
 
@@ -118,10 +120,9 @@ if (isset($_REQUEST['import'])) {
         if (strpos($email, ' ')) {
             list($email, $info) = explode(' ', $email);
         }
-        if (!is_email($email)){
+        if (!is_email($email) && $omit_invalid){
             unset($email, $info);
         }
-
         //# actually looks like the "info" bit will get lost, but
         //# in a way, that doesn't matter
         $user_list[$email] = array(
@@ -171,7 +172,7 @@ if (isset($_REQUEST['import'])) {
                 count($import_lists)).'</h3>';
         echo $GLOBALS['img_busy'];
         echo '<div id="progresscount" style="width: 200; height: 50;">Progress</div>';
-        echo '<br/> <iframe id="import1" src="./?page=pageaction&action=import1&ajaxed=true&file='.urlencode(basename($newfile)).addCsrfGetToken().'" scrolling="no" height="50"></iframe>';
+        echo '<br/> <iframe id="import1" src="./?page=pageaction&action=import1&ajaxed=true&omitinvalid='.$omit_invalid.'&file='.urlencode(basename($newfile)).addCsrfGetToken().'" scrolling="no" height="50"></iframe>';
     } // end else
     // print '<p class="button">'.PageLink2("import1",$GLOBALS['I18N']->get('Import some more emails')).'</p>';
 } else {
@@ -231,6 +232,10 @@ if (isset($_REQUEST['import'])) {
                 <tr>
                     <td><?php echo $GLOBALS['I18N']->get('Test output:'); ?></td>
                     <td><input type="checkbox" name="import_test" value="yes" checked="checked"/></td>
+                </tr>
+                <tr>
+                    <td><?php echo s('Omit Invalid') ?>:</td>
+                    <td><input type="checkbox" name="omit_invalid" checked="checked" value="yes"/></td>
                 </tr>
                 <!--tr><td colspan="2"><?php echo $GLOBALS['I18N']->get('If you choose "send notification email" the subscribers you are adding will be sent the request for confirmation of subscription to which they will have to reply. This is recommended, because it will identify invalid emails.'); ?></td></tr>
 <tr><td><?php echo $GLOBALS['I18N']->get('Send Notification email'); ?><input type="radio" name="notify" value="yes"></td><td><?php echo $GLOBALS['I18N']->get('Make confirmed immediately'); ?><input type="radio" name="notify" value="no"></td></tr>

--- a/public_html/lists/admin/import1.php
+++ b/public_html/lists/admin/import1.php
@@ -1,10 +1,10 @@
 <?php
-require_once dirname(__FILE__).'/accesscheck.php';
+require_once dirname(__FILE__) . '/accesscheck.php';
 
 $subselect = '';
 $report = '';
 if (!ALLOW_IMPORT) {
-    echo '<p class="information">'.$GLOBALS['I18N']->get('import is not available').'</p>';
+    echo '<p class="information">' . $GLOBALS['I18N']->get('import is not available') . '</p>';
 
     return;
 }
@@ -21,7 +21,7 @@ if (!is_dir($GLOBALS['tmpdir']) || !is_writable($GLOBALS['tmpdir'])) {
 }
 //if (ini_get("open_basedir")) {
 if (!is_dir($GLOBALS['tmpdir']) || !is_writable($GLOBALS['tmpdir'])) {
-    Warn($GLOBALS['I18N']->get('The temporary directory for uploading is not writable, so import will fail').' ('.$GLOBALS['tmpdir'].')');
+    Warn($GLOBALS['I18N']->get('The temporary directory for uploading is not writable, so import will fail') . ' (' . $GLOBALS['tmpdir'] . ')');
 }
 
 $import_lists = getSelectedLists('importlists');
@@ -77,10 +77,10 @@ if (isset($_REQUEST['import'])) {
     }
 
     if ($_FILES['import_file'] && filesize($_FILES['import_file']['tmp_name']) > 10) {
-        $newfile = $GLOBALS['tmpdir'].'/import'.$GLOBALS['installation_name'].time();
+        $newfile = $GLOBALS['tmpdir'] . '/import' . $GLOBALS['installation_name'] . time();
         move_uploaded_file($_FILES['import_file']['tmp_name'], $newfile);
         if (!($fp = fopen($newfile, 'r'))) {
-            Fatal_Error($GLOBALS['I18N']->get('Cannot read file. It is not readable !').' ('.$newfile.')');
+            Fatal_Error($GLOBALS['I18N']->get('Cannot read file. It is not readable !') . ' (' . $newfile . ')');
 
             return;
         }
@@ -120,7 +120,7 @@ if (isset($_REQUEST['import'])) {
         if (strpos($email, ' ')) {
             list($email, $info) = explode(' ', $email);
         }
-        if (!is_email($email) && $omit_invalid){
+        if (!is_email($email) && $omit_invalid) {
             unset($email, $info);
         }
         //# actually looks like the "info" bit will get lost, but
@@ -140,8 +140,8 @@ if (isset($_REQUEST['import'])) {
 
     // View test output of emails
     if ($test_import) {
-        echo '<p>'.$GLOBALS['I18N']->get('There should only be ONE email per line.').' '.$GLOBALS['I18N']->get('If the output looks ok, go').' <a href="javascript:history.go(-1)">'.$GLOBALS['I18N']->get('back').'</a> '.$GLOBALS['I18N']->get('to resubmit for real').'.</p>
-        <p><strong>'.$GLOBALS['I18N']->get('Test output:').'</strong></p>
+        echo '<p>' . $GLOBALS['I18N']->get('There should only be ONE email per line.') . ' ' . $GLOBALS['I18N']->get('If the output looks ok, go') . ' <a href="javascript:history.go(-1)">' . $GLOBALS['I18N']->get('back') . '</a> ' . $GLOBALS['I18N']->get('to resubmit for real') . '.</p>
+        <p><strong>' . $GLOBALS['I18N']->get('Test output:') . '</strong></p>
         <hr/>';
         $i = 1;
         foreach ($user_list as $email => $data) {
@@ -151,7 +151,7 @@ if (isset($_REQUEST['import'])) {
                 $html = '';
                 foreach (array('info') as $item) {
                     if ($user_list[$email][$item]) {
-                        $html .= "$item -> ".$user_list[$email][$item].'<br/>';
+                        $html .= "$item -> " . $user_list[$email][$item] . '<br/>';
                     }
                 }
                 if ($html) {
@@ -166,23 +166,23 @@ if (isset($_REQUEST['import'])) {
 
         // Do import
     } else {
-        file_put_contents($newfile.'.data', serialize($_POST));
+        file_put_contents($newfile . '.data', serialize($_POST));
 
-        echo '<h3>'.s('Importing %d subscribers to %d lists, please wait', count($email_list),
-                count($import_lists)).'</h3>';
+        echo '<h3>' . s('Importing %d subscribers to %d lists, please wait', count($email_list),
+                count($import_lists)) . '</h3>';
         echo $GLOBALS['img_busy'];
         echo '<div id="progresscount" style="width: 200; height: 50;">Progress</div>';
-        echo '<br/> <iframe id="import1" src="./?page=pageaction&action=import1&ajaxed=true&omitinvalid='.$omit_invalid.'&file='.urlencode(basename($newfile)).addCsrfGetToken().'" scrolling="no" height="50"></iframe>';
+        echo '<br/> <iframe id="import1" src="./?page=pageaction&action=import1&ajaxed=true&omitinvalid=' . $omit_invalid . '&file=' . urlencode(basename($newfile)) . addCsrfGetToken() . '" scrolling="no" height="50"></iframe>';
     } // end else
     // print '<p class="button">'.PageLink2("import1",$GLOBALS['I18N']->get('Import some more emails')).'</p>';
 } else {
     echo FormStart(' enctype="multipart/form-data" name="import"');
 
-    if ( !isSuperUser()) {
+    if (!isSuperUser()) {
         $access = accessLevel('import1');
         switch ($access) {
             case 'owner':
-                $subselect = ' where owner = '.$_SESSION['logindetails']['id'];
+                $subselect = ' where owner = ' . $_SESSION['logindetails']['id'];
                 break;
             case 'all':
                 $subselect = '';
@@ -194,14 +194,14 @@ if (isset($_REQUEST['import'])) {
         }
     }
 
-    $result = Sql_query('SELECT id,name FROM '.$tables['list']."$subselect ORDER BY listorder");
+    $result = Sql_query('SELECT id,name FROM ' . $tables['list'] . "$subselect ORDER BY listorder");
     $c = 0;
     if (Sql_Affected_Rows() == 1) {
         $row = Sql_fetch_array($result);
-        printf('<input type="hidden" name="listname[%d]" value="%s"><input type="hidden" name="importlists[%d]" value="%d">'.$GLOBALS['I18N']->get('adding_users').' <b>%s</b>',
+        printf('<input type="hidden" name="listname[%d]" value="%s"><input type="hidden" name="importlists[%d]" value="%d">' . $GLOBALS['I18N']->get('adding_users') . ' <b>%s</b>',
             $c, stripslashes($row['name']), $c, $row['id'], stripslashes($row['name']));
     } else {
-        echo '<h3>'.s('Select the lists to add the emails to').'</h3>';
+        echo '<h3>' . s('Select the lists to add the emails to') . '</h3>';
         echo ListSelectHTML($import_lists, 'importlists', $subselect);
     } ?>
 
@@ -210,6 +210,7 @@ if (isset($_REQUEST['import'])) {
 
         var fieldstocheck = new Array();
         var fieldnames = new Array();
+
         function addFieldToCheck(value, name) {
             fieldstocheck[fieldstocheck.length] = value;
             fieldnames[fieldnames.length] = name;
@@ -242,8 +243,8 @@ if (isset($_REQUEST['import'])) {
 <tr><td colspan="2"><?php echo $GLOBALS['I18N']->get('If you are going to send notification to users, you may want to add a little delay between messages') ?></td></tr>
 <tr><td><?php echo $GLOBALS['I18N']->get('Notification throttle') ?>:</td><td><input type="text" name="throttle_import" size="5"> <?php echo $GLOBALS['I18N']->get('(default is nothing, will send as fast as it can)') ?></td></tr-->
                 <?php
-                include_once dirname(__FILE__).'/subscribelib2.php';
-    echo ListAllAttributes(); ?>
+                include_once dirname(__FILE__) . '/subscribelib2.php';
+                echo ListAllAttributes(); ?>
 
                 <tr>
                     <td><p class="input"><input type="submit" name="import"

--- a/public_html/lists/admin/import1.php
+++ b/public_html/lists/admin/import1.php
@@ -118,6 +118,9 @@ if (isset($_REQUEST['import'])) {
         if (strpos($email, ' ')) {
             list($email, $info) = explode(' ', $email);
         }
+        if (!is_email($email)){
+            unset($email, $info);
+        }
 
         //# actually looks like the "info" bit will get lost, but
         //# in a way, that doesn't matter


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description

1. Email validation on "import via a text file" (used "is_email" function)
2. Added "Count invalid emails" to import report
3. Validate emails only if "omit invalid" is checked (it's checked by default)

## Related Issue
<!--- If it fixes an open issue on Mantis (https://mantis.phplist.org), please include a link to the issue here. -->
https://mantis.phplist.org/view.php?id=19861
