### PR TITLE
On the message bounces page display the bounce id

### DIFF
--- a/public_html/lists/admin/msgbounces.php
+++ b/public_html/lists/admin/msgbounces.php
@@ -81,7 +81,7 @@ if ($total) {
 echo '<p>'.number_format($total).' '.s('bounces to campaign').' \''.campaignTitle($messageid).'\'</p>';
 $start = empty($_GET['start']) ? 0 : sprintf('%d', $_GET['start']);
 if ($total > $numpp && !$download ) {
-    $limit = "limit $start,".$numpp;
+    $limit = " limit $start, $numpp";
     echo simplePaging('msgbounces&amp;id='.$messageid, $start, $total, $numpp);
 
     $query .= $limit;

--- a/public_html/lists/admin/msgbounces.php
+++ b/public_html/lists/admin/msgbounces.php
@@ -45,13 +45,16 @@ if (!$messageid) {
 
     return;
 }
-
-$userTable = $GLOBALS['tables']['user'];
-
-$messageBounceTable = $GLOBALS['tables']['user_message_bounce'];
-$query= "select  u.id as userid, u.email, mb.time from $messageBounceTable mb join $userTable u
-on u.id = mb.user where mb.message = '$messageid' ";
-
+$query = <<<END
+    select
+        u.id as userid,
+        u.email,
+        mb.bounce,
+        mb.time
+    from {$tables['user_message_bounce']} mb
+    join {$tables['user']} u on u.id = mb.user
+    where mb.message = $messageid
+END;
 $req = Sql_Query($query);
 
 $total = Sql_Affected_Rows();
@@ -96,15 +99,12 @@ if ($download) {
 }
 $bouncels = new WebblerListing(s('Bounces on').' '.shortenTextDisplay($messagedata['subject'], 30));
 $bouncels->noShader();
-$bouncels->setElementHeading('Subscriber ID');
+$bouncels->setElementHeading(s('Bounce ID'));
+
 while ($row = Sql_Fetch_Array($req)) {
-
-    $bouncels->addElement($row['userid'], PageUrl2('user&amp;id='.$row['userid']));
-    $bouncels->addColumn($row['userid'], s('Subscriber address'), PageLink2('user&id='.$row['userid'], $row['email']));
-    $bouncels->addColumn($row['userid'], s('Time'), formatDateTime($row['time']));
-
-
-
+    $bouncels->addElement($row['bounce'], PageUrl2('bounce&amp;id='.$row['bounce']));
+    $bouncels->addColumn($row['bounce'], s('user'), PageLink2('user&id='.$row['userid'], $row['email']));
+    $bouncels->addColumn($row['bounce'], s('Time'), formatDateTime($row['time']));
 }
 if ($download) {
     ob_end_clean();
@@ -113,4 +113,3 @@ if ($download) {
 } else {
      echo $bouncels->display();
 }
-


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
The message bounces page has one row for each bounce for that campaign, but the rows do not show or link to the actual bounce. The rows also have two links to the subscriber page.

This change includes the bounce id as a link to the bounce page.
## Related Issue
<!--- If it fixes an open issue on Mantis (https://mantis.phplist.org), please include a link to the issue here. -->

## Screenshots (if appropriate):
Prior
![Screenshot from 2020-01-19 21-02-20](https://user-images.githubusercontent.com/3147688/72688456-5b3cbc80-3aff-11ea-8257-7a041fc3922f.png)

After
![Screenshot from 2020-01-19 21-04-09](https://user-images.githubusercontent.com/3147688/72688461-5f68da00-3aff-11ea-986c-370a8bd85100.png)
