### PR TITLE
Mantis 19934 - Parse CSV by CSV standard - rfc4180

### DIFF
--- a/public_html/lists/admin/CsvReader.php
+++ b/public_html/lists/admin/CsvReader.php
@@ -1,0 +1,55 @@
+<?php
+
+class CsvReader
+{
+    private $fh;
+    private $delimiter;
+    private $totalRows;
+
+    const ENCLOSURE = '"';
+    const ESCAPE = "\0";
+
+    /**
+     * Constructor.
+     * Setting auto_detect_line_endings is needed to allow CR as line separator.
+     * Read all rows from the file to get the count of rows ignoring empty lines.
+     */
+    public function __construct($filename, $delimiter)
+    {
+        ini_set('auto_detect_line_endings', true);
+        $this->fh = fopen($filename, 'r');
+        $this->delimiter = $delimiter;
+        $this->totalRows = 0;
+
+        while ($row = fgetcsv($this->fh, 0, $this->delimiter, self::ENCLOSURE, SELF::ESCAPE)) {
+            if ($row[0] !== null) {
+                ++$this->totalRows;
+            }
+        }
+        rewind($this->fh);
+    }
+
+    /**
+     * Return the number of rows in the file.
+     *
+     * @return int
+     */
+    public function totalRows()
+    {
+        return $this->totalRows;
+    }
+
+    /**
+     * Return the result of calling fgetcsv() ignoring empty lines.
+     *
+     * @return array|false|null
+     */
+    public function getRow()
+    {
+        do {
+            $row = fgetcsv($this->fh, 0, $this->delimiter, self::ENCLOSURE, SELF::ESCAPE);
+        } while ($row && $row[0] === null);
+
+        return $row;
+    }
+}

--- a/public_html/lists/admin/actions/import2.php
+++ b/public_html/lists/admin/actions/import2.php
@@ -4,6 +4,7 @@ verifyCsrfGetToken();
 
 require dirname(__FILE__).'/../structure.php';
 require dirname(__FILE__).'/../inc/importlib.php';
+require dirname(__FILE__).'/../CsvReader.php';
 
 @ob_end_flush();
 $status = 'FAIL';
@@ -12,36 +13,24 @@ flush();
 if (filesize($_SESSION['import_file']) > 50000) {
     @ini_set('memory_limit', memory_get_usage() + 50 * filesize($_SESSION['import_file']));
 }
-$email_list = file_get_contents($_SESSION['import_file']);
 flush();
-// Clean up email file
-$email_list = trim($email_list);
-$email_list = str_replace("\r", "\n", $email_list);
-$email_list = str_replace("\n\r", "\n", $email_list);
-$email_list = str_replace("\n\n", "\n", $email_list);
 
-if ($_SESSION['import_record_delimiter'] != "\n") {
-    $email_list = str_replace($_SESSION['import_record_delimiter'], "\n", $email_list);
-}
-
-// Split file/emails into array
-$email_list = explode("\n", $email_list); //WARNING the file contents get replace by an array
-output(sprintf('..'.$GLOBALS['I18N']->get('ok, %d lines').'</p>', count($email_list)));
-$header = array_shift($email_list);
-$total = count($email_list);
-$headers = str_getcsv($header, $_SESSION['import_field_delimiter']);
+$csvReader = new CsvReader($_SESSION['import_file'], $_SESSION['import_field_delimiter']);
+$total = $csvReader->totalRows();
+output(sprintf('..'.$GLOBALS['I18N']->get('ok, %d lines').'</p>', $total));
+--$total; // now the number of subscribers to be imported
+$headers = $csvReader->getRow();
 $headers = array_unique($headers);
 $_SESSION['columnnames'] = $headers;
 
 //## show progress and adjust working space
