### PR TITLE
Add website config option to stats recorded

### DIFF
--- a/public_html/lists/admin/connect.php
+++ b/public_html/lists/admin/connect.php
@@ -408,6 +408,8 @@ function sendMessageStats($msgid)
     }
     $data = Sql_Fetch_Array_Query(sprintf('select * from %s where id = %d', $tables['message'], $msgid));
     $msg .= 'phpList version '.VERSION."\n";
+    $msg .= 'phpList url '.getConfig("website")."\n";
+
     $diff = timeDiff($data['sendstart'], $data['sent']);
 
     if ($data['id'] && $data['processed'] > 10 && $diff != 'very little time') {


### PR DESCRIPTION
Add website config option value to the stats email which is sent after a campaign finishes sending. 