### PR TITLE
Mantis 20150 - Total Clicks on campaign list page reports error

### DIFF
--- a/public_html/lists/admin/mclicks.php
+++ b/public_html/lists/admin/mclicks.php
@@ -52,7 +52,7 @@ if (!$id) {
     return;
 }
 
-echo 
+echo
     '<div class="actions pull-right">'.PageLinkButton(
         'mclicks&id='.$id.'&dl=1'
         , s('Download as CSV file')
@@ -68,8 +68,8 @@ $totalbounced = Sql_Fetch_Row_Query(sprintf('select count(user) from %s where me
 $totalclicked = Sql_Fetch_Row_Query(sprintf('select count(distinct userid) from %s where messageid = %d',
     $GLOBALS['tables']['linktrack_uml_click'], $id));
 //total clicks
-$totalclicks = Sql_Fetch_Row_Query(sprintf('select count(userid) from %s where messageid = %d',
-    $GLOBALS['tables']['linktrack_uml_click'], $id));
+$totalclicks = Sql_Fetch_Row_Query(sprintf('select sum(clicked) from %s where messageid = %d',
+    $GLOBALS['tables']['linktrack_ml'], $id));
 if (($totalusers[0] - $totalbounced[0]) > 0) {
     $clickperc = sprintf('%0.2f', ($totalclicked[0] / ($totalusers[0] - $totalbounced[0]) * 100));
 } else {
@@ -135,7 +135,7 @@ while ($row = Sql_Fetch_Array($req)) {
         FROM
             '.$GLOBALS['tables']['linktrack_uml_click'].'
         WHERE
-            messageid = '.sprintf($id, '%d').' 
+            messageid = '.sprintf($id, '%d').'
             AND forwardid = '.sprintf($row['forwardid'], '%d')
     );
 


### PR DESCRIPTION

<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
Make the total clicks value consistent between the Campaign click statistics summary page and the detailed page for a specific campaign.

## Related Issue
<!--- If it fixes an open issue on Mantis (https://mantis.phplist.org), please include a link to the issue here. -->
https://mantis.phplist.org/view.php?id=20150
## Screenshots (if appropriate):
The Summary page shows 116 clicks

![Screenshot from 2020-01-29 17-49-36](https://user-images.githubusercontent.com/3147688/73382708-f2ec9880-42bf-11ea-8a23-e3836b5e7dcd.png)

But the detailed page for the campaign shows 69 clicks.
![Screenshot from 2020-01-29 17-49-52](https://user-images.githubusercontent.com/3147688/73382712-f5e78900-42bf-11ea-8556-9f466c33e3e5.png)

After this change the two figures are the same
![Screenshot from 2020-01-29 17-50-39](https://user-images.githubusercontent.com/3147688/73382800-1d3e5600-42c0-11ea-87ad-e80d3f256ebb.png)

