### PR TITLE
Send sql error

### DIFF
--- a/public_html/lists/admin/send.php
+++ b/public_html/lists/admin/send.php
@@ -22,6 +22,8 @@ $some = 0;
 
 // handle commandline
 if ($GLOBALS['commandline']) {
+    $subselect = '';
+    $ownership = '';
     $cline = parseCline();
     reset($cline);
     if (!$cline || !is_array($cline) || !$cline['s'] || !$cline['l']) {


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
An sql syntax error was reported when running the send page from the command line

```
phpList - Database error 1064 while doing query  You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near '' at line 1
phpList - Sql error SELECT * FROM phplist_message where id = 148  and owner = 
```
This was caused by incorrect permissions being derived when phplist is run from the command line. There are two changes
1) The function accessLevel() returns 0 as a default value when the an admin is not logged-in.  The usual way of the calling code testing this value is through a switch statement with cases such as 'owner' or 'all'. But those comparisons are "loose" which means 0 will match the first case, usually 'owner', instead of falling through to the default. The change is for accessLevel() to return 'none' instead of 0.
2) Regardless of that problem, when run from the command line phplist doesn't seem to have a "current admin", so the result of accessLevel() is going to be wrong. The second change is to mimic 'all' permissions.
## Related Issue
<!--- If it fixes an open issue on Mantis (https://mantis.phplist.org), please include a link to the issue here. -->

## Screenshots (if appropriate):
