### PR TITLE
Tidy-up some code in phplistmailer

### DIFF
--- a/public_html/lists/admin/class.phplistmailer.php
+++ b/public_html/lists/admin/class.phplistmailer.php
@@ -30,11 +30,11 @@ class phplistMailer extends phplistMailerBase
     public function __construct($messageid, $email, $inBlast = true, $exceptions = false)
     {
         parent::__construct($exceptions);
-        $this->addCustomHeader('X-phpList-version: '.VERSION);
-        $this->addCustomHeader("X-MessageID: $messageid");
-        $this->addCustomHeader("X-ListMember: $email");
+        $this->addCustomHeader('X-phpList-version', VERSION);
+        $this->addCustomHeader('X-MessageID', $messageid);
+        $this->addCustomHeader('X-ListMember', $email);
         if (GOOGLE_SENDERID != '') {
-            $this->addCustomHeader("Feedback-ID: $messageid:".GOOGLE_SENDERID);
+            $this->addCustomHeader('Feedback-ID', "$messageid:".GOOGLE_SENDERID);
         }
 
         //# amazon SES doesn't like this
@@ -56,7 +56,7 @@ class phplistMailer extends phplistMailerBase
         */
 
         if (!USE_AMAZONSES && USE_PRECEDENCE_HEADER) {
-            $this->addCustomHeader('Precedence: bulk');
+            $this->addCustomHeader('Precedence', 'bulk');
         }
 
         $newwrap = getConfig('wordwrap');
@@ -233,10 +233,6 @@ class phplistMailer extends phplistMailerBase
         }
     }
 
-    public function build_message()
-    {
-    }
-
     public function CreateHeader()
     {
         $parentheader = parent::CreateHeader();
@@ -249,32 +245,12 @@ class phplistMailer extends phplistMailerBase
         return $header;
     }
 
-    public function CreateBody()
-    {
-        $body = parent::CreateBody();
-        /*
-              if ($this->ContentType != 'text/plain') {
-                foreach ($GLOBALS['plugins'] as $plugin) {
-                  $plreturn =  $plugin->mimeWrap($this->messageid,$body,$this->header,$this->ContentTypeHeader,$this->destinationemail);
-                  if (is_array($plreturn) && sizeof($plreturn) == 3) {
-                    $this->header = $plreturn[0];
-                    $body = $plreturn[1];
-                    $this->ContentTypeHeader = $plreturn[2];
-                  }
-                }
-              }
-        */
-        return $body;
-    }
-
     public function compatSend(
         $to_name,
         $to_addr,
         $from_name,
         $from_addr,
-        $subject = '',
-        $headers = '',
-        $envelope = ''
+        $subject = ''
     ) {
         if (!empty($from_addr) && method_exists($this, 'SetFrom')) {
             $this->SetFrom($from_addr, $from_name);
@@ -301,7 +277,7 @@ class phplistMailer extends phplistMailerBase
                 if ($pluginHeaders && count($pluginHeaders)) {
                     foreach ($pluginHeaders as $headerItem => $headerValue) {
                         //# @@TODO, do we need to sanitise them?
-                        $this->addCustomHeader($headerItem.': '.$headerValue);
+                        $this->addCustomHeader($headerItem, $headerValue);
                     }
                 }
             }
@@ -313,15 +289,6 @@ class phplistMailer extends phplistMailerBase
         } else {
             logEvent(s('Error, empty message-body sending email to %s', $to_addr));
 
-            return 0;
-        }
-
-        return 1;
-    }
-
-    public function Send()
-    {
-        if (!parent::Send()) {
             return 0;
         }
 

--- a/public_html/lists/admin/sendemaillib.php
+++ b/public_html/lists/admin/sendemaillib.php
@@ -750,11 +750,11 @@ function sendEmail($messageid, $email, $hash, $htmlpref = 0, $rssitems = array()
     if ($forwardedby) {
         $mail->add_timestamp();
     }
-    $mail->addCustomHeader('List-Help: <'.$text['preferences'].'>');
-    $mail->addCustomHeader('List-Unsubscribe: <'.$text['jumpoffurl'].'>');
-    $mail->addCustomHeader('List-Unsubscribe-Post: List-Unsubscribe=One-Click');
-    $mail->addCustomHeader('List-Subscribe: <'.getConfig('subscribeurl').'>');
-    $mail->addCustomHeader('List-Owner: <mailto:'.getConfig('admin_address').'>');
+    $mail->addCustomHeader('List-Help', '<'.$text['preferences'].'>');
+    $mail->addCustomHeader('List-Unsubscribe', '<'.$text['jumpoffurl'].'>');
+    $mail->addCustomHeader('List-Unsubscribe-Post', 'List-Unsubscribe=One-Click');
+    $mail->addCustomHeader('List-Subscribe', '<'.getConfig('subscribeurl').'>');
+    $mail->addCustomHeader('List-Owner', '<mailto:'.getConfig('admin_address').'>');
 
     list($dummy, $domaincheck) = explode('@', $destinationemail);
     $text_domains = explode("\n", trim(getConfig('alwayssendtextto')));


### PR DESCRIPTION

<!---Thanks for contributing to phpList!-->

## Description
Simplify the use of the phpmailer addCustomHeader() method to avoid unnecessary joining of the header name and header value. phpmailer immediately converts that back to header name and header value.

Remove some redundant methods:
- build_message() is not used anywhere in the phplist code
- CreateBody() overrides the parent method but now doesn't add anything
- Send() also overrides the parent method but doesn't add anything and doesn't appear to be called from anywhere

Remove unused parameters $headers and $envelope from compatSend().


## Related Issue
<!--- If it fixes an open issue on Mantis (https://mantis.phplist.org), please include a link to the issue here. -->

## Screenshots (if appropriate):
Headers in an email after the changes
![Screenshot from 2020-01-06 10-22-27](https://user-images.githubusercontent.com/3147688/71813019-81c71600-3070-11ea-8f9e-b7a6c03efab9.png)
