### PR TITLE
Correct the target page to show bounces for a campaign

### DIFF
--- a/public_html/lists/admin/messages.php
+++ b/public_html/lists/admin/messages.php
@@ -221,12 +221,12 @@ if (isset($_GET['duplicate'])) {
         $GLOBALS['tables']['message'], (string) Uuid::generate(4), $_SESSION['logindetails']['id'],$GLOBALS['tables']['message'],
         intval($_GET['duplicate'])));
     if ($newId = Sql_Insert_Id()) {  // if we don't have a newId then the copy failed
-		Sql_Query(sprintf('insert into %s (id,name,data) '.
-			'select %d,name,data from %s where name in ("sendmethod","sendurl","campaigntitle","excludelist","subject") and id = %d',
-			$GLOBALS['tables']['messagedata'],$newId,$GLOBALS['tables']['messagedata'],intval($_GET['duplicate'])));
-		Sql_Query(sprintf('insert into %s (messageid, listid, entered)  select %d, listid, now() from %s where messageid = %d',
-			$GLOBALS['tables']['listmessage'],$newId,$GLOBALS['tables']['listmessage'],intval($_GET['duplicate'])));
-	}
+        Sql_Query(sprintf('insert into %s (id,name,data) '.
+            'select %d,name,data from %s where name in ("sendmethod","sendurl","campaigntitle","excludelist","subject") and id = %d',
+            $GLOBALS['tables']['messagedata'],$newId,$GLOBALS['tables']['messagedata'],intval($_GET['duplicate'])));
+        Sql_Query(sprintf('insert into %s (messageid, listid, entered)  select %d, listid, now() from %s where messageid = %d',
+            $GLOBALS['tables']['listmessage'],$newId,$GLOBALS['tables']['listmessage'],intval($_GET['duplicate'])));
+    }
 
 }
 
@@ -501,7 +501,7 @@ END;
             $resultStats .= '
             <tr>
                 <td>' .s('Bounced').'</td>
-                <td>'.(!empty($viewStats['bounces']) ? PageLink2('bounces&id='.$msg['id'],$viewStatsFormatted['bounces']): '0').'</td>
+                <td>'.(!empty($viewStats['bounces']) ? PageLink2('msgbounces&id='.$msg['id'],$viewStatsFormatted['bounces']): '0').'</td>
             </tr>
         </tbody>
     </table>';


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
On the List of Campaigns page the number of bounces for a campaign is a link to the wrong page. Currently it goes to the bounces page but should go to the msgbounces page which shows bounces only for that campaign.
## Related Issue
<!--- If it fixes an open issue on Mantis (https://mantis.phplist.org), please include a link to the issue here. -->

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/3147688/72668451-f7db5d80-3a1e-11ea-8ce5-a2c01bb5efdc.png)
