### PR TITLE
Set travis build distribution to trusty to avoid old PHP version build errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+
 language: php
 
 cache:


### PR DESCRIPTION
Set the distribution used for travis to trusty to fix build failures with error The command "phpenv global 5.5" failed and exited with 1 during ., eg https://travis-ci.org/phpList/phplist-ui-bootlist/jobs/553261701.

See also: https://travis-ci.community/t/php-5-4-and-5-5-archives-missing/3723/2).