### PR TITLE
Correct Dutch translations

### DIFF
--- a/public_html/lists/admin/locale/nl/pagetitles.php
+++ b/public_html/lists/admin/locale/nl/pagetitles.php
@@ -1,16 +1,16 @@
 <?php
 
 switch ($page) {
-  case 'home': $page_title = 'Hoofd Admin Pagina'; break;
+  case 'home': $page_title = 'Hoofd admin'; break;
   case 'setup': $page_title = 'Configuratie Opties'; break;
-  case 'about': $page_title = 'About '.NAME; break;
-  case 'attributes': $page_title = 'Configureer Attributen'; break;
+  case 'about': $page_title = 'Over '.NAME; break;
+  case 'attributes': $page_title = 'Configureer attributen'; break;
   case 'stresstest': $page_title = 'Stress Test'; break;
-  case 'list': $page_title = 'De Lijst van de Lijsten'; break;
-  case 'editattributes': $page_title = 'Configureer Attributen'; break;
+  case 'list': $page_title = 'De Lijst der Lijsten'; break;
+  case 'editattributes': $page_title = 'Configureer attributen'; break;
   case 'editlist': $page_title = 'Bewerk een lijst'; break;
-  case 'checki18n': $page_title = 'Controleer of vertaling bestaat'; break;
-  case 'import4': $page_title = 'Importeer emails van een extere database'; break;
+  case 'checki18n': $page_title = 'Controleer of de vertaling bestaat'; break;
+  case 'import4': $page_title = 'Importeer emails van een externe database'; break;
   case 'import3': $page_title = 'Importeer emails van IMAP'; break;
   case 'import2':
   case 'import1':
@@ -18,10 +18,10 @@ switch ($page) {
   case 'export': $page_title = 'Exporteer gebruikers'; break;
   case 'initialise': $page_title = 'Initialiseer de database'; break;
   case 'send': $page_title = 'Verzend een Bericht'; break;
-  case 'preparesend': $page_title = 'Bereidt een bericht voor om te verzenden'; break;
+  case 'preparesend': $page_title = 'Bereid een bericht voor om te verzenden'; break;
   case 'sendprepared': $page_title = 'Verzend een voorbereid bericht'; break;
-  case 'members': $page_title = 'Lijst van Leden'; break;
-  case 'users': $page_title = 'Lijst van alle Gebruikers'; break;
+  case 'members': $page_title = 'Lijst van leden'; break;
+  case 'users': $page_title = 'Lijst van alle gebruikers'; break;
   case 'reconcileusers': $page_title = 'Herwerk gebruikers'; break;
   case 'user': $page_title = 'Details van een gebruiker'; break;
   case 'userhistory': $page_title = 'Geschiedenis van een gebruiker'; break;
@@ -32,11 +32,11 @@ switch ($page) {
   case 'upgrade': $page_title = 'Upgrade '.NAME; break;
   case 'templates': $page_title = 'Templates in het systeem'; break;
   case 'template': $page_title = 'Bewerk of voeg een nieuw sjabloon toe'; break;
-  case 'viewtemplate': $page_title = 'Sjabloon Voorbeeld'; break;
+  case 'viewtemplate': $page_title = 'Sjabloon voorbeeld'; break;
   case 'configure': $page_title = 'Configureeer '.NAME; break;
-  case 'admin': $page_title = 'Bewerk een Administrator'; break;
-  case 'admins': $page_title = 'Lijst van Administrators'; break;
-  case 'adminattributes': $page_title = 'Configureer Administrator attributen'; break;
+  case 'admin': $page_title = 'Bewerk een administrator'; break;
+  case 'admins': $page_title = 'Lijst van administrators'; break;
+  case 'adminattributes': $page_title = 'Configureer administrator attributen'; break;
   case 'processbounces': $page_title = 'zoek bounces van de server op'; break;
   case 'bounces': $page_title = 'Lijst van bounces'; break;
   case 'bounce': $page_title = 'Bekijk een bounce'; break;
@@ -44,12 +44,12 @@ switch ($page) {
   case 'spage': $page_title = 'Inschrijf pagina&acute;s'; break;
   case 'eventlog': $page_title = 'Logboek'; break;
   case 'getrss': $page_title = 'Zoek RSS feeds op'; break;
-  case 'viewrss': $page_title = 'Bekijk RSS Items'; break;
+  case 'viewrss': $page_title = 'Bekijk RSS items'; break;
   case 'community': $page_title = 'Welkom bij de PHPlist community'; break;
   case 'vote': $page_title = 'Stem voor PHPlist'; break;
   case 'login': $page_title = 'Login'; break;
-  case 'logout': $page_title = 'Log Uit'; break;
-  case 'mclicks': $page_title = 'Bericht Klik Statistieken'; break;
-  case 'uclicks': $page_title = 'URL Klik Statistieken'; break;
-  case 'massunconfirm': $page_title = 'Massa Onbevestigde emails'; break;
+  case 'logout': $page_title = 'Log uit'; break;
+  case 'mclicks': $page_title = 'Bericht klik statistieken'; break;
+  case 'uclicks': $page_title = 'URL klik statistieken'; break;
+  case 'massunconfirm': $page_title = 'Massa onbevestigde emails'; break;
 }

--- a/public_html/lists/admin/locale/nl/phplist.po
+++ b/public_html/lists/admin/locale/nl/phplist.po
@@ -23,27 +23,27 @@ msgstr ""
 #: public_html/lists/index.php:622
 #, php-format
 msgid "You are logged in as administrator (%s) of this phpList system"
-msgstr "Je bent aangemeld als beheerder (%s) van phpList"
+msgstr "Je bent aangemeld als beheerder (%s) van dit phpList systeem"
 
 #: public_html/lists/index.php:623
 msgid ""
 "You are therefore offered the following choice, which your subscribers will "
 "not see when they load this page."
 msgstr ""
-"Daarom word je de volgende keuze voor gelegd, die jouw abonnees niet zien "
+"Daarom word je de volgende keuze voorgelegd, die jouw abonnees niet zien "
 "als ze deze pagina bezoeken."
 
 #: public_html/lists/index.php:624
 msgid "Go back to admin area"
-msgstr "Ga terug naar de beheerpagina"
+msgstr "Ga terug naar de beheeromgeving"
 
 #: public_html/lists/index.php:625
 msgid "Please choose"
-msgstr "Kies"
+msgstr "Maak een keuze"
 
 #: public_html/lists/index.php:625
 msgid "Make this subscriber confirmed immediately"
-msgstr "Bevestig de inschrijving van deze persoon"
+msgstr "Bevestig direct de inschrijving van deze persoon"
 
 #: public_html/lists/index.php:626
 msgid "Send this subscriber a request for confirmation email"
@@ -70,7 +70,7 @@ msgstr ""
 
 #: public_html/lists/index.php:805
 msgid "\"Jump off\" used by subscriber, reason not requested"
-msgstr "Deze abonnee heeft geen reden gegeven voor de uitschrijving"
+msgstr "Deze abonnee heeft geen reden opgegeven voor de uitschrijving"
 
 #: public_html/lists/index.php:807
 msgid "\"Jump off\" set, reason not requested"
@@ -176,7 +176,7 @@ msgstr "Berichten verwijderd"
 
 #: public_html/lists/admin/send.php:97
 msgid "start a new message"
-msgstr "Maak een nieuw bericht"
+msgstr "Maak een nieuw bericht aan"
 
 #: public_html/lists/admin/send.php:97 public_html/lists/admin/messages.php:77
 msgid "Start a new campaign"
@@ -262,7 +262,7 @@ msgstr "ga naar"
 
 #: public_html/lists/admin/home.php:21 public_html/lists/admin/setup.php:22
 msgid "Initialise Database"
-msgstr "Database tabellen aangemaakt"
+msgstr "Database tabellen aanmaken"
 
 #: public_html/lists/admin/home.php:22
 msgid "to continue"
@@ -582,7 +582,7 @@ msgstr "Verander je eigen details (bijv wachtwoord)"
 
 #: public_html/lists/admin/home.php:391
 msgid "System Functions"
-msgstr "Programma"
+msgstr "Systeem functionaliteiten"
 
 #: public_html/lists/admin/dbcheck.php:8
 msgid "Database structure check"
@@ -1801,7 +1801,7 @@ msgstr ""
 #: public_html/lists/admin/actions/processqueue.php:17
 #: public_html/lists/admin/index.php:290
 msgid "Incorrect processing secret"
-msgstr "Geheim proces niet juist"
+msgstr "Procesgeheim niet juist"
 
 #: public_html/lists/admin/processbounces.php:56
 msgid "Bounce processing error"
@@ -2338,7 +2338,7 @@ msgstr "Niet een volledige URL"
 
 #: public_html/lists/admin/template.php:128
 msgid "No Title"
-msgstr "Geen Titel"
+msgstr "Geen titel"
 
 #: public_html/lists/admin/template.php:130
 msgid "Template does not contain the [CONTENT] placeholder"
@@ -2702,7 +2702,7 @@ msgstr "bewerk deze waarde"
 #: public_html/lists/admin/configure.php:152
 #: public_html/lists/admin/spage.php:66 public_html/lists/admin/spage.php:67
 msgid "edit"
-msgstr "bewerk"
+msgstr "bewerken"
 
 #: public_html/lists/admin/hostedprocessqueuesetup.php:7
 #: public_html/lists/admin/editattributes.php:154
@@ -3749,7 +3749,7 @@ msgstr "Het verzenden van het testbericht naar"
 
 #: public_html/lists/admin/send_core.php:479
 msgid "success"
-msgstr "is gelukt."
+msgstr "gelukt"
 
 #: public_html/lists/admin/send_core.php:484
 msgid "Email address not found to send test message."
@@ -7923,11 +7923,11 @@ msgstr "Beschrijving van de verzendlijst"
 
 #: public_html/lists/admin/editlist.php:183
 msgid "Save"
-msgstr "Sla op"
+msgstr "Opslaan"
 
 #: public_html/lists/admin/editlist.php:184
 msgid "Cancel"
-msgstr "Annuleer"
+msgstr "Annuleren"
 
 #: public_html/lists/admin/editlist.php:184
 msgid "Do not save, and go back to the lists"


### PR DESCRIPTION
## Description
Some of the Dutch translations are translated very robotic, and/or contain typo's. Also capital casing is sometimes misused at a few places. This PR fixes those.

## Related Issue
Not related

## Screenshots (if appropriate):
Not applicable