### PR TITLE
add trusty for the build dist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: php
 
 cache:


### PR DESCRIPTION
Not sure why travis is now using xenial on the build set up so, a simple PR from @marianaballa is failing the checks: https://travis-ci.org/phpList/phplist3/builds/563051547

