### PR TITLE
Test links in public pages

### DIFF
--- a/tests/features/bootstrap/FeatureContext.php
+++ b/tests/features/bootstrap/FeatureContext.php
@@ -355,4 +355,12 @@ class FeatureContext extends MinkContext
     {
         $this->getSession()->wait(5000, '(0 === jQuery.active)');
     }
+    
+     /**
+     * @Given I go back
+     */
+    public function iGoBack()
+    {
+        $this->getSession()->getDriver()->back();
+    }
 }

--- a/tests/features/getting-started/publicPages.feature
+++ b/tests/features/getting-started/publicPages.feature
@@ -9,7 +9,7 @@ Scenario: Use public pages links
     Then I should see "Update your preferences"
     Then I should see "Unsubscribe from our Newsletters"
     Then I should see "Contact the administrator"
-    Given I follow "Subscribe to our newsletter"
+    Given I follow "Subscribe to our Newsletter"
     Then I should see "Email address *"
     Given I go back
     And I follow "Update your preferences"

--- a/tests/features/getting-started/publicPages.feature
+++ b/tests/features/getting-started/publicPages.feature
@@ -6,9 +6,9 @@ Feature: Use public pages as a subscriber
 Scenario: Use public pages links
     Given I am on "/lists"
     Then I should see "Subscribe to our Newsletter"
-    Then I should see "Update your preferences"
-    Then I should see "Unsubscribe from our Newsletters"
-    Then I should see "Contact the administrator"
+    And I should see "Update your preferences"
+    And I should see "Unsubscribe from our Newsletters"
+    And I should see "Contact the administrator"
     Given I follow "Subscribe to our Newsletter"
     Then I should see "Email address *"
     Given I go back

--- a/tests/features/getting-started/publicPages.feature
+++ b/tests/features/getting-started/publicPages.feature
@@ -1,0 +1,20 @@
+Feature: Use public pages as a subscriber
+  In order to interact with a phplist installation
+  As a subscriber
+  I need to be able to view and use public pages
+
+Scenario: Use public pages links
+    Given I am on "/lists"
+    Then I should see "Subscribe to our newsletter"
+    Then I should see "Update your preferences"
+    Then I should see "Unsubscribe from our Newsletters"
+    Then I should see "Contact the administrator"
+    Given I follow "Subscribe to our newsletter"
+    Then I should see "Email address *"
+    Given I go back
+    And I follow "Update your preferences"
+    Then I should see "This page requires a personal identification that can be found on each message that you receive."
+    Given I go back 
+    And I follow "Unsubscribe from our Newsletters"
+    Then I should see "Please enter a valid email address:"
+ 

--- a/tests/features/getting-started/publicPages.feature
+++ b/tests/features/getting-started/publicPages.feature
@@ -5,7 +5,7 @@ Feature: Use public pages as a subscriber
 
 Scenario: Use public pages links
     Given I am on "/lists"
-    Then I should see "Subscribe to our newsletter"
+    Then I should see "Subscribe to our Newsletter"
     Then I should see "Update your preferences"
     Then I should see "Unsubscribe from our Newsletters"
     Then I should see "Contact the administrator"


### PR DESCRIPTION
This is a simple test that looks for the default links on the public pages and checks if they lead to the corresponding pages.

Mantis: https://mantis.phplist.org/view.php?id=19925

