### PR TITLE
Make MySQL Sessions work with PHP 7.2

### DIFF
--- a/public_html/lists/admin/sessionlib.php
+++ b/public_html/lists/admin/sessionlib.php
@@ -12,21 +12,17 @@ if (basename($_SERVER['SCRIPT_NAME']) != 'index.php') {
     return;
 }
 
-@ini_set('session.save_handler', 'user');
 $SessionTableName = $GLOBALS['SessionTableName'];
 
-if (ini_get('session.save_handler') == 'user') {
-    session_set_save_handler(
-        'mysql_session_open',
-        'mysql_session_close',
-        'mysql_session_read',
-        'mysql_session_write',
-        'mysql_session_destroy',
-        'mysql_session_gc'
-    );
-} else {
-    //  @ini_set("session.save_handler","files");
-}
+
+session_set_save_handler(
+	'mysql_session_open',
+	'mysql_session_close',
+	'mysql_session_read',
+	'mysql_session_write',
+	'mysql_session_destroy',
+	'mysql_session_gc'
+);
 
 if (!Sql_Table_exists($GLOBALS['SessionTableName'])) {
     Sql_Create_Table($GLOBALS['SessionTableName'], array(
@@ -58,7 +54,7 @@ function mysql_session_read($SessionID)
 
         return $data[0];
     } else {
-        return false;
+        return '';
     }
 }
 


### PR DESCRIPTION
## Description
Fix 500 Error with no error message under PHP 7.2 and make MySQL session handler work.
- Tested to work with PHP 7.2 and 5.6
- ini_set('session.save_handler', 'user') not allowed in php 7.2
- The read callback must always return a session encoded (serialized) string, or an EMPTY STRING if there is no data to read.