### PR TITLE
Remove duplicate page title on verify db structure page

### DIFF
--- a/public_html/lists/admin/dbcheck.php
+++ b/public_html/lists/admin/dbcheck.php
@@ -5,8 +5,6 @@ if (!defined('PHPLISTINIT')) {
     exit;
 }
 
-echo '<h3>'.s('Database structure check').'</h3>';
-
 unset($_SESSION['dbtables']);
 $pass = true;
 


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
Remove duplicate page title on verify db structure page
## Related Issue
<!--- If it fixes an open issue on Mantis (https://mantis.phplist.org), please include a link to the issue here. -->
https://mantis.phplist.org/view.php?id=19894
