### PR TITLE
Improve notification logic

### DIFF
--- a/public_html/lists/admin/index.php
+++ b/public_html/lists/admin/index.php
@@ -527,17 +527,9 @@ if (!$ajax && $page != 'login') {
 
         include 'updateLib.php';
 
-        if (showUpdateNotification()) {
-            try {
+        if (showUpdateNotification()  && (getCurrentphpListVersion()!==false) && extension_loaded('curl')) {
 
-                $updateNotif = checkForUpdate('init.php');
-
-            } catch (Exception $e) {
-
-                echo s('Error: '), $e->getMessage(), "\n";
-
-            }
-
+            $updateNotif = checkForUpdate('init.php');
             $moreInfo = '<a href="https://www.phplist.com/download?utm_source=pl' . VERSION . '&amp;utm_medium=updatedownload&amp;utm_campaign=phpList" title="' . s('Download the new version') . '" target="_blank">' . s('Download the new version') . '</a>';
 
             if (file_exists($updaterdir) && ALLOW_UPDATER) {

--- a/public_html/lists/admin/index.php
+++ b/public_html/lists/admin/index.php
@@ -521,13 +521,13 @@ if (!$ajax && $page != 'login') {
         echo Info($GLOBALS['I18N']->get('Running in testmode, no emails will be sent. Check your config file.'));
     }
 
-    if (!strpos(VERSION, 'dev')){
+    if (!strpos(VERSION, 'dev')) {
 
         $updaterdir = __DIR__ . '/../updater';
 
         include 'updateLib.php';
 
-        if (showUpdateNotification()  && (getCurrentphpListVersion()!==false) && extension_loaded('curl')) {
+        if (showUpdateNotification() && (getCurrentphpListVersion() !== false) && extension_loaded('curl')) {
 
             $updateNotif = checkForUpdate('init.php');
             $moreInfo = '<a href="https://www.phplist.com/download?utm_source=pl' . VERSION . '&amp;utm_medium=updatedownload&amp;utm_campaign=phpList" title="' . s('Download the new version') . '" target="_blank">' . s('Download the new version') . '</a>';

--- a/public_html/lists/admin/updateLib.php
+++ b/public_html/lists/admin/updateLib.php
@@ -4,7 +4,6 @@
  *
  * @param string $path Production version location
  * @return mixed
- * @throws Exception
  */
 function getCurrentphpListVersion($path = '')
 {
@@ -13,11 +12,11 @@ function getCurrentphpListVersion($path = '')
     preg_match_all('/define\(\"VERSION\",\"(.*)\"\);/', $version, $matches);
 
     if (isset($matches[1][0])) {
-
         return $matches[1][0];
+    } else {
+        return
+            false;
     }
-
-    throw new Exception(s('No production version found.'));
 }
 
 /**

--- a/public_html/lists/admin/updateLib.php
+++ b/public_html/lists/admin/updateLib.php
@@ -3,7 +3,7 @@
  * Get Current phpList Version.
  *
  * @param string $path Production version location
- * @return mixed
+ * @return string|bool
  */
 function getCurrentphpListVersion($path = '')
 {
@@ -14,8 +14,7 @@ function getCurrentphpListVersion($path = '')
     if (isset($matches[1][0])) {
         return $matches[1][0];
     } else {
-        return
-            false;
+        return false;
     }
 }
 


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
- Return false if a production version is not found. 
- Updated PHPDocs.
- Show notification only if the version is found in init.php.
- Check if curl extension is loaded before checking for update.
## Related Issue
<!--- If it fixes an open issue on Mantis (https://mantis.phplist.org), please include a link to the issue here. -->
TBA
