### PR TITLE
Max processing time for the processqueue page (for remote batch processing)

### DIFF
--- a/public_html/lists/admin/actions/processqueue.php
+++ b/public_html/lists/admin/actions/processqueue.php
@@ -1,5 +1,10 @@
 <?php
 
+// adding max processing time option
+if(!empty($_GET['max_processqueue_time'])) {
+  set_time_limit(intval($_GET['max_processqueue_time'])+10);
+}
+
 //# temporarily remove this check, to make sure processing the queue with a remote call continues to work
 //# https://mantis.phplist.com/view.php?id=17316
 //verifyCsrfGetToken();
@@ -184,6 +189,10 @@ if (defined('MAX_PROCESSQUEUE_TIME') && MAX_PROCESSQUEUE_TIME > 0) {
 // in-page processing force to a minute max, and make sure there's a batch size
 if (empty($GLOBALS['commandline'])) {
     $maxProcessQueueTime = min($maxProcessQueueTime, 60);
+    // adding max processing time option
+    if(!empty($_GET['max_processqueue_time'])) {
+        $maxProcessQueueTime=intval($_GET['max_processqueue_time']);
+    }
     if ($counters['num_per_batch'] <= 0) {
         $counters['num_per_batch'] = 10000;
     }


### PR DESCRIPTION
The current processqueue page, even when called from a command line
(using curl for example), will stop processing the queue after 60
seconds. This change lets you specify the max processing time in the GET
request so that the processqueue page can be used outside of a web
browser for batch processing.

<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->

## Related Issue
<!--- If it fixes an open issue on Mantis (https://mantis.phplist.org), please include a link to the issue here. -->

## Screenshots (if appropriate):
