### PR TITLE
Use the standard processing to format some datetime values.

### DIFF
--- a/public_html/lists/admin/admin.php
+++ b/public_html/lists/admin/admin.php
@@ -180,10 +180,11 @@ foreach ($struct as $key => $val) {
         list($a, $b) = explode(':', $val[1]);
     }
     if ($a == 'sys') {
-        if ($b == 'Privileges') { //# this whole thing of using structure is getting silly, @@TODO rewrite without
-        } else {
-            //If key is 'password' and the passwords are encrypted, locate two radio buttons to allow an update.
-            if ($b == 'Password') {
+        switch ($b) {
+            case 'Privileges':
+                break;
+            case 'Password':
+                //If key is 'password' and the passwords are encrypted, locate two radio buttons to allow an update.
                 $changeAdminPass = !empty($_SESSION['firstinstall']);
                 if ($addAdmin===true){
 
@@ -233,16 +234,26 @@ foreach ($struct as $key => $val) {
                         s('Update it?'),
                         $checkYes, s('Yes'), $checkNo, s('No'));
                 }
-            } else {
-                if ($b != 'Password') {
-                    if ($addAdmin !==true) {
-                        printf('<tr><td>%s</td><td>%s</td></tr>', s($b), $data[$key]);
-                    }
-                } else {
-                    printf('<tr><td>%s</td><td><input type="text" name="%s" value="%s" size="30" /></td></tr>'."\n",
-                        s('Password'), $key, stripslashes($data[$key]));
+                break;
+            default:
+                if ($addAdmin) {
+                    break;
                 }
-            }
+
+                switch ($key) {
+                    case 'created':
+                        $value = formatDateTime($data[$key]);
+                        break;
+                    case 'modified':
+                        $value = formatDateTime($data[$key]);
+                        break;
+                    case 'passwordchanged':
+                        $value = formatDate($data[$key]);
+                        break;
+                    default:
+                        $value = $data[$key];
+                }
+                printf('<tr><td>%s</td><td>%s</td></tr>', s($b), $value);
         }
     } elseif ($key == 'loginname' && $data[$key] == 'admin') {
         printf('<tr><td>'.s('Login Name').'</td><td>admin</td>');

--- a/public_html/lists/admin/plugins.php
+++ b/public_html/lists/admin/plugins.php
@@ -171,17 +171,17 @@ if (defined('PLUGIN_ROOTDIR') && !is_writable(PLUGIN_ROOTDIR)) {
     Info(s('PHP has no <a href="http://php.net/zip">Zip capability</a>. This is required to allow installation from a remote URL'));
 } else {
     echo '<h3>'.s('Install a new plugin').'</h3>';
-		echo '<div class="jumbotron col-sm-12">';
+        echo '<div class="jumbotron col-sm-12">';
     echo '<div class="col-sm-3 col-md-3 col-lg-3 row"><a class="resourceslink btn btn-info" href="http://resources.phplist.com/plugins/" title="'.s('Find plugins').'" target="_blank">'.s('Find plugins').'</a></div><div class="clearfix visible-xs visible-md"></div><br class="visible-xs visible-md" />';
     echo formStart('class="form-horizontal"');
     echo '<fieldset class="col-sm-9 col-md-9 col-lg-9 input-group">
       <label for="pluginurl" class="pull-left control-label">' .s('Plugin package URL').'</label>
-			<div class="clearfix visible-xs visible-md"></div>
+            <div class="clearfix visible-xs visible-md"></div>
       <div type="field" class="pull-left col-lg-7 col-md-9 input-group"><input type="text" id="pluginurl" name="pluginurl" /></div>
       <button type="submit" name="download">' .s('Install plugin').'</button>
       </fieldset>';
-		echo '</form>';
-		echo '</div>';
+        echo '</form>';
+        echo '</div>';
 }
 
 $ls = new WebblerListing(s('Installed plugins'));
@@ -277,7 +277,7 @@ foreach ($GLOBALS['allplugins'] as $pluginname => $plugin) {
     if (!empty($pluginDetails['installDate'])) {
         //  $ls->addColumn($pluginname,s('installed'),date('Y-m-d',$pluginDetails['installDate']));
         $details .= '<div class="detail"><span class="label">'.s('installed').'</span>';
-        $details .= '<span class="value">'.date('Y-m-d', $pluginDetails['installDate']).'</span></div>';
+        $details .= '<span class="value">'.formatDateTime(date('Y-m-d', $pluginDetails['installDate'])).'</span></div>';
     }
     if (!empty($pluginDetails['installUrl'])) {
         //   $ls->addRow($pluginname,s('installation Url'),$pluginDetails['installUrl']);

--- a/public_html/lists/admin/send.php
+++ b/public_html/lists/admin/send.php
@@ -109,7 +109,7 @@ if (!$GLOBALS['commandline']) {
             $ls->addElement($element, PageUrl2('send&amp;id='.$row['id']));
             $ls->setClass($element, 'row1');
             //    $ls->addColumn($element,$I18N->get('edit'),PageLink2('send&amp;id='.$row['id'],$I18N->get('edit')));
-            $ls->addColumn($element, $I18N->get('entered'), $row['entered']);
+            $ls->addColumn($element, $I18N->get('entered'), formatDateTime($row['entered']));
             $ls->addColumn($element, $I18N->get('age'), secs2time($row['age']));
             $ls->addRow($element, '',
                 '<a class="del" href="'.PageUrl2('send&amp;delete='.$row['id']).'" title="'.$I18N->get('del').'">'.$I18N->get('del').'</a>');


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
Use consistent formatting of date and datetime fields on the Send, Admin and Plugins pages.

On the admin page use a switch statement to help clarify the processing.
## Related Issue
<!--- If it fixes an open issue on Mantis (https://mantis.phplist.org), please include a link to the issue here. -->

## Screenshots (if appropriate):
Send a campaign page before the change
![image](https://user-images.githubusercontent.com/3147688/77306702-f3b60f80-6cef-11ea-9a06-fd3fc7370ddd.png)

After the change
![image](https://user-images.githubusercontent.com/3147688/77306755-0597b280-6cf0-11ea-9f05-3b40bb339169.png)
