### PR TITLE
Mantis 20117 - processbounces has sql error inserting into user_message_bounce table

### DIFF
--- a/public_html/lists/admin/processbounces.php
+++ b/public_html/lists/admin/processbounces.php
@@ -247,7 +247,7 @@ function processBounceData($bounceid, $msgid, $userid, $bounceDate = null)
                         %d,
                         -1,
                         %d,
-                        %s
+                        "%s"
             )',
                 $tables['user_message_bounce'],
                 $userid, $bounceid, $bounceDate)


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
Add missing quotes around datetime value when inserting into the user_message_bounce table.
## Related Issue
<!--- If it fixes an open issue on Mantis (https://mantis.phplist.org), please include a link to the issue here. -->

## Screenshots (if appropriate):
