### PR TITLE
Add Updater repository to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,7 @@ install:
 
   # setup database and phplist
   - mkdir -p build/screenshot
+  - cd public_html/lists/ && wget https://github.com/phpList/updater/archive/master.tar.gz && tar -xzf master.tar.gz && mv updater-master updater && rm master.tar.gz && cd ../../
   - cd public_html/lists/admin/ui/ && wget https://github.com/phpList/phplist-ui-bootlist/archive/master.tar.gz
     && tar -xzf master.tar.gz && mv phplist-ui-bootlist-master phplist-ui-bootlist &&
     rm master.tar.gz && cd ../../../../


### PR DESCRIPTION
Add the Updater Repository to the Travis set up

Mantis: https://mantis.phplist.org/view.php?id=19924

To be merged after changes to https://github.com/phpList/updater/pull/75 are made.