### PR TITLE
redundant JS causing error

### DIFF
--- a/public_html/lists/admin/export.php
+++ b/public_html/lists/admin/export.php
@@ -152,7 +152,3 @@ while ($row = Sql_fetch_array($res)) {
     </p></form>
 
 <?php
-
-if ($checked == 'nodate') {
-    echo '<script type="text/javascript">$("#exportdates").hide();</script>';
-}


### PR DESCRIPTION
## Description
This JS is not needed and causes an error as it runs before jQuery is loaded. 

The functionality is handled in admin/js/phplistapp.js around line 395

## Related Issue
NA

## Screenshots (if appropriate):
error from chrome
?page=export&tk=2cfda4e7e6cba9534ba3bdaec27d651a:289 Uncaught ReferenceError: $ is not defined