### PR TITLE
Do not change URLs that already have a scheme

### DIFF
--- a/public_html/lists/admin/inc/maillib.php
+++ b/public_html/lists/admin/inc/maillib.php
@@ -145,9 +145,9 @@ function addAbsoluteResources($text, $url)
         for ($i = 0; $i < count($foundtags[0]); ++$i) {
             $match = $foundtags[2][$i];
             $tagmatch = $foundtags[1][$i];
-//      print "$match<br/>";
-            if (preg_match('#^(http|javascript|https|ftp|mailto):#i', $match)) {
-                // scheme exists, leave it alone
+
+            if (preg_match('#^[a-z][a-z0-9.-]*:#i', $match)) {
+                // begins with a scheme, leave it alone
             } elseif (preg_match("#\[.*\]#U", $match)) {
                 // placeholders used, leave alone as well
             } elseif (substr($match, 0, 2) == '//') {


### PR DESCRIPTION


<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
A problem raised on the user forum regarding a link whose URL was a phone number, tel:1234, being changed to an http URL
https://discuss.phplist.org/t/problems-with-href-links/2026/9

When adding absolute resources leave alone URLs that already have a scheme. The regular expression allows any valid scheme as described at https://www.ietf.org/rfc/rfc2396.txt section 3.1.

## Related Issue
<!--- If it fixes an open issue on Mantis (https://mantis.phplist.org), please include a link to the issue here. -->

## Screenshots (if appropriate):
