### PR TITLE
Converting the database to UTF8

### DIFF
--- a/public_html/lists/admin/converttoutf8.php
+++ b/public_html/lists/admin/converttoutf8.php
@@ -29,10 +29,10 @@ while ($row = Sql_Fetch_Assoc($req)) {
         $maxsize = $row['tablesize'];
     }
 }
-$maxsize = (int) $maxsize;
-$avail = disk_free_space('/'); //# we have no idea where MySql stores the data, so this is only a crude check and warning.
-
 $maxsize = (int) ($maxsize * 1.2); //# add another 20%
+$row = Sql_Fetch_Row_Query('select @@datadir');
+$dataDir = $row[0];
+$avail = disk_free_space($dataDir);
 
 $require_confirmation = !isset($_GET['force']) || $_GET['force'] != 'yes';
 

--- a/public_html/lists/admin/upgrade.php
+++ b/public_html/lists/admin/upgrade.php
@@ -229,9 +229,10 @@ if ($dbversion == VERSION && !$force) {
                 $maxsize = $row['tablesize'];
             }
         }
-        $maxsize = (int) $maxsize;
-        $avail = disk_free_space('/'); //# we have no idea where MySql stores the data, so this is only a crude check and warning.
         $maxsize = (int) ($maxsize * 1.2); //# add another 20%
+        $row = Sql_Fetch_Row_Query('select @@datadir');
+        $dataDir = $row[0];
+        $avail = disk_free_space($dataDir);
 
         //# convert to UTF8
         $dbname = $GLOBALS['database_name'];


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
Two changes to the page that converts the database to UTF8.

- Avoid displaying the warning about lack of disk space when the database has already been upgraded to UTF8. Displaying the warning regardless had caused some confusion, see this topic in the user forum https://discuss.phplist.org/t/is-there-a-way-to-convert-database-to-utf8-by-command-line/5732/10

- Currently the processing checks the space available on the drive with the root directory '/', which might not be the actual location of the database. mysql has a parameter, datadir, giving the location of the database that can be used instead of '/'.
This change is also made to the upgrade page.

## Related Issue
<!--- If it fixes an open issue on Mantis (https://mantis.phplist.org), please include a link to the issue here. -->

## Screenshots (if appropriate):
