### PR TITLE
Mantis 20028 - When insert into message table fails the fatal error is not displayed by Trevellin theme

### DIFF
--- a/public_html/lists/admin/send_core.php
+++ b/public_html/lists/admin/send_core.php
@@ -58,7 +58,9 @@ if (!$id) {
     $id = Sql_Insert_Id();
     if (empty($id)) { // something went wrong creating the campaign
         Fatal_Error(s('Unable to create campaign, did you forget to upgrade the database?'));
-        exit;
+        $done = 1;
+
+        return;
     }
 
     if (isset($_GET['list'])) {


### PR DESCRIPTION


<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
When inserting into message table fails return to the caller instead of exiting, which is the same approach as used elsewhere.
## Related Issue
<!--- If it fixes an open issue on Mantis (https://mantis.phplist.org), please include a link to the issue here. -->
https://mantis.phplist.org/view.php?id=20028
## Screenshots (if appropriate):
Trevellin now displays the error
![trevellin message insert fatal error](https://user-images.githubusercontent.com/3147688/61529473-4df02980-aa19-11e9-9564-cb83e19e2920.png)
Dressprow displays the error
![dressprow message insert fatal error](https://user-images.githubusercontent.com/3147688/61529478-50528380-aa19-11e9-85c2-f8c02037b16b.png)
