### PR TITLE
Mantis 20069 - Some quirks with simple paging

### DIFF
--- a/public_html/lists/admin/connect.php
+++ b/public_html/lists/admin/connect.php
@@ -1546,8 +1546,8 @@ function Help($topic, $text = '?')
 function isPrivateList($listid) {
 
     $activeVal = Sql_Query(sprintf('
-          SELECT active 
-          FROM   %s 
+          SELECT active
+          FROM   %s
           WHERE  id = %d',
             $GLOBALS['tables']['list'], sql_escape($listid))
     );
@@ -2237,35 +2237,36 @@ function printarray($array)
 
 function simplePaging($baseurl, $start, $total, $numpp, $itemname = '')
 {
-    $end = $start ? $start + $numpp : $numpp;
-    if ($end > $total) {
-        $end = $total;
-    }
+    $start = max(0, $start);
+    $end = min($total, $start + $numpp);
+
     if (!empty($itemname)) {
         $text = $GLOBALS['I18N']->get('Listing %d to %d of %d');
     } else {
         $text = $GLOBALS['I18N']->get('Listing %d to %d');
     }
-    if ($start > 0) {
-        $listing = sprintf($text, $start + 1, $end, $total).' '.$itemname;
-    } else {
-        $listing = sprintf($text, 1, $end, $total).' '.$itemname;
-        $start = 0;
-    }
+    $listing = sprintf($text, $start + 1, $end, $total).' '.$itemname;
+
     if ($total < $numpp) {
         return $listing;
     }
+    // The last page displays the remaining items
+    $remainingItems = $total % $numpp;
 
-//# 22934 - new code
+    if ($remainingItems == 0) {
+        $remainingItems = $numpp;
+    }
+    $startLast = $total - $remainingItems;
+
     return '<div class="paging">
     <p class="range">' .$listing.'</p><div class="controls">
     <a title="' .$GLOBALS['I18N']->get('First Page').'" class="first" href="'.PageUrl2($baseurl.'&amp;start=0').'"></a>
     <a title="' .$GLOBALS['I18N']->get('Previous').'" class="previous" href="'.PageUrl2($baseurl.sprintf('&amp;start=%d',
             max(0, $start - $numpp))).'"></a>
     <a title="' .$GLOBALS['I18N']->get('Next').'" class="next" href="'.PageUrl2($baseurl.sprintf('&amp;start=%d',
-            min($total, $start + $numpp))).'"></a>
+            min($startLast, $start + $numpp))).'"></a>
     <a title="' .$GLOBALS['I18N']->get('Last Page').'" class="last" href="'.PageUrl2($baseurl.sprintf('&amp;start=%d',
-            $total - $numpp)).'"></a>
+            $startLast)).'"></a>
     </div></div>
   ';
 }


### PR DESCRIPTION

<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
When displaying a set of results using simple paging
- Avoid paging past the final page.
- Display only the remaining items on the last page.
## Related Issue
<!--- If it fixes an open issue on Mantis (https://mantis.phplist.org), please include a link to the issue here. -->
https://mantis.phplist.org/view.php?id=20069
## Screenshots (if appropriate):
Event log page showing the last page,
prior to change shows the last 50 events
![Screenshot from 2019-08-27 08-25-14](https://user-images.githubusercontent.com/3147688/64079929-22ce4a80-cce6-11e9-9c57-0c528cb490f5.png)
after change shows the last 47 events

![Screenshot from 2019-08-27 08-22-39](https://user-images.githubusercontent.com/3147688/64079933-2d88df80-cce6-11e9-9e8b-d8f8a5f11616.png)



