### PR TITLE
Add a 'clicks' overview tab to the subscriber profile page

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: php
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,15 +18,15 @@ matrix:
         - php: '7.1'
           env: BROWSER=goutte TAGS="~javascript && ~@first-run && ~@wip"
         - php: '7.1'
-          env: BROWSER=chrome TAGS="~@first-run && ~@wip"
+          env: BROWSER=chrome TAGS="~javascript && ~@first-run && ~@wip"
         - php: '7.2'
           env: BROWSER=goutte TAGS="~javascript && ~@first-run && ~@wip"
         - php: '7.2'
-          env: BROWSER=chrome TAGS="~@first-run && ~@wip && ~javascript"
+          env: BROWSER=chrome TAGS="~javascript && ~@first-run && ~@wip"
         - php: '7.3'
           env: BROWSER=goutte TAGS="~javascript && ~@first-run && ~@wip"
         - php: '7.3'
-          env: BROWSER=chrome TAGS="~@first-run && ~@wip"
+          env: BROWSER=chrome TAGS="~javascript && ~@first-run && ~@wip"
 
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
         - php: '7.2'
           env: BROWSER=goutte TAGS="~javascript && ~@first-run && ~@wip"
         - php: '7.2'
-          env: BROWSER=chrome TAGS="~@first-run && ~@wip"
+          env: BROWSER=chrome TAGS="~@first-run && ~@wip && ~javascript"
         - php: '7.3'
           env: BROWSER=goutte TAGS="~javascript && ~@first-run && ~@wip"
         - php: '7.3'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Please note that this project is released with a [Contributor Code of Conduct](h
 
 # Reporting an Issue
 
-You can report an issue here in Github, or use our issue tracker at https://mantis.phplist.com.
+You can report an issue here in Github or use our issue tracker at https://mantis.phplist.com.
 Most issues are in Mantis, and it may be best to check around to see if your issue has been reported before.
 
 Please follow the guidelines below when creating an issue so that your issue can be more promptly resolved:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,18 +4,20 @@
 
 :+1::tada: Many thanks for taking the time to contribute! :tada::+1:
 
+# Contributor Code of Conduct
+Please note that this project is released with a [Contributor Code of Conduct](https://github.com/phpList/core/blob/master/CODE_OF_CONDUCT.md). By participating in this project, you agree to abide by its terms.
 
 # Reporting an Issue
 
-You can report an issue here in Github, or use our issue tracker at https://mantis.phplist.com
+You can report an issue here in Github, or use our issue tracker at https://mantis.phplist.com.
 Most issues are in Mantis, and it may be best to check around to see if your issue has been reported before.
 
 Please follow the guidelines below when creating an issue so that your issue can be more promptly resolved:
 
 * Provide information including the version of PHP and phpList, the type of operating system and Web server, MySQL version, browser type and version;
-* Provide the **complete** error call stack if available. A screenshot to explain the issue is very welcome.
+* Provide the **complete** error call stack if available. A screenshot to explain the issue is very welcomed.
 * Describe the steps for reproducing the issue. 
-* If possible try to reproduce this error on our demo at https://demo.phplist.com/lists/admin/
+* If possible, try to reproduce this error on our demo at https://demo.phplist.com/lists/admin/
 
 **Do not report an issue if**
 
@@ -24,7 +26,7 @@ Please follow the guidelines below when creating an issue so that your issue can
 
 **Avoid duplicated issues**
 
-Before you report an issue, please search through [existing issues](https://mantis.phplist.com) to see if your issue is already reported or fixed to make sure you are not reporting a duplicated issue. 
+Before you report an issue, please search through [existing issues on Mantis](https://mantis.phplist.com) and [GitHub](https://github.com/phpList/phplist3/issues) to see if your issue is already reported or fixed to make sure you are not reporting a duplicated issue. 
 Also, make sure you have the latest version of phpList and see if the issue still exists.
 
 
@@ -39,4 +41,4 @@ There are a few guidelines that we need contributors to follow so that we can ha
 * Before we can accept your patches, you'll have to sign the Contributors License Agreement 
   * https://www.phplist.com/cla
 * Make sure there is an issue created for the thing you are working on if it requires significant effort to fix
-* Open a pull request
+* Open a Pull Request

--- a/public_html/lists/admin/actions/campaigns.php
+++ b/public_html/lists/admin/actions/campaigns.php
@@ -52,24 +52,48 @@ if ($num) {
     $ls->setElementHeading(s('Campaign Id'));
 
     while ($msg = Sql_Fetch_Array($msgs)) {
-        $ls->addElement($msg['messageid'],
-            PageURL2('message', s('view'), 'id='.$msg['messageid']));
+        $ls->addElement(
+            $msg['messageid']
+            , PageURL2(
+                'message'
+                , s('view')
+                , 'id='.$msg['messageid']
+            )
+        );
+        
         if (defined('CLICKTRACK') && CLICKTRACK) {
             $clicksreq = Sql_Fetch_Row_Query(sprintf('select sum(clicked) as numclicks from %s where userid = %s and messageid = %s',
                 $GLOBALS['tables']['linktrack_uml_click'], $user['id'], $msg['messageid']));
             $clicks = sprintf('%d', $clicksreq[0]);
             if ($clicks) {
-                $ls->addColumn($msg['messageid'], s('clicks'),
-                    PageLink2('userclicks&amp;userid='.$user['id'].'&amp;msgid='.$msg['messageid'], $clicks));
+                $ls->addColumn(
+                    $msg['messageid'], s('clicks')
+                    , PageLink2(
+                        'userclicks&amp;userid='.$user['id'].'&amp;msgid='.$msg['messageid']
+                        , $clicks
+                    )
+                );
             } else {
                 $ls->addColumn($msg['messageid'], s('clicks'), 0);
             }
         }
 
-        $ls->addColumn($msg['messageid'], s('sent'), formatDateTime($msg['entered'], 1));
+        $ls->addColumn(
+            $msg['messageid']
+            , s('sent')
+            , formatDateTime($msg['entered'], 1)
+        );
         if (!$msg['notviewed']) {
-            $ls->addColumn($msg['messageid'], s('viewed'), formatDateTime($msg['viewed'], 1));
-            $ls->addColumn($msg['messageid'], s('Response time'), secs2time($msg['responsetime']));
+            $ls->addColumn(
+                $msg['messageid']
+                , s('viewed')
+                , formatDateTime($msg['viewed'], 1)
+            );
+            $ls->addColumn(
+                $msg['messageid']
+                , s('Response time')
+                , secs2time($msg['responsetime'])
+            );
             $resptime += $msg['responsetime'];
             $totalresp += 1;
         }

--- a/public_html/lists/admin/actions/campaigns.php
+++ b/public_html/lists/admin/actions/campaigns.php
@@ -23,9 +23,24 @@ $user = sql_fetch_array($result);
 
 $ls = new WebblerListing(s('Campaigns'));
 if (Sql_Table_Exists($GLOBALS['tables']['usermessage'])) {
-    $msgs = Sql_Query(sprintf('select messageid,entered,viewed,(viewed = 0 or viewed is null) as notviewed,
-abs(unix_timestamp(entered) - unix_timestamp(viewed)) as responsetime from %s where userid = %d and status = "sent" order by entered desc',
-        $GLOBALS['tables']['usermessage'], $user['id']));
+    $msgs = Sql_Query('
+        SELECT
+            messageid,
+            entered,
+            viewed,
+            (viewed = 0 OR viewed IS NULL) AS notviewed,
+            ABS(
+                UNIX_TIMESTAMP(entered) - UNIX_TIMESTAMP(viewed)
+            ) AS responsetime
+        FROM
+            '.$GLOBALS['tables']['usermessage'].'
+        WHERE
+            userid = '.$user['id'].' AND
+        STATUS
+            = "sent"
+        ORDER BY
+            entered
+        DESC');
     $num = Sql_Affected_Rows();
 } else {
     $num = 0;

--- a/public_html/lists/admin/actions/userlinkclicks.php
+++ b/public_html/lists/admin/actions/userlinkclicks.php
@@ -54,7 +54,7 @@ if (Sql_Table_Exists($GLOBALS['tables']['usermessage'])) {
 } else {
     $num = 0;
 }
-printf('%d '.s('links clicked by this subscriber').'<br/>', $num);
+printf('%d '.s('total clicks by this subscriber').'<br/>', $num);
 if ($num) {
     $resptime = 0;
     $totalresp = 0;

--- a/public_html/lists/admin/actions/userlinkclicks.php
+++ b/public_html/lists/admin/actions/userlinkclicks.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * Ajax-called script to fetch list of URLs clicked by a given subscriber
+ */
+
+require_once dirname(__FILE__).'/../accesscheck.php';
+if (!defined('PHPLISTINIT')) {
+    exit;
+}
+
+// If click tracking is disabled, then return nothing
+if ( !defined('CLICKTRACK') || !CLICKTRACK ) {
+    echo s('Clicktracking is disabled');
+    return;
+}
+
+if (!$_GET['id']) {
+    Fatal_Error(s('no such User'));
+
+    return;
+} else {
+    $id = sprintf('%d', $_GET['id']);
+}
+$status = "";
+
+$result = Sql_query("SELECT * FROM {$GLOBALS['tables']['user']} where id = $id");
+if (!Sql_Affected_Rows()) {
+    Fatal_Error(s('no such User'));
+
+    return;
+}
+$user = sql_fetch_array($result);
+
+$ls = new WebblerListing(s('Clicks'));
+if (Sql_Table_Exists($GLOBALS['tables']['usermessage'])) {
+    $urls = Sql_Query('
+        SELECT 
+            luc.messageid
+            , luc.userid
+            , firstclick
+            , latestclick
+            , fwd.url AS url
+            , luc.forwardid
+        FROM 
+            '.$GLOBALS['tables']['linktrack_uml_click'].' AS luc
+        LEFT JOIN
+            '.$GLOBALS['tables']['linktrack_forward'].' AS fwd 
+                ON fwd.id = luc.forwardid
+        WHERE 
+            luc.userid = '.$user['id']
+    );
+    $num = Sql_Affected_Rows();
+} else {
+    $num = 0;
+}
+printf('%d '.s('links clicked by this subscriber').'<br/>', $num);
+if ($num) {
+    $resptime = 0;
+    $totalresp = 0;
+    $ls->setElementHeading(s('URL'));
+
+    while ($url = Sql_Fetch_Array($urls)) {
+        $ls->addElement(
+            shortenTextDisplay($url['url'], 150)
+            , PageURL2('uclicks&id='.$url['forwardid'])
+        );
+
+        $clicksreq = Sql_Fetch_Row_Query('
+            SELECT
+                SUM(clicked) AS numclicks
+            FROM
+                '.$GLOBALS['tables']['linktrack_uml_click'].'
+            WHERE
+                userid = '.$user['id'].'
+                AND messageid = '.$url['messageid']
+        );
+
+        $clicks = sprintf('%d', $clicksreq[0]);
+
+        if ($clicks) {
+            $ls->addColumn(
+                $url['url']
+                , s('clicks')
+                , PageLink2(
+                    'userclicks&amp;userid='.$user['id'].'&amp;msgid='.$url['messageid']
+                    , number_format($clicks)
+                )
+            );
+        }
+    }
+}
+
+echo $ls->display();

--- a/public_html/lists/admin/actions/userlinkclicks.php
+++ b/public_html/lists/admin/actions/userlinkclicks.php
@@ -73,7 +73,7 @@ if ($num) {
                 '.$GLOBALS['tables']['linktrack_uml_click'].'
             WHERE
                 userid = '.$user['id'].'
-                AND messageid = '.$url['messageid']
+                AND forwardid = '.$url['forwardid']
         );
 
         $clicks = sprintf('%d', $clicksreq[0]);

--- a/public_html/lists/admin/bounces.php
+++ b/public_html/lists/admin/bounces.php
@@ -42,13 +42,13 @@ if (ALLOW_DELETEBOUNCE && isset($_GET['action']) && $_GET['action']) {
         case 'deleteunidentified':
             $req = Sql_Query(sprintf('delete from %s where status = "unidentified bounce" and date_add(date,interval 2 month) < now()',
                 $tables['bounce']));
-            $count = Sql_Num_Rows($req);
+            $count = Sql_Affected_Rows($req);
             $actionresult = s('%d unidentified bounces older than 2 months have been deleted', $count);
             break;
         case 'deleteprocessed':
             $req = Sql_Query(sprintf('delete from %s where comment != "not processed" and date_add(date,interval 2 month) < now()',
                 $tables['bounce']));
-            $count = Sql_Num_Rows($req);
+            $count = Sql_Affected_Rows($req);
             $actionresult = s('%d processed bounces older than 2 months have been deleted', $count);
             break;
         case 'deleteall':
@@ -88,17 +88,17 @@ if ($total > MAX_USER_PP) {
     $paging = simplePaging("bounces&amp;tab=$currentTab", $start, $total, MAX_USER_PP,
         $status.' '.$GLOBALS['I18N']->get('bounces'));
     $query = sprintf('
-        select 
-            * 
-        from 
-            %s 
-        where 
-            status %s "unidentified bounce" 
-        order by 
-            date desc 
-        limit 
-            %s 
-        offset 
+        select
+            *
+        from
+            %s
+        where
+            status %s "unidentified bounce"
+        order by
+            date desc
+        limit
+            %s
+        offset
             %s'
         , $tables['bounce']
         , $status_compare
@@ -109,13 +109,13 @@ if ($total > MAX_USER_PP) {
 } else {
     $paging = '';
     $query = sprintf('
-        select 
-            * 
-        from 
-            %s 
-        where 
-            status '.$status_compare.' "unidentified bounce" 
-        order by 
+        select
+            *
+        from
+            %s
+        where
+            status '.$status_compare.' "unidentified bounce"
+        order by
             date desc'
         , $tables['bounce']
     );
@@ -188,7 +188,7 @@ while ($bounce = Sql_fetch_array($result)) {
     */
     $ls->addColumn($element, s('Campaign'), $messageid);
 
-    
+
     if (
         preg_match("#([\d]+) bouncecount increased#", $bounce['comment'], $regs)
         OR preg_match("#([\d]+) marked unconfirmed#", $bounce['comment'], $regs)
@@ -196,11 +196,11 @@ while ($bounce = Sql_fetch_array($result)) {
         // Fetch additional data to be able to print subscriber address
         $userdata = Sql_Fetch_Array_Query(
             sprintf('
-                select 
-                    * 
-                from 
-                    %s 
-                where 
+                select
+                    *
+                from
+                    %s
+                where
                     id = %d'
                 , $GLOBALS['tables']['user']
                 , $regs[1]

--- a/public_html/lists/admin/locale/templates/phplist.pot
+++ b/public_html/lists/admin/locale/templates/phplist.pot
@@ -185,7 +185,7 @@ msgid "age"
 msgstr ""
 
 #: public_html/lists/admin/send.php:115 public_html/lists/admin/spage.php:101
-#: public_html/lists/admin/send_core.php:949
+#: public_html/lists/admin/send_core.php:951
 #: public_html/lists/admin/eventlog.php:113
 #: public_html/lists/admin/admins.php:106
 #: public_html/lists/admin/bouncerules.php:111
@@ -431,7 +431,7 @@ msgid "List all Messages"
 msgstr ""
 
 #: public_html/lists/admin/home.php:249
-#: public_html/lists/admin/send_core.php:388
+#: public_html/lists/admin/send_core.php:390
 msgid "processqueue"
 msgstr ""
 
@@ -1238,7 +1238,7 @@ msgid "Remote queue processing has been activated successfully"
 msgstr ""
 
 #: public_html/lists/admin/lib.php:2042
-#: public_html/lists/admin/send_core.php:390
+#: public_html/lists/admin/send_core.php:392
 msgid "view progress"
 msgstr ""
 
@@ -1367,7 +1367,7 @@ msgstr ""
 #: public_html/lists/admin/statsoverview.php:97
 #: public_html/lists/admin/messages.php:12
 #: public_html/lists/admin/messages.php:17
-#: public_html/lists/admin/send_core.php:732
+#: public_html/lists/admin/send_core.php:734
 #: public_html/lists/admin/message.php:105
 #: public_html/lists/admin/userclicks.php:84
 #: public_html/lists/admin/userclicks.php:103
@@ -2463,14 +2463,14 @@ msgid "to email addresses"
 msgstr ""
 
 #: public_html/lists/admin/template.php:359
-#: public_html/lists/admin/send_core.php:994
+#: public_html/lists/admin/send_core.php:996
 #: public_html/lists/admin/spageedit.php:308
 msgid "(comma separate addresses - all must be existing subscribers)"
 msgstr ""
 
 #: public_html/lists/admin/template.php:360
-#: public_html/lists/admin/send_core.php:998
-#: public_html/lists/admin/send_core.php:1362
+#: public_html/lists/admin/send_core.php:1000
+#: public_html/lists/admin/send_core.php:1364
 #: public_html/lists/admin/spageedit.php:309
 msgid "Send Test"
 msgstr ""
@@ -3246,7 +3246,7 @@ msgstr ""
 #: public_html/lists/admin/messages.php:205
 #: public_html/lists/admin/messages.php:265
 #: public_html/lists/admin/messages.php:280
-#: public_html/lists/admin/send_core.php:501
+#: public_html/lists/admin/send_core.php:503
 #: public_html/lists/admin/import3.php:382
 #: public_html/lists/admin/initialise.php:120
 #: public_html/lists/admin/initialise.php:163
@@ -3258,7 +3258,7 @@ msgid "Requeuing"
 msgstr ""
 
 #: public_html/lists/admin/messages.php:257
-#: public_html/lists/admin/send_core.php:1306
+#: public_html/lists/admin/send_core.php:1308
 #: public_html/lists/admin/message.php:57
 msgid ""
 "This campaign is scheduled to stop sending in the past. No mails will be "
@@ -3266,9 +3266,9 @@ msgid ""
 msgstr ""
 
 #: public_html/lists/admin/messages.php:259
-#: public_html/lists/admin/send_core.php:373
-#: public_html/lists/admin/send_core.php:1301
-#: public_html/lists/admin/send_core.php:1307
+#: public_html/lists/admin/send_core.php:375
+#: public_html/lists/admin/send_core.php:1303
+#: public_html/lists/admin/send_core.php:1309
 #: public_html/lists/admin/message.php:59
 msgid "Review Scheduling"
 msgstr ""
@@ -3310,7 +3310,7 @@ msgid "and %d more"
 msgstr ""
 
 #: public_html/lists/admin/messages.php:450
-#: public_html/lists/admin/send_core.php:578
+#: public_html/lists/admin/send_core.php:580
 #: public_html/lists/admin/list.php:229 public_html/lists/admin/user.php:538
 #: public_html/lists/admin/spageedit.php:369
 msgid "Lists"
@@ -3350,7 +3350,7 @@ msgid "total"
 msgstr ""
 
 #: public_html/lists/admin/messages.php:570
-#: public_html/lists/admin/send_core.php:836
+#: public_html/lists/admin/send_core.php:838
 #: public_html/lists/admin/actions/mclicks.php:94
 #: public_html/lists/admin/userclicks.php:253
 #: public_html/lists/admin/mclicks.php:142
@@ -3358,7 +3358,7 @@ msgid "text"
 msgstr ""
 
 #: public_html/lists/admin/messages.php:570
-#: public_html/lists/admin/send_core.php:833
+#: public_html/lists/admin/send_core.php:835
 #: public_html/lists/admin/actions/mclicks.php:94
 #: public_html/lists/admin/mclicks.php:141
 msgid "html"
@@ -3577,462 +3577,462 @@ msgstr ""
 msgid "Unable to create campaign, did you forget to upgrade the database?"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:115
+#: public_html/lists/admin/send_core.php:117
 #: public_html/lists/admin/index.php:760 public_html/lists/admin/index.php:781
 msgid "Access Denied"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:123
-#: public_html/lists/admin/send_core.php:1344
+#: public_html/lists/admin/send_core.php:125
+#: public_html/lists/admin/send_core.php:1346
 msgid "Send Campaign"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:154
+#: public_html/lists/admin/send_core.php:156
 msgid ""
 "You should not paste the results of a test message back into the editor<br/"
 ">This will break the click-track statistics, and overload the server."
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:199
+#: public_html/lists/admin/send_core.php:201
 msgid ""
 "Warning: You indicated the content was not HTML, but there were  some HTML  "
 "tags in it. This  may  cause  errors"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:243
+#: public_html/lists/admin/send_core.php:245
 msgid ""
 "You are trying to send a remote URL, but PEAR::HTTP_Request or CURL is not "
 "available, so this will fail"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:283
+#: public_html/lists/admin/send_core.php:285
 msgid "Mime Type is longer than 255 characters, this is trouble"
-msgstr ""
-
-#: public_html/lists/admin/send_core.php:318
-#, php-format
-msgid "Attachment %d succesfully added"
 msgstr ""
 
 #: public_html/lists/admin/send_core.php:320
 #, php-format
+msgid "Attachment %d succesfully added"
+msgstr ""
+
+#: public_html/lists/admin/send_core.php:322
+#, php-format
 msgid "Adding attachment %d failed"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:323
+#: public_html/lists/admin/send_core.php:325
 msgid "Uploaded file not properly received, empty file"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:335
+#: public_html/lists/admin/send_core.php:337
 msgid "Adding attachment"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:348
+#: public_html/lists/admin/send_core.php:350
 msgid "Campaign saved as draft"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:354
+#: public_html/lists/admin/send_core.php:356
 msgid "Campaign added"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:371
-#: public_html/lists/admin/send_core.php:1300
+#: public_html/lists/admin/send_core.php:373
+#: public_html/lists/admin/send_core.php:1302
 msgid ""
 "This campaign is scheduled to stop sending before the embargo time. No mails "
 "will be sent."
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:381
+#: public_html/lists/admin/send_core.php:383
 msgid "Campaign queued"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:399
+#: public_html/lists/admin/send_core.php:401
 msgid "Sorry, you used invalid characters in the Subject field."
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:401
+#: public_html/lists/admin/send_core.php:403
 msgid "Sorry, you used invalid characters in the From field."
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:403
+#: public_html/lists/admin/send_core.php:405
 msgid "Please enter a from line."
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:405
+#: public_html/lists/admin/send_core.php:407
 msgid "Please enter a message"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:407
+#: public_html/lists/admin/send_core.php:409
 msgid "Please enter a subject"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:409
+#: public_html/lists/admin/send_core.php:411
 msgid "Error: you can use an attribute in one rule only"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:411
+#: public_html/lists/admin/send_core.php:413
 msgid "Please select the list(s) to send the campaign to"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:443
+#: public_html/lists/admin/send_core.php:445
 #, php-format
 msgid "You can send a test mail once every %d seconds"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:446
+#: public_html/lists/admin/send_core.php:448
 msgid "Sending test mails is currently not available"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:451
+#: public_html/lists/admin/send_core.php:453
 msgid "No target email addresses listed for testing."
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:468
+#: public_html/lists/admin/send_core.php:470
 #, php-format
 msgid "There is a maximum of %d test emails allowed"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:499
+#: public_html/lists/admin/send_core.php:501
 msgid "Sent test mail to"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:503
+#: public_html/lists/admin/send_core.php:505
 msgid "success"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:510
+#: public_html/lists/admin/send_core.php:512
 msgid "Email address not found to send test message."
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:512
+#: public_html/lists/admin/send_core.php:514
 msgid "add"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:538
+#: public_html/lists/admin/send_core.php:540
 msgid "Removed Attachment "
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:560
-#: public_html/lists/admin/send_core.php:584
-#: public_html/lists/admin/send_core.php:708
+#: public_html/lists/admin/send_core.php:562
+#: public_html/lists/admin/send_core.php:586
+#: public_html/lists/admin/send_core.php:710
 msgid "Content"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:563
+#: public_html/lists/admin/send_core.php:565
 msgid "Text"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:567
+#: public_html/lists/admin/send_core.php:569
 msgid "Forward"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:570
+#: public_html/lists/admin/send_core.php:572
 msgid "Format"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:573
+#: public_html/lists/admin/send_core.php:575
 msgid "Attach"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:576
+#: public_html/lists/admin/send_core.php:578
 msgid "Scheduling"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:606
+#: public_html/lists/admin/send_core.php:608
 msgid "Finish"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:650
+#: public_html/lists/admin/send_core.php:652
 msgid "What is prepare a message"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:697
+#: public_html/lists/admin/send_core.php:699
 msgid "Campaign subject"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:700
+#: public_html/lists/admin/send_core.php:702
 msgid "From Line"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:709
+#: public_html/lists/admin/send_core.php:711
 msgid "Send a Webpage"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:710
-#: public_html/lists/admin/send_core.php:877
-#: public_html/lists/admin/send_core.php:878
+#: public_html/lists/admin/send_core.php:712
+#: public_html/lists/admin/send_core.php:879
+#: public_html/lists/admin/send_core.php:880
 msgid "Compose Message"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:721
+#: public_html/lists/admin/send_core.php:723
 msgid "Send a Webpage - URL"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:741
+#: public_html/lists/admin/send_core.php:743
 #, php-format
 msgid "phpList operates in the time zone \"%s\""
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:744
+#: public_html/lists/admin/send_core.php:746
 msgid "Dates and times are relative to the Server Time"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:744
+#: public_html/lists/admin/send_core.php:746
 msgid "Current Server Time is"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:748
+#: public_html/lists/admin/send_core.php:750
 msgid "Embargoed Until"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:750
+#: public_html/lists/admin/send_core.php:752
 #: public_html/lists/admin/message.php:125
 msgid "Stop sending after"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:757
+#: public_html/lists/admin/send_core.php:759
 msgid "Repeat campaign every"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:763
+#: public_html/lists/admin/send_core.php:765
 msgid "no repetition"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:768
-#: public_html/lists/admin/send_core.php:809
+#: public_html/lists/admin/send_core.php:770
+#: public_html/lists/admin/send_core.php:811
 msgid "hour"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:773
-#: public_html/lists/admin/send_core.php:814
+#: public_html/lists/admin/send_core.php:775
+#: public_html/lists/admin/send_core.php:816
 msgid "day"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:778
-#: public_html/lists/admin/send_core.php:819
+#: public_html/lists/admin/send_core.php:780
+#: public_html/lists/admin/send_core.php:821
 msgid "week"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:783
+#: public_html/lists/admin/send_core.php:785
 msgid "fortnight"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:789
+#: public_html/lists/admin/send_core.php:791
 msgid "four weeks"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:791
+#: public_html/lists/admin/send_core.php:793
 msgid "Repeat Until"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:798
+#: public_html/lists/admin/send_core.php:800
 msgid "Requeue every"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:804
+#: public_html/lists/admin/send_core.php:806
 msgid "do not requeue"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:822
+#: public_html/lists/admin/send_core.php:824
 msgid "Requeue Until"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:832
+#: public_html/lists/admin/send_core.php:834
 msgid "Send as"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:862
+#: public_html/lists/admin/send_core.php:864
 msgid "Use Template"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:863
+#: public_html/lists/admin/send_core.php:865
 msgid "select one"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:864
+#: public_html/lists/admin/send_core.php:866
 msgid "No template"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:905
+#: public_html/lists/admin/send_core.php:907
 msgid "Plain text version of message"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:907
+#: public_html/lists/admin/send_core.php:909
 msgid "generate from HTML"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:913
+#: public_html/lists/admin/send_core.php:915
 #: public_html/lists/admin/spageedit.php:227
 msgid "Footer"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:915
+#: public_html/lists/admin/send_core.php:917
 msgid "forwardfooter"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:922
+#: public_html/lists/admin/send_core.php:924
 msgid "Add attachments to your campaign"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:924
+#: public_html/lists/admin/send_core.php:926
 msgid "The upload has the following limits set by the server"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:925
+#: public_html/lists/admin/send_core.php:927
 msgid "Maximum size of total data being sent to the server"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:926
+#: public_html/lists/admin/send_core.php:928
 msgid "Maximum size of each individual file"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:935
+#: public_html/lists/admin/send_core.php:937
 msgid "Current Attachments"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:939
+#: public_html/lists/admin/send_core.php:941
 msgid "filename"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:940
+#: public_html/lists/admin/send_core.php:942
 #: public_html/lists/admin/users.php:324
 msgid "desc"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:941
+#: public_html/lists/admin/send_core.php:943
 msgid "size"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:945
 #: public_html/lists/admin/send_core.php:947
+#: public_html/lists/admin/send_core.php:949
 #: public_html/databasestructure.php:93
 msgid "file"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:952
+#: public_html/lists/admin/send_core.php:954
 msgid "Delete checked"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:956
+#: public_html/lists/admin/send_core.php:958
 msgid ""
 "The total size of attachments is very large. Sending this campaign may fail "
 "due to resource limits."
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:961
+#: public_html/lists/admin/send_core.php:963
 msgid "New Attachment"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:961
+#: public_html/lists/admin/send_core.php:963
 msgid "Add (and save)"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:964
+#: public_html/lists/admin/send_core.php:966
 msgid "or"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:964
+#: public_html/lists/admin/send_core.php:966
 msgid "Path to file on server"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:968
+#: public_html/lists/admin/send_core.php:970
 msgid "Description of attachment"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:993
+#: public_html/lists/admin/send_core.php:995
 msgid "to email address(es)"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:1014
+#: public_html/lists/admin/send_core.php:1016
 msgid "email to alert when sending of this message starts"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:1015
 #: public_html/lists/admin/send_core.php:1017
+#: public_html/lists/admin/send_core.php:1019
 msgid "separate multiple with a comma"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:1016
+#: public_html/lists/admin/send_core.php:1018
 msgid "email to alert when sending of this message has finished"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:1023
+#: public_html/lists/admin/send_core.php:1025
 msgid "add Google Analytics tracking code"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:1033
+#: public_html/lists/admin/send_core.php:1035
 msgid "Reset click statistics"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:1043
+#: public_html/lists/admin/send_core.php:1045
 msgid "This is a test campaign"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:1050
+#: public_html/lists/admin/send_core.php:1052
 msgid "Estimated size of HTML email"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:1053
+#: public_html/lists/admin/send_core.php:1055
 msgid "Estimated size of text email"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:1101
+#: public_html/lists/admin/send_core.php:1103
 msgid "Estimated size of mailout"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:1106
+#: public_html/lists/admin/send_core.php:1108
 #, php-format
 msgid ""
 "About %d users to receive HTML and %s users to receive text version of email"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:1258
+#: public_html/lists/admin/send_core.php:1260
 msgid "subject missing"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:1267
+#: public_html/lists/admin/send_core.php:1269
 msgid "message content missing"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:1276
+#: public_html/lists/admin/send_core.php:1278
 msgid "Incorrect URL for sending"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:1285
+#: public_html/lists/admin/send_core.php:1287
 msgid "From missing"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:1314
+#: public_html/lists/admin/send_core.php:1316
 msgid "destination lists missing"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:1320
+#: public_html/lists/admin/send_core.php:1322
 msgid "Content contains click track links."
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:1339
+#: public_html/lists/admin/send_core.php:1341
 msgid "Place Campaign in Queue for Sending"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:1343
+#: public_html/lists/admin/send_core.php:1345
 msgid ""
 "Some required information is missing. The send button will be enabled when "
 "this is resolved."
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:1349
+#: public_html/lists/admin/send_core.php:1351
 msgid "Save as draft"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:1352
+#: public_html/lists/admin/send_core.php:1354
 msgid "Save and continue editing"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:1356
+#: public_html/lists/admin/send_core.php:1358
 msgid "Campaign Title"
 msgstr ""
 
-#: public_html/lists/admin/send_core.php:1359
+#: public_html/lists/admin/send_core.php:1361
 msgid "Meta data"
 msgstr ""
 

--- a/public_html/lists/admin/send_core.php
+++ b/public_html/lists/admin/send_core.php
@@ -58,7 +58,9 @@ if (!$id) {
     $id = Sql_Insert_Id();
     if (empty($id)) { // something went wrong creating the campaign
         Fatal_Error(s('Unable to create campaign, did you forget to upgrade the database?'));
-        exit;
+        $done = 1;
+
+        return;
     }
 
     if (isset($_GET['list'])) {

--- a/public_html/lists/admin/structure.php
+++ b/public_html/lists/admin/structure.php
@@ -424,7 +424,7 @@ $DBstructphplist = array(
         'index_4'     => array('miduidindex (messageid,userid)', ''),
         'unique_1'    => array('miduidfwdid (messageid,userid,forwardid)', ''),
     ),
-    'linktrack_forward' => array(
+    'linktrack_forward' => array( // This is the url / link tracking table; name is misleading
         'id'   => array('integer not null primary key auto_increment', 'forward ID'),
         'url'  => array('varchar(2083)', 'URL to log'),
         'urlhash'     => array('char(32)', 'hash value of URL'),

--- a/public_html/lists/admin/user.php
+++ b/public_html/lists/admin/user.php
@@ -537,6 +537,7 @@ echo '<ul>';
 echo '<li><a href="#details">'.s('Details').'</a></li>';
 echo '<li><a href="#lists">'.s('Lists').'</a></li>';
 echo '<li><a href="./?page=pageaction&action=campaigns&ajaxed=true&id='.$id .addCsrfGetToken().'">'.s('Campaigns').'</a></li>';
+echo '<li><a href="./?page=pageaction&action=userlinkclicks&ajaxed=true&id='.$id .addCsrfGetToken().'">'.s('Clicks').'</a></li>';
 echo '<li><a href="./?page=pageaction&action=bounces&ajaxed=true&id='.$id .addCsrfGetToken().'">'.s('Bounces').'</a></li>';
 echo '<li><a href="./?page=pageaction&action=subscription&ajaxed=true&id='.$id .addCsrfGetToken().'">'.s('Subscription').'</a></li>';
 

--- a/public_html/lists/admin/userclicks.php
+++ b/public_html/lists/admin/userclicks.php
@@ -164,23 +164,36 @@ if ($fwdid && $msgid) {
     echo '<div class="jumbotron">'.$GLOBALS['I18N']->get('All clicks by').' <b>'.PageLink2('user&amp;id='.$userid, $userdata['email']).'</b></div>';
 
     $query = sprintf('
-        SELECT SUM(htmlclicked) AS htmlclicked,
-        SUM(textclicked) AS textclicked,
-        user.email,
-        user.id AS userid,
-        MIN(firstclick) AS firstclick,
-        MAX(latestclick) AS latestclick,
-        SUM(clicked) AS clicked,
-        GROUP_CONCAT(messageid ORDER BY messageid SEPARATOR \' \') AS messageid,
-        forwardid,
-        url
-        FROM %s AS uml_click
-        JOIN %s AS user ON uml_click.userid = user.id
-        JOIN %s AS forward ON forward.id = uml_click.forwardid
-        WHERE uml_click.userid = %d
-        GROUP BY forwardid
-        ORDER BY clicked DESC, url
-        ',
+        SELECT
+            SUM(htmlclicked) AS htmlclicked,
+            SUM(textclicked) AS textclicked,
+            USER.email,
+            USER.id AS userid,
+            MIN(firstclick) AS firstclick,
+            MAX(latestclick) AS latestclick,
+            SUM(clicked) AS clicked,
+            GROUP_CONCAT(
+                messageid
+            ORDER BY
+                messageid SEPARATOR \' \'
+            ) AS messageid,
+            forwardid,
+            url
+        FROM
+            %s AS uml_click
+        JOIN %s AS USER
+        ON
+            uml_click.userid = USER.id
+        JOIN %s AS forward
+        ON
+            forward.id = uml_click.forwardid
+        WHERE
+            uml_click.userid = %d
+        GROUP BY
+            forwardid
+        ORDER BY
+            clicked DESC,
+            url',
         $GLOBALS['tables']['linktrack_uml_click'],
         $GLOBALS['tables']['user'],
         $GLOBALS['tables']['linktrack_forward'],

--- a/tests/features/bootstrap/FeatureContext.php
+++ b/tests/features/bootstrap/FeatureContext.php
@@ -363,4 +363,13 @@ class FeatureContext extends MinkContext
     {
         $this->getSession()->getDriver()->back();
     }
+
+     /**
+     * @When I confirm the popup
+     */
+    public function iConfirmPopup()
+    {  
+        $this->getSession()->getDriver()->getWebDriverSession()->accept_alert();
+    }
+
 }

--- a/tests/features/getting-started/add-plugin.feature
+++ b/tests/features/getting-started/add-plugin.feature
@@ -12,5 +12,6 @@ Scenario: Install new Plugin and update
         Then I should see "Plugin installed successfully"
         Given I follow "Continue" 
         And I press "update" 
+        Then I wait for 5 seconds
         When I confirm the pop up 
         Then I should not see "failed"

--- a/tests/features/getting-started/add-plugin.feature
+++ b/tests/features/getting-started/add-plugin.feature
@@ -1,0 +1,16 @@
+@javascript
+Feature: Update plugin
+    In order to user extra functions of phpPlist
+    As an admin user
+    I need to be able to add, update or remove plugins
+
+Scenario: Install new Plugin and update
+        Given I have logged in as an administrator
+        And I am on "/lists/admin/?page=plugins"
+        When I fill in "pluginurl" with "https://github.com/bramley/phplist-plugin-autoresponder/archive/master.zip"
+        And I press "download"
+        Then I should see "Plugin installed successfully"
+        Given I follow "Continue" 
+        And I press "update" 
+        When I confirm the pop up 
+        Then I should not see "failed"


### PR DESCRIPTION
Add a tab to the subscriber profile page, which lists all clicks that subscriber has ever performed, across all campaigns, with links to general stats about each URL that they clicked, and also click stats for the last campaign in which that URL appeared.

## Screenshots (if appropriate):
![Selection_601](https://user-images.githubusercontent.com/695422/61807463-e0d5fd00-ae39-11e9-9baa-7fe70af643ba.png)
