### PR TITLE
Add option to entirely remove credits from emails

### DIFF
--- a/public_html/lists/admin/init.php
+++ b/public_html/lists/admin/init.php
@@ -236,6 +236,9 @@ if (!defined('ALLOW_ATTACHMENTS')) {
 if (!defined('EMAILTEXTCREDITS')) {
     define('EMAILTEXTCREDITS', 0);
 }
+if (!defined('EMAILCREDITS')) {
+    define('EMAILCREDITS', 1);
+}
 if (!defined('PAGETEXTCREDITS')) {
     define('PAGETEXTCREDITS', 0);
 }

--- a/public_html/lists/admin/lib.php
+++ b/public_html/lists/admin/lib.php
@@ -475,7 +475,9 @@ function constructSystemMail($message, $subject = '')
         $htmlcontent = str_replace('[CONTENT]', $htmlmessage, $htmltemplate);
         $htmlcontent = str_replace('[SUBJECT]', $subject, $htmlcontent);
         $htmlcontent = str_replace('[FOOTER]', '', $htmlcontent);
-        if (!EMAILTEXTCREDITS) {
+        if (!EMAILCREDITS) {
+            $phpListPowered = '';
+        } elseif (!EMAILTEXTCREDITS) {
             $phpListPowered = preg_replace('/src=".*power-phplist.png"/', 'src="powerphplist.png"',
                 $GLOBALS['PoweredByImage']);
         } else {

--- a/public_html/lists/admin/sendemaillib.php
+++ b/public_html/lists/admin/sendemaillib.php
@@ -260,7 +260,9 @@ function sendEmail($messageid, $email, $hash, $htmlpref = 0, $rssitems = array()
 
       Michiel Dethmers, phpList Ltd 2003 - 2013
     */
-    if (!EMAILTEXTCREDITS) {
+    if (!EMAILCREDITS) {
+        $html['signature'] = '';
+    } elseif (!EMAILTEXTCREDITS) {
         $html['signature'] = $PoweredByImage; //'<div align="center" id="signature"><a href="https://www.phplist.com"><img src="powerphplist.png" width=88 height=31 title="Powered by PHPlist" alt="Powered by PHPlist" border="0" /></a></div>';
         // oops, accidentally became spyware, never intended that, so take it out again :-)
         $html['signature'] = preg_replace('/src=".*power-phplist.png"/', 'src="powerphplist.png"', $html['signature']);

--- a/public_html/lists/config/config_extended.php
+++ b/public_html/lists/config/config_extended.php
@@ -299,6 +299,10 @@ define('REGISTER', 1);
 // to be 1, the HTML emails will then only add a line of text as signature
 define('EMAILTEXTCREDITS', 0);
 
+// If you still want to remove the credits from emails completely
+// set the next constant to 0.
+define('EMAILCREDITS', 1);
+
 // if you want to also remove the image from your public webpages
 // set the next one to 1, and the pages will only include a line of text
 define('PAGETEXTCREDITS', 0);


### PR DESCRIPTION
## Description
<!--- Please provide a general description of your changes in the Pull Request -->

I'm aware of the comments regarding the credits in the code and this contribution may be contentious. But I would like to encourage you to review my suggestion with new perspectives. I gave this contribution a lot of thought.

Basically, I added an option (a new constant) to deactivate credits in emails entirely (not pages). No text and no image is shown.

I found several posts online how to change the source code to deactivate the credits. They demonstrate that there are unmet needs in the community. But I also understand the original authors deserving respect and the wish to gain more clients for phplist.com. And I think that both is possible.

You have probably better statistics through your analytics tools but I doubt that the credits have a high click rate. The average list subscriber is not in the target audience. I imagine the target audience to be web admins and marketers which are only a small percentage of the population. Therefore the credits may do more harm than benefit to the project. I summarised the downsides below.

I believe that the free plan on phplist.com has the potential to be far more effective. That is how Mailchimp became popular. There are probably some clever marketing tricks out there with referral programs and more that still give the community the option to opt out. And I think that the free phpList product will become more popular the better it fits the needs of the community. That's the strength of free software.

In terms of respect, I don't think that credits that have been placed by the authors of phpList show any respect to the authors themselves. You can't give yourself respect in this way. Respect is shown in the communication with the authors and by submitting pull requests which respect all code standards and try to make your work easy. I'm very grateful for the work that has been done and consider the free software community be lucky to have this tool. A big thanks to all contributors.
Just as an idea, you could try to encourage people to create their own version of the credits, referring to phpList. They could be more effective and avoid the downsides of the generic credits.

Okay, so why do people not want credits? Some people are just very particular about their design and brand but there are more downsides that apply in general:

- Subscribers can get confused about the sender of the email. That is problematic for privacy sensitive lists. I promised my subscribers that their data is not given to third parties and I don't want them to think that phpList has their email address or can track their clicks.

- Support requests that should go to the mailing list provider may go to the phpList team.

- Subscribers get used to this footer and then trust phishing emails with the same footer.

- The credits are also used in spam emails and legit emails get a higher spam score which decreases deliverability of all emails send by phpList.

Similar reasons to the above were given by the Roundcube team when they encouraged all users to create custom skins for their product. They don't want instances of Roundcube to be associated with the Roundcube dev team because they see it as counter productive.

If you have any suggestions how to improve this pull request or address my concerns in a better way, I would be very happy to help and further work on this. Lastly, my opinion above is just what I'm thinking right now. You may have good reasons that convince me of the opposite. Let's discuss it.