### PR TITLE
Prevent subscribing to private lists

### DIFF
--- a/public_html/lists/admin/connect.php
+++ b/public_html/lists/admin/connect.php
@@ -1538,7 +1538,7 @@ function Help($topic, $text = '?')
 /**
  * Checks if the list is private based on if the specified list id is active or not.
  *
- * @param Integer $listid
+ * @param int $listid
  * @return bool
  */
 function isPrivateList($listid) {

--- a/public_html/lists/admin/connect.php
+++ b/public_html/lists/admin/connect.php
@@ -1535,6 +1535,31 @@ function Help($topic, $text = '?')
     return sprintf('<a href="help/?topic=%s" class="helpdialog" target="_blank">%s</a>', $topic, $text);
 }
 
+/**
+ * Checks if the list is private based on if the specified list id is active or not.
+ *
+ * @param Integer $listid
+ * @return bool
+ */
+function isPrivateList($listid) {
+
+    $activeVal = Sql_Query(sprintf('
+          SELECT active 
+          FROM   %s 
+          WHERE  id = %d',
+            $GLOBALS['tables']['list'], sql_escape($listid))
+    );
+
+    while ($row = Sql_Fetch_Row($activeVal)) {
+        $activeVal = $row[0];
+    }
+
+    if ($activeVal == 0) {
+        return true;
+    } else
+        return false;
+}
+
 // Debugging system, needs $debug = TRUE and $verbose = TRUE or $debug_log = {path} in config.php
 // Hint: When using log make sure the file gets write permissions
 

--- a/public_html/lists/admin/subscribelib2.php
+++ b/public_html/lists/admin/subscribelib2.php
@@ -245,7 +245,7 @@ if (isset($_POST['subscribe']) && is_email($_POST['email']) && $listsok && $allt
 
     if (isset($_POST['list']) && is_array($_POST['list'])) {
         foreach ($_POST['list'] as $key => $val) {
-            if ($val == 'signup' && !isPrivateList($key)) { // make sure that the list is private
+            if ($val == 'signup' && !isPrivateList($key)) { // make sure that the list is not private
                 $key = sprintf('%d', $key);
                 if (!empty($key)) {
                     $result = Sql_query(sprintf('replace into %s (userid,listid,entered) values(%d,%d,now())',

--- a/public_html/lists/admin/subscribelib2.php
+++ b/public_html/lists/admin/subscribelib2.php
@@ -245,7 +245,7 @@ if (isset($_POST['subscribe']) && is_email($_POST['email']) && $listsok && $allt
 
     if (isset($_POST['list']) && is_array($_POST['list'])) {
         foreach ($_POST['list'] as $key => $val) {
-            if ($val == 'signup') {
+            if ($val == 'signup' && !isPrivateList($key)) { // make sure that the list is private
                 $key = sprintf('%d', $key);
                 if (!empty($key)) {
                     $result = Sql_query(sprintf('replace into %s (userid,listid,entered) values(%d,%d,now())',
@@ -527,7 +527,7 @@ if (isset($_POST['subscribe']) && is_email($_POST['email']) && $listsok && $allt
     $lists = '';
     if (is_array($_POST['list'])) {
         foreach ($_POST['list'] as $key => $val) {
-            if ($val == 'signup') {
+            if ($val == 'signup' && !isPrivateList($key)) {
                 $result = Sql_query(sprintf('replace into %s (userid,listid,entered) values(%d,%d,now())',$GLOBALS['tables']['listuser'],$userid,$key));
 //        $lists .= "  * ".$_POST["listname"][$key]."\n";
             }
@@ -746,7 +746,7 @@ function ListAvailableLists($userid = 0, $lists_to_show = '')
 
 
     foreach ($showlists as $listid) {
-        if (preg_match("/^\d+$/", $listid)) {
+        if (preg_match("/^\d+$/", $listid) && !isPrivateList($listid)) {
             array_push($listset, $listid);
         }
     }


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
There was no check if the list is private or not when users subscribe/update preferences.
I created a function that determines if the list is private or not. Additional test is needed.

## Related Issue
<!--- If it fixes an open issue on Mantis (https://mantis.phplist.org), please include a link to the issue here. -->
TBA

