### PR TITLE
Include List-Unsubscribe-Post header to indicate one-click functionality

### DIFF
--- a/public_html/lists/admin/sendemaillib.php
+++ b/public_html/lists/admin/sendemaillib.php
@@ -752,6 +752,7 @@ function sendEmail($messageid, $email, $hash, $htmlpref = 0, $rssitems = array()
     }
     $mail->addCustomHeader('List-Help: <'.$text['preferences'].'>');
     $mail->addCustomHeader('List-Unsubscribe: <'.$text['jumpoffurl'].'>');
+    $mail->addCustomHeader('List-Unsubscribe-Post: List-Unsubscribe=One-Click');
     $mail->addCustomHeader('List-Subscribe: <'.getConfig('subscribeurl').'>');
     $mail->addCustomHeader('List-Owner: <mailto:'.getConfig('admin_address').'>');
 


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->
Looking at an email that was sent from Mailchimp there was a List-Unsubscribe-Post header that I had not noticed previously.
```
List-Unsubscribe: <https://ianvisits.us19.list-manage.com/unsubscribe?u=7c0eed00da5d863f228529675&id=1c15e553b2&e=ceacaa0bc4&c=3aed3f5a59>, <mailto:unsubscribe-mc.us19_7c0eed00da5d863f228529675.3aed3f5a59-ceacaa0bc4@mailin.mcsv.net?subject=unsubscribe>
List-Unsubscribe-Post: List-Unsubscribe=One-Click
```
The purpose of that header, explained in https://tools.ietf.org/html/rfc8058, is to provide a signal that the List-Unsubscribe header field has one-click functionality, which phplist does have because of the `jo` parameter. An example
```
List-Unsubscribe: <http://strontian/lists/?p=unsubscribe&uid=1bbf5b37bbb1df69698c4b89e1429474&jo=1>
```
Adding this header can have a positive effect in making mail systems display an Unsubscribe button or link. Testing this with my Yahoo account using the Android Yahoo app, without the header Yahoo did not offer an unsubscribe option, but with the header it did.
Clicking the Unsubscribe option did then trigger the unsubscription.



## Description
<!--- Please provide a general description of your changes in the Pull Request -->

## Related Issue
<!--- If it fixes an open issue on Mantis (https://mantis.phplist.org), please include a link to the issue here. -->

## Screenshots (if appropriate):
![Screenshot_20191205-104315](https://user-images.githubusercontent.com/3147688/70228487-56d56380-174c-11ea-8af5-189c95697d57.png)

