### PR TITLE
Display campaign title and bounce time on Subscriber Profile campaigns tab

### DIFF
--- a/public_html/lists/admin/actions/campaigns.php
+++ b/public_html/lists/admin/actions/campaigns.php
@@ -68,11 +68,16 @@ if ($num) {
 
         $ls->addColumn($element, s('sent'), formatDateTime($msg['entered'], 1));
         if (!$msg['notviewed']) {
-            $ls->addColumn($element, s('viewed'), formatDateTime($msg['viewed'], 1));
-            $ls->addColumn($element, s('Response time'), secs2time($msg['responsetime']));
+            $viewed = formatDateTime($msg['viewed'], 1);
+            $responseTime = secs2time($msg['responsetime']);
             $resptime += $msg['responsetime'];
             $totalresp += 1;
+        } else {
+            $viewed = '';
+            $responseTime = '';
         }
+        $ls->addColumn($element, s('viewed'), $viewed);
+        $ls->addColumn($element, s('Response time'), $responseTime);
 
         if ($msg['bouncetime']) {
             $ls->addColumn($element, s('bounce'), formatDateTime($msg['bouncetime'], 1));

--- a/public_html/lists/admin/actions/campaigns.php
+++ b/public_html/lists/admin/actions/campaigns.php
@@ -23,9 +23,23 @@ $user = sql_fetch_array($result);
 
 $ls = new WebblerListing(s('Campaigns'));
 if (Sql_Table_Exists($GLOBALS['tables']['usermessage'])) {
-    $msgs = Sql_Query(sprintf('select messageid,entered,viewed,(viewed = 0 or viewed is null) as notviewed,
-abs(unix_timestamp(entered) - unix_timestamp(viewed)) as responsetime from %s where userid = %d and status = "sent" order by entered desc',
-        $GLOBALS['tables']['usermessage'], $user['id']));
+    $msgs = Sql_Query(sprintf(
+        'select messageid,
+            entered,
+            viewed,
+            (viewed = 0 or viewed is null) as notviewed,
+            abs(unix_timestamp(entered) - unix_timestamp(viewed)) as responsetime,
+            (select max(time)
+                from %s umb
+                where umb.message = messageid and umb.user = userid
+            ) as bouncetime
+            from %s
+            where userid = %d and status = "sent"
+            order by entered desc',
+        $GLOBALS['tables']['user_message_bounce'],
+        $GLOBALS['tables']['usermessage'],
+        $user['id']
+    ));
     $num = Sql_Affected_Rows();
 } else {
     $num = 0;
@@ -59,8 +73,9 @@ if ($num) {
             $resptime += $msg['responsetime'];
             $totalresp += 1;
         }
-        if (!empty($bounces[$msg['messageid']])) {
-            $ls->addColumn($element, s('bounce'), $bounces[$msg['messageid']]);
+
+        if ($msg['bouncetime']) {
+            $ls->addColumn($element, s('bounce'), formatDateTime($msg['bouncetime'], 1));
         }
     }
     if ($totalresp) {

--- a/public_html/lists/admin/actions/campaigns.php
+++ b/public_html/lists/admin/actions/campaigns.php
@@ -34,32 +34,33 @@ printf('%d '.s('messages sent to this user').'<br/>', $num);
 if ($num) {
     $resptime = 0;
     $totalresp = 0;
-    $ls->setElementHeading(s('Campaign Id'));
+    $ls->setElementHeading(s('Campaign'));
 
     while ($msg = Sql_Fetch_Array($msgs)) {
-        $ls->addElement($msg['messageid'],
-            PageURL2('message', s('view'), 'id='.$msg['messageid']));
+        $element = sprintf('<!--%d--> %s', $msg['messageid'],  campaignTitle($msg['messageid']));
+        $ls->addElement($element, PageURL2('message', s('view'), 'id='.$msg['messageid']));
+
         if (defined('CLICKTRACK') && CLICKTRACK) {
             $clicksreq = Sql_Fetch_Row_Query(sprintf('select sum(clicked) as numclicks from %s where userid = %s and messageid = %s',
                 $GLOBALS['tables']['linktrack_uml_click'], $user['id'], $msg['messageid']));
             $clicks = sprintf('%d', $clicksreq[0]);
             if ($clicks) {
-                $ls->addColumn($msg['messageid'], s('clicks'),
+                $ls->addColumn($element, s('clicks'),
                     PageLink2('userclicks&amp;userid='.$user['id'].'&amp;msgid='.$msg['messageid'], $clicks));
             } else {
-                $ls->addColumn($msg['messageid'], s('clicks'), 0);
+                $ls->addColumn($element, s('clicks'), 0);
             }
         }
 
-        $ls->addColumn($msg['messageid'], s('sent'), formatDateTime($msg['entered'], 1));
+        $ls->addColumn($element, s('sent'), formatDateTime($msg['entered'], 1));
         if (!$msg['notviewed']) {
-            $ls->addColumn($msg['messageid'], s('viewed'), formatDateTime($msg['viewed'], 1));
-            $ls->addColumn($msg['messageid'], s('Response time'), secs2time($msg['responsetime']));
+            $ls->addColumn($element, s('viewed'), formatDateTime($msg['viewed'], 1));
+            $ls->addColumn($element, s('Response time'), secs2time($msg['responsetime']));
             $resptime += $msg['responsetime'];
             $totalresp += 1;
         }
         if (!empty($bounces[$msg['messageid']])) {
-            $ls->addColumn($msg['messageid'], s('bounce'), $bounces[$msg['messageid']]);
+            $ls->addColumn($element, s('bounce'), $bounces[$msg['messageid']]);
         }
     }
     if ($totalresp) {


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
On the Campaigns tab of the Subscriber Profile page

- display the campaign title instead of the campaign id, as that should be more useful.
- when the email bounced display the time of the bounce. This used to be displayed but an earlier change to the tabs stopped it working.
- ensure that the viewed and response time columns are always displayed so that the bounce column is displayed after those. The bounce column will be displayed only when at least one email has bounced.
## Related Issue
<!--- If it fixes an open issue on Mantis (https://mantis.phplist.org), please include a link to the issue here. -->

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/3147688/69627267-387fb180-1042-11ea-8dfe-ee571deb695c.png)
