### PR TITLE
Include the seconds value in the date field of a bounce record.

### DIFF
--- a/public_html/lists/admin/processbounces.php
+++ b/public_html/lists/admin/processbounces.php
@@ -202,7 +202,7 @@ function processImapBounce($link, $num, $header)
         //# just say we did something, when actually we didn't
         return true;
     }
-    $bounceDateFormatted = date('Y-m-d H:i', $bounceDate);
+    $bounceDateFormatted = date('Y-m-d H:i:s', $bounceDate);
 
     Sql_Query(sprintf('insert into %s (date,header,data)
     values("%s","%s","%s")',


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
When inserting into the bounce table the date column is taken from the Date header of the bounce but the value does not include seconds. See screenshot where all date column values have 0 seconds.

This change makes the value include the seconds value from the Date header. The phplist code has been like this for years, so there might have been a reason for not including seconds but I can't see that is important now.
## Related Issue
<!--- If it fixes an open issue on Mantis (https://mantis.phplist.org), please include a link to the issue here. -->

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/3147688/70860233-2c876100-1f17-11ea-98db-2bdd9ac06cf7.png)
