### PR TITLE
Format dates using a configurable format string

### DIFF
--- a/public_html/lists/admin/defaultconfig.php
+++ b/public_html/lists/admin/defaultconfig.php
@@ -98,6 +98,14 @@ $default_config = array(
         'allowempty'  => true,
         'category'    => 'general',
     ),
+    'date_format' => array(
+        'value'       => 'j F Y',
+        'description' => s('Date format'),
+        'infoicon'    => true,
+        'type'        => 'text',
+        'allowempty'  => false,
+        'category'    => 'general',
+    ),
     'rc_notification' => array(
         'value'       => 0,
         'description' => s('Show notification for Release Candidates'),


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
Provide a configuration setting to allow customising the format of a displayed date.
The functions dealing with formatting dates and times have been moved to be together.

Currently some pages such as Statistics Overview force the month to be displayed in short format. This change does not change that.
The time part of a datetime is not changed by this.
## Related Issue
<!--- If it fixes an open issue on Mantis (https://mantis.phplist.org), please include a link to the issue here. -->

## Screenshots (if appropriate):
Configure to display the month name first
![Screenshot from 2020-03-20 14-25-47](https://user-images.githubusercontent.com/3147688/77173386-55d80000-6ab7-11ea-960e-072c829d6489.png)

Resultant display of a date
![Screenshot from 2020-03-20 14-26-44](https://user-images.githubusercontent.com/3147688/77173392-5b354a80-6ab7-11ea-9075-0107b47aae7d.png)

Help text
![image](https://user-images.githubusercontent.com/3147688/77174767-7bfe9f80-6ab9-11ea-842f-e54cf5fc115b.png)

