### PR TITLE
Updating a plugin fails due to php 7.3 PCRE change

### DIFF
--- a/public_html/lists/admin/plugins.php
+++ b/public_html/lists/admin/plugins.php
@@ -34,7 +34,7 @@ if (!empty($_POST['pluginurl']) && class_exists('ZipArchive')) {
 
     //# verify the url against known locations, and require it to be "zip".
     //# let's hope Github keeps this structure for a while
-    if (!preg_match('~^https?://github\.com/([\w-_]+)/([\w-_]+)/archive/(.+)\.zip$~i', $packageurl, $regs)) {
+    if (!preg_match('~^https?://github\.com/([\w\-_]+)/([\w\-_]+)/archive/(.+)\.zip$~i', $packageurl, $regs)) {
         echo Error(s('Invalid download URL, please reload the page and try again'));
 
         return;
@@ -365,7 +365,7 @@ $ls->usePanel(
 );
 echo $ls->display();
 
-/** 
+/**
  * Creates a link to the plugins page to show only plugins that meet the filter value.
  *
  * @param string $filterParam the URL query parameter
@@ -383,7 +383,7 @@ function filterLink($filterParam, $count, $caption)
         : $caption;
 }
 
-/** 
+/**
  * Query GitHub for the latest tag of a plugin.
  * Cache the result of each query for 24 hours to limit the number of API calls.
  *


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
Ensure that regex pattern is compatible with php 7.3

## Related Issue
<!--- If it fixes an open issue on Mantis (https://mantis.phplist.org), please include a link to the issue here. -->
https://mantis.phplist.org/view.php?id=20004
## Screenshots (if appropriate):