-if (count($email_list)) {
+if ($total > 0) {
     $import_field_delimiter = $_SESSION['import_field_delimiter'];
-    if (count($email_list) > 300 && !$_SESSION['test_import']) {
+    if ($total > 300 && !$_SESSION['test_import']) {
         // this is a possibly a time consuming process, so show a progress bar
         echo '<script language="Javascript" type="text/javascript"> document.write(progressmeter); start();</script>';
         flush();
         // increase the memory to make sure we are not running out
-        //    $mem = sizeof($email_list);
         ini_set('memory_limit', '32M');
     }
 
@@ -65,18 +54,17 @@ if (count($email_list)) {
     $c = 1;
     $count['invalid_email'] = 0;
     $num_lists = count($_SESSION['lists']);
-    $total = count($email_list);
     $cnt = 0;
     $count['emailmatch'] = 0;
     $count['fkeymatch'] = 0;
     $count['dataupdate'] = 0;
     $count['duplicate'] = 0;
     $additional_emails = 0;
-    foreach ($email_list as $line) {
+
+    while ($values = $csvReader->getRow()) {
         set_time_limit(60);
         // will contain attributes to store / change
         $user = array();
-        $values = str_getcsv($line, $_SESSION['import_field_delimiter']);
         $system_values = array();
         foreach ($system_attribute_mapping as $column => $index) {
             //   print '<br/>'.$column . ' = '. $values[$index];
@@ -114,8 +102,8 @@ if (count($email_list)) {
             $replace = array();
             foreach ($_SESSION['import_attribute'] as $key => $val) {
                 if (!empty($values[$val['index']])) {
-                    $user[$val['index']] = addslashes($values[$val['index']]);
-                    $replace[$key] = addslashes($values[$val['index']]);
+                    $user[$val['index']] = htmlspecialchars($values[$val['index']]);
+                    $replace[$key] = htmlspecialchars($values[$val['index']]);
                 }
             }
         } else {

--- a/tests/phpunit/CsvReaderTest.php
+++ b/tests/phpunit/CsvReaderTest.php
@@ -1,0 +1,145 @@
+<?php
+
+require __DIR__ . '/../../public_html/lists/admin/CsvReader.php';
+
+class CsvReaderTest extends PHPUnit\Framework\TestCase
+{
+    private static $temporaryFiles = [];
+
+    private function createTestFile($data)
+    {
+        $filename = tempnam(sys_get_temp_dir(), 'phpunit_');
+        file_put_contents($filename, $data);
+        self::$temporaryFiles[] = $filename;
+
+        return $filename;
+    }
+
+    /**
+     * @test
+     * @dataProvider lineEndingDataProvider
+     */
+    public function lineEnding($filename, $expected)
+    {
+        $csv = new csvReader($filename, ',');
+        $this->assertEquals($expected, $csv->totalRows());
+    }
+
+    public function lineEndingDataProvider()
+    {
+        $dataForTests = [
+            'line-ending CRNL' => ["email,name,country\r\nfoo@foo.com,Jim Smith,United Kingdom\r\n", 2],
+            'line-ending NL' => ["email,name,country\nfoo@foo.com,Jim Smith,United Kingdom\n", 2],
+            'line-ending CR' => ["email,name,country\rfoo@foo.com,Jim Smith,United Kingdom\r", 2],
+        ];
+
+        return array_map(
+            function ($item) {
+                $data = $item[0];
+                $expected = $item[1];
+                $filename = $this->createTestFile($data);
+
+                return [$filename, $expected];
+            },
+            $dataForTests
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function embeddedEnclosure()
+    {
+        $le = "\n";
+        $data = '"email","name","description"' . $le
+            . '"foo@foo.com","Jim Smith","before "" after"' . $le
+            . '"foo2@foo.com","John Brown","a description"' . $le;
+        $filename = $this->createTestFile($data);
+
+        $csv = new csvReader($filename, ',');
+        $this->assertEquals(3, $csv->totalRows());
+
+        $headers = $csv->getRow();
+        $fields = $csv->getRow();
+        $this->assertEquals('before " after', $fields[2]);
+    }
+
+    /**
+     * @test
+     */
+    public function embeddedDelimiter()
+    {
+        $le = "\n";
+        $data = '"email","name","description"' . $le
+            . '"foo@foo.com","Jim Smith","before , after"' . $le
+            . '"foo2@foo.com","John Brown","a description"' . $le;
+        $filename = $this->createTestFile($data);
+
+        $csv = new csvReader($filename, ',');
+        $this->assertEquals(3, $csv->totalRows());
+
+        $headers = $csv->getRow();
+        $fields = $csv->getRow();
+        $this->assertEquals('before , after', $fields[2]);
+    }
+
+    /**
+     * @test
+     * @dataProvider embeddedLineEndingDataProvider
+     */
+    public function embeddedLineEnding($le)
+    {
+        $data = '"email","name","description"' . $le
+            . '"foo2@foo.com","John Brown","a description"' . $le
+            . sprintf('"foo@foo.com","Jim Smith","%s"', "before $le after") . $le;
+        $filename = $this->createTestFile($data);
+
+        $csv = new csvReader($filename, ',');
+        $this->assertEquals(3, $csv->totalRows());
+
+        $headers = $csv->getRow();
+        $csv->getRow();
+        $fields = $csv->getRow();
+        $this->assertEquals("before $le after", $fields[2]);
+    }
+
+    public function embeddedLineEndingDataProvider()
+    {
+        return [
+            'embedded NL' => ["\n"],
+            'embedded CRNL' => ["\r\n"],
+            'embedded CR' => ["\r"],
+        ];
+    }
+
+    /**
+     * @test
+     */
+    public function embeddedBackslash()
+    {
+        $le = "\n";
+        $data = '"email","name","description"' . $le
+            . '"foo@foo.com","Jim Smith","before \"" after"' . $le
+            . '"foo2@foo.com","John Brown","at end\"' . $le;
+        $filename = $this->createTestFile($data);
+
+        $csv = new csvReader($filename, ',');
+        $this->assertEquals(3, $csv->totalRows());
+
+        $headers = $csv->getRow();
+        $fields = $csv->getRow();
+        $this->assertEquals('before \" after', $fields[2]);
+        $fields = $csv->getRow();
+        $this->assertEquals('at end\\', $fields[2]);
+    }
+
+    public static function tearDownAfterClass() : void
+    {
+        array_walk(
+            self::$temporaryFiles,
+            function ($item) {
+                unlink($item);
+            }
+        );
+    }
+}


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
Use fgetcsv() to parse an import file. Instigated by discussion on another pull request https://github.com/phpList/phplist3/pull/585

New class to encapsulate reading a csv file. It uses fgetcsv() to read line by line instead of loading the complete file into an array. This is to reduce the memory usage but requires the file to be parsed twice in order to count the number of rows.

Similar changes to admin/import2.php and admin/actions/import2.php to use the new class.
Remove references to the $email_list variable.
Remove the current manipulation of the various line endings.
Use htmlspecialchars() instead of addslashes()

Some phpunit tests.
## Related Issue
<!--- If it fixes an open issue on Mantis (https://mantis.phplist.org), please include a link to the issue here. -->
https://mantis.phplist.org/view.php?id=19934

## Screenshots (if appropriate):
