### PR TITLE
Allow PHPMAILER_PATH to specify a different version of PHPMailer 6.

### DIFF
--- a/public_html/lists/admin/class.phplistmailerbase.php
+++ b/public_html/lists/admin/class.phplistmailerbase.php
@@ -8,7 +8,10 @@ if (USE_PHPMAILER6) {
             $prefixLength = strlen($prefix);
 
             if (substr($classname, 0, $prefixLength) == $prefix) {
-                $filename = 'PHPMailer6/src/' . substr($classname, $prefixLength) . '.php';
+                $phpmailerPath = defined('PHPMAILER_PATH') && PHPMAILER_PATH != ''
+                    ? rtrim(PHPMAILER_PATH, '/') . '/'
+                    : 'PHPMailer6/src/';
+                $filename = $phpmailerPath . substr($classname, $prefixLength) . '.php';
                 require $filename;
             }
         }

--- a/public_html/lists/config/config_extended.php
+++ b/public_html/lists/config/config_extended.php
@@ -561,14 +561,16 @@ Message sending options
 
 */
 
-// you can specify the location of the phpMailer class here
-// if not set, the version included in the distribution will be used
-//# eg for Debian based systems, it may be something like the example below
-//# when you do this, you may need to run some tests, to see if the phpMailer version
-//# you have works ok
-//define ('PHPMAILER_PATH','/usr/share/php/libphp-phpmailer/class.phpmailer.php');
-// or a more recent version of phpMailer will be like this
-//define ('PHPMAILER_PATH','/usr/share/php/libphp-phpmailer/PHPMailerAutoload.php');
+// If you are using PHPMailer 5 then you can use a different version to the phplist distribution by specifying
+// the location of the PHPMailer autoload file
+// if not set, the PHPMailer version included in the distribution will be used
+// eg for Debian based systems, it may be something like the example below
+// when you do this, you may need to run some tests, to see if the phpMailer version you have works ok
+//define ('PHPMAILER_PATH', '/usr/share/php/libphp-phpmailer/PHPMailerAutoload.php');
+//
+// If you are using PHPMailer 6 then you can use a different version by setting the location of the PHPMailer
+// src directory, e.g.
+//define ('PHPMAILER_PATH', '/var/www/PHPMailer-master/src');
 
 // To use a SMTP server please give your server hostname here, leave it blank to use the standard
 // PHP mail() command.


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
Allow PHPMAILER_PATH to specify a different version of PHPMailer 6 to simplify testing a later version of PHPMailer.
## Related Issue
<!--- If it fixes an open issue on Mantis (https://mantis.phplist.org), please include a link to the issue here. -->

## Screenshots (if appropriate):
