### PR TITLE
Fix more detailed subscriber click stats the userdataexport csv files

### DIFF
--- a/public_html/lists/admin/exportuserdata.php
+++ b/public_html/lists/admin/exportuserdata.php
@@ -187,15 +187,20 @@ while ($row = Sql_Fetch_Assoc($umlrows))
 
 fputcsv($output, array(' '), $csvColumnDelimiter);
 // output the column headings
-fputcsv($output, array(' ','User clicks Info'), $csvColumnDelimiter);
-fputcsv($output, array('Link ID', 'Message ID','Name', 'Data', 'Date'), $csvColumnDelimiter);
-$userclickrows = Sql_Query(
-    sprintf(
-        'select linkid, userid, messageid, name, data, date 
-                from %s where userid = %d'
-
-
-        , $GLOBALS['tables']['linktrack_userclick'], $user['id'])
+fputcsv($output, array(' ', s('Subscriber click statistics')), $csvColumnDelimiter);
+fputcsv($output, array( s('URL'), s('Link ID'), s('Message ID'), s('Name'), s('Data'), s('Date') ), $csvColumnDelimiter );
+$userclickrows = Sql_Query('
+    SELECT
+        linkid,
+        userid,
+        messageid,
+        NAME,
+        DATA,
+        DATE
+    FROM
+        '.$GLOBALS['tables']['linktrack_userclick'].'
+    WHERE
+        userid = '.sprintf('%d', $user['id'])
 );
 
 while ($row = Sql_Fetch_Assoc($userclickrows))

--- a/public_html/lists/admin/exportuserdata.php
+++ b/public_html/lists/admin/exportuserdata.php
@@ -190,6 +190,7 @@ fputcsv($output, array(' '), $csvColumnDelimiter);
 fputcsv($output, array(' ', s('Subscriber click statistics')), $csvColumnDelimiter);
 fputcsv($output, array( s('URL'), s('Link ID'), s('Campaign ID'), s('First click'), s('Last click'), s('Total clicks') ), $csvColumnDelimiter );
 
+// Query to get subscriber click data (all clicks from subscriber); from userclicks.php
 $userclickrows = Sql_Query('
     SELECT
         url,
@@ -215,8 +216,7 @@ $userclickrows = Sql_Query('
     ORDER BY 
         clicked DESC, 
         url
-    ');
-
+');
 
 while ($row = Sql_Fetch_Assoc($userclickrows))
     fputcsv($output, $row, $csvColumnDelimiter);

--- a/public_html/lists/admin/exportuserdata.php
+++ b/public_html/lists/admin/exportuserdata.php
@@ -224,14 +224,17 @@ while ($row = Sql_Fetch_Assoc($userclickrows))
 fputcsv($output, array(' '), $csvColumnDelimiter);
 // output the column headings
 fputcsv($output, array(' ','Message Forward Info'), $csvColumnDelimiter);
-fputcsv($output, array('Message ID','Forward', 'Status', 'Time'), $csvColumnDelimiter);
-$forwardrows = Sql_Query(
-    sprintf(
-        'select message, forward, status, time 
-                from %s where user = %d'
-
-
-        , $GLOBALS['tables']['user_message_forward'], $user['id'])
+fputcsv($output, array( s('Message ID'), s('Forward address'), s('Status'), s('Time') ), $csvColumnDelimiter);
+$forwardrows = Sql_Query('
+SELECT
+    message,
+    forward,
+    status,
+    time
+FROM
+    '.$GLOBALS['tables']['user_message_forward'].'
+WHERE
+    USER = '.sprintf('%d', $user['id'])
 );
 
 while ($row = Sql_Fetch_Assoc($forwardrows))

--- a/public_html/lists/admin/exportuserdata.php
+++ b/public_html/lists/admin/exportuserdata.php
@@ -225,6 +225,8 @@ fputcsv($output, array(' '), $csvColumnDelimiter);
 // output the column headings
 fputcsv($output, array(' ','Message Forward Info'), $csvColumnDelimiter);
 fputcsv($output, array( s('Message ID'), s('Forward address'), s('Status'), s('Time') ), $csvColumnDelimiter);
+
+// Query to fetch forwarded messages data
 $forwardrows = Sql_Query('
 SELECT
     message,

--- a/public_html/lists/admin/exportuserdata.php
+++ b/public_html/lists/admin/exportuserdata.php
@@ -222,9 +222,6 @@ while ($row = Sql_Fetch_Assoc($userclickrows))
     fputcsv($output, $row, $csvColumnDelimiter);
 
 fputcsv($output, array(' '), $csvColumnDelimiter);
-// output the column headings
-fputcsv($output, array(' ','Message Forward Info'), $csvColumnDelimiter);
-fputcsv($output, array( s('Message ID'), s('Forward address'), s('Status'), s('Time') ), $csvColumnDelimiter);
 
 // Query to fetch forwarded messages data
 $forwardrows = Sql_Query('
@@ -239,10 +236,21 @@ WHERE
     USER = '.sprintf('%d', $user['id'])
 );
 
-while ($row = Sql_Fetch_Assoc($forwardrows))
-    fputcsv($output, $row, $csvColumnDelimiter);
+$totalForwards = Sql_Num_Rows( $forwardrows );
 
+// print table heading
+fputcsv($output, array(' ','Message Forward Info'), $csvColumnDelimiter);
 
+if ( $totalForwards < 1) {
+    fputcsv( $output, array(' ', s('No forwarded campaign data')), $csvColumnDelimiter );
+} else {
+
+    // print column headings
+    fputcsv($output, array( s('Message ID'), s('Forward address'), s('Status'), s('Time') ), $csvColumnDelimiter);
+
+    while ($row = Sql_Fetch_Assoc($forwardrows))
+        fputcsv($output, $row, $csvColumnDelimiter);
+}
 
 fclose($output);
 exit;

--- a/public_html/lists/admin/userclicks.php
+++ b/public_html/lists/admin/userclicks.php
@@ -163,7 +163,7 @@ if ($fwdid && $msgid) {
 } elseif ($userid) {
     echo '<div class="jumbotron">'.$GLOBALS['I18N']->get('All clicks by').' <b>'.PageLink2('user&amp;id='.$userid, $userdata['email']).'</b></div>';
 
-    $query = sprintf('
+    $query = '
         SELECT
             SUM(htmlclicked) AS htmlclicked,
             SUM(textclicked) AS textclicked,
@@ -179,24 +179,19 @@ if ($fwdid && $msgid) {
                 forwardid,
                 url
         FROM 
-            %s AS uml_click
+            '.$GLOBALS['tables']['linktrack_uml_click'].' AS uml_click
+        JOIN
+            '.$GLOBALS['tables']['user'].' AS user ON uml_click.userid = user.id
         JOIN 
-            %s AS user ON uml_click.userid = user.id
-        JOIN 
-            %s AS forward ON forward.id = uml_click.forwardid
+            '.$GLOBALS['tables']['linktrack_forward'].' AS forward ON forward.id = uml_click.forwardid
         WHERE 
-            uml_click.userid = %d
+            uml_click.userid = '.sprintf('%d', $userid).'
         GROUP BY 
             forwardid
         ORDER BY 
             clicked DESC, 
             url
-        ',
-        $GLOBALS['tables']['linktrack_uml_click'],
-        $GLOBALS['tables']['user'],
-        $GLOBALS['tables']['linktrack_forward'],
-        $userid
-    );
+        ';
 }
 
 //ob_end_flush();

--- a/public_html/lists/admin/userclicks.php
+++ b/public_html/lists/admin/userclicks.php
@@ -164,22 +164,33 @@ if ($fwdid && $msgid) {
     echo '<div class="jumbotron">'.$GLOBALS['I18N']->get('All clicks by').' <b>'.PageLink2('user&amp;id='.$userid, $userdata['email']).'</b></div>';
 
     $query = sprintf('
-        SELECT SUM(htmlclicked) AS htmlclicked,
-        SUM(textclicked) AS textclicked,
-        user.email,
-        user.id AS userid,
-        MIN(firstclick) AS firstclick,
-        MAX(latestclick) AS latestclick,
-        SUM(clicked) AS clicked,
-        GROUP_CONCAT(messageid ORDER BY messageid SEPARATOR \' \') AS messageid,
-        forwardid,
-        url
-        FROM %s AS uml_click
-        JOIN %s AS user ON uml_click.userid = user.id
-        JOIN %s AS forward ON forward.id = uml_click.forwardid
-        WHERE uml_click.userid = %d
-        GROUP BY forwardid
-        ORDER BY clicked DESC, url
+        SELECT
+            SUM(htmlclicked) AS htmlclicked,
+            SUM(textclicked) AS textclicked,
+            user.email,
+            user.id AS userid,
+            MIN(firstclick) AS firstclick,
+            MAX(latestclick) AS latestclick,
+            SUM(clicked) AS clicked,
+            GROUP_CONCAT(
+                messageid
+            ORDER BY
+                messageid SEPARATOR \' \') AS messageid,
+                forwardid,
+                url
+        FROM 
+            %s AS uml_click
+        JOIN 
+            %s AS user ON uml_click.userid = user.id
+        JOIN 
+            %s AS forward ON forward.id = uml_click.forwardid
+        WHERE 
+            uml_click.userid = %d
+        GROUP BY 
+            forwardid
+        ORDER BY 
+            clicked DESC, 
+            url
         ',
         $GLOBALS['tables']['linktrack_uml_click'],
         $GLOBALS['tables']['user'],


### PR DESCRIPTION
Data in the csv table 'User clicks Info' was missing due to the db query used. Replace the sql query to get data, and more data.

Also add a check for the forwarded email data to see if any results are returned, and if not, print message saying so.

Note: The behaviour of tables where no data is found is now inconsistent: all tables show col headings and no data, except for the forwarded message data table, which now does the table title and a message stating forwarded data is absent of that is the case. It would be good to add conditional checks to the other tables to test for this too in future.