### PR TITLE
Add support for including Matomo instead of Google Analytics query parameters on URLs

### DIFF
--- a/public_html/lists/admin/AnalyticsQuery.php
+++ b/public_html/lists/admin/AnalyticsQuery.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * This interface is implemented by internal phplist classes.
+ * A plugin can also implement this interface to customise the parameters for analytic tracking, such as Google Analytics or Matomo.
+ */
+interface AnalyticsQuery
+{
+    /**
+     * Provide the query parameters to be added to a URL.
+     *
+     * @param string $emailFormat HTML or text
+     * @param array  $messageData
+     *
+     * @return array query parameters as key => value
+     */
+    public function trackingParameters($emailFormat, $messageData);
+
+    /**
+     * Provide the query parameters that can be edited on the Finish tab.
+     *
+     * @param array $messageData
+     *
+     * @return array query parameters as key => default value
+     */
+    public function editableParameters($messageData);
+
+    /**
+     * Provide the prefix of the tracking parameters.
+     * This is used to remove existing tracking parameters from a URL.
+     *
+     * @return string
+     */
+    public function prefix();
+}

--- a/public_html/lists/admin/analytics.php
+++ b/public_html/lists/admin/analytics.php
@@ -1,0 +1,109 @@
+<?php
+
+class GoogleAnalyticsQuery implements AnalyticsQuery
+{
+    public function trackingParameters($emailFormat, $messageData)
+    {
+        return array(
+            'utm_source' => $messageData['utm_source'],
+            'utm_medium' => $messageData['utm_medium'],
+            'utm_campaign' => $messageData['utm_campaign'],
+            'utm_content' => $emailFormat,
+        );
+    }
+
+    public function editableParameters($messageData)
+    {
+        return array(
+            'utm_source' => 'phpList',
+            'utm_medium' => 'email',
+            'utm_campaign' => $messageData['subject'],
+        );
+    }
+
+    public function prefix()
+    {
+        return 'utm_';
+    }
+}
+
+class MatomoAnalyticsQuery implements AnalyticsQuery
+{
+    public function trackingParameters($emailFormat, $messageData)
+    {
+        return array(
+            'pk_source' => $messageData['pk_source'],
+            'pk_medium' => $messageData['pk_medium'],
+            'pk_campaign' => $messageData['pk_campaign'],
+            'pk_content' => $emailFormat,
+        );
+    }
+
+    public function editableParameters($messageData)
+    {
+        return array(
+            'pk_source' => 'phpList',
+            'pk_medium' => 'email',
+            'pk_campaign' => $messageData['subject'],
+        );
+    }
+
+    public function prefix()
+    {
+        return 'pk_';
+    }
+}
+
+/**
+ * Return an instance of a class that will provide the parameters for an analytic tracker.
+ *
+ * @return AnalyticsQuery class instance
+ */
+function getAnalyticsQuery()
+{
+    global $analyticsqueryplugin;
+
+    $config = getConfig('analytic_tracker');
+
+    if ($config == 'plugin' && $analyticsqueryplugin) {
+        return $analyticsqueryplugin;
+    }
+
+    return $config == 'matomo'
+        ? new MatomoAnalyticsQuery()
+        : new GoogleAnalyticsQuery();
+}
+
+/**
+ * Add analytic query parameters to the URL also removing any existing values.
+ *
+ * @param string $url
+ * @param array  $trackingParameters query parameters as key => value
+ * @param string $prefix tracking parameter prefix
+ *
+ * @return string
+ */
+function addAnalyticsTracking($url, $trackingParameters, $prefix)
+{
+    $position = strpos($url, '#');
+
+    if ($position !== false) {
+        $baseUrl = substr($url, 0, $position);
+        $fragment = substr($url, $position);
+    } else {
+        $baseUrl = $url;
+        $fragment = '';
+    }
+
+    if (strpos($baseUrl, $prefix) !== false) {
+        // Take off existing tracking code. The regex can leave a trailing ? or & which needs to be removed.
+        $regex = sprintf('/%s.+?=[^&]+(&|$)/', $prefix);
+        $baseUrl = rtrim(preg_replace($regex, '', $baseUrl), '?&');
+    }
+
+    // re-construct the URL but exclude any empty parameters
+    $trackingcode = http_build_query(array_filter($trackingParameters));
+    $separator = strpos($baseUrl, '?') ? '&' : '?';
+
+    return $baseUrl.$separator.$trackingcode.$fragment;
+}

--- a/public_html/lists/admin/defaultconfig.php
+++ b/public_html/lists/admin/defaultconfig.php
@@ -146,10 +146,18 @@ $default_config = array(
     ),
     'always_add_googletracking' => array(
         'value'       => '0',
-        'description' => s('Always add Google tracking code to campaigns'),
+        'description' => s('Always add analytics tracking code to campaigns'),
         'type'        => 'boolean',
         'allowempty'  => true,
         'category'    => 'campaign',
+    ),
+    'analytic_tracker' => array(
+        'values'       => array('google' => 'Google Analytics', 'matomo' => 'Matomo'),
+        'value'        => 'google',
+        'description'  => s('Analytics tracking code to add to campaign URLs'),
+        'type'         => 'select',
+        'allowempty'   => false,
+        'category'     => 'campaign',
     ),
     // report address is the person who gets the reports
     'report_address' => array(

--- a/public_html/lists/admin/js/phplistapp.js
+++ b/public_html/lists/admin/js/phplistapp.js
@@ -286,6 +286,14 @@ $(document).ready(function () {
         }
     });
 
+    $("#google_track").on("click",function () {
+        if (this.checked) {
+            $("#analytics").show();
+        } else {
+            $("#analytics").hide();
+        }
+    });
+
     $("input:radio[name=sendmethod]").on("change",function () {
         if (this.value == "remoteurl") {
             $("#remoteurl").show();

--- a/public_html/lists/admin/pluginlib.php
+++ b/public_html/lists/admin/pluginlib.php
@@ -3,11 +3,13 @@
 require_once dirname(__FILE__).'/accesscheck.php';
 require_once dirname(__FILE__).'/EmailSender.php';
 include_once dirname(__FILE__).'/defaultplugin.php';
+require_once dirname(__FILE__).'/AnalyticsQuery.php';
 
 $GLOBALS['plugins'] = array();
 $GLOBALS['editorplugin'] = false;
 $GLOBALS['authenticationplugin'] = false;
 $GLOBALS['emailsenderplugin'] = false;
+$GLOBALS['analyticsqueryplugin'] = false;
 
 $pluginRootDirs = array();
 if (PLUGIN_ROOTDIRS != '') {
@@ -115,6 +117,12 @@ foreach ($pluginFiles as $file) {
                         $GLOBALS['emailsenderplugin'] = $pluginInstance;
                     }
 
+                    if (!$GLOBALS['analyticsqueryplugin'] && $pluginInstance instanceof AnalyticsQuery) {
+                        $GLOBALS['analyticsqueryplugin'] = $pluginInstance;
+                        // Add 'plugin' as an option on the Settings page
+                        $default_config['analytic_tracker']['values'] += array('plugin' => $analyticsqueryplugin->name);
+                    }
+
                     if (!empty($pluginInstance->DBstruct)) {
                         foreach ($pluginInstance->DBstruct as $tablename => $tablecolumns) {
                             $GLOBALS['tables'][$className.'_'.$tablename] = $GLOBALS['table_prefix'].$className.'_'.$tablename;
@@ -145,7 +153,7 @@ foreach ($plugins as $className => $pluginInstance) {
         $pluginInstance->enabled = false;
         unset($plugins[$className]);
         continue;
-    }                            
+    }
     $pluginInstance->activate();
 }
 

--- a/tests/phpunit/AnalyticsTest.php
+++ b/tests/phpunit/AnalyticsTest.php
@@ -1,0 +1,117 @@
+<?php
+
+require __DIR__ . '/../../public_html/lists/admin/AnalyticsQuery.php';
+require __DIR__ . '/../../public_html/lists/admin/analytics.php';
+
+/*
+ * simulate phplist configuration settings and plugins
+ */
+$config = [];
+$plugins = [];
+
+function getConfig($param)
+{
+    global $config;
+
+    return $config[$param];
+}
+
+class AnalyticsTest extends PHPUnit\Framework\TestCase
+{
+    /**
+     * @test
+     */
+    public function createMatomoAnalyticsQuery()
+    {
+        global $config;
+
+        $config = ['analytic_tracker' => 'matomo'];
+
+        $tracker = getAnalyticsQuery();
+        $this->assertInstanceOf('MatomoAnalyticsQuery', $tracker);
+    }
+
+    /**
+     * @test
+     */
+    public function createGoogleAnalyticsQuery()
+    {
+        global $config;
+
+        $config = ['analytic_tracker' => 'google'];
+
+        $tracker = getAnalyticsQuery();
+        $this->assertInstanceOf('GoogleAnalyticsQuery', $tracker);
+    }
+
+    /**
+     * @test
+     * @dataProvider addTrackingParametersDataProvider
+     */
+    public function addTrackingParameters($url, $format, $messageData, $expected)
+    {
+        global $config;
+
+        $config = ['analytic_tracker' => 'google'];
+
+        $analytics = getAnalyticsQuery();
+        $parameters = $analytics->trackingParameters($format, $messageData);
+        $prefix = $analytics->prefix();
+        $newUrl = addAnalyticsTracking($url, $parameters, $prefix);
+        $this->assertEquals($expected, $newUrl);
+    }
+
+    public function addTrackingParametersDataProvider()
+    {
+        return [
+            'no tracking parameters' => [
+                'https://mysite.com/index.php?p1=aaa',
+                'HTML',
+                ['utm_source' => 'newsource', 'utm_medium' => 'newmedium', 'utm_campaign' => 'newcampaign'],
+                'https://mysite.com/index.php?p1=aaa&utm_source=newsource&utm_medium=newmedium&utm_campaign=newcampaign&utm_content=HTML',
+            ],
+            'no parameters' => [
+                'https://mysite.com/index.php',
+                'HTML',
+                ['utm_source' => 'newsource', 'utm_medium' => 'newmedium', 'utm_campaign' => 'newcampaign'],
+                'https://mysite.com/index.php?utm_source=newsource&utm_medium=newmedium&utm_campaign=newcampaign&utm_content=HTML',
+            ],
+            'only tracking parameters' => [
+                'https://mysite.com/index.php?utm_source=mysource&utm_medium=mymedium&utm_campaign=mycampaign&utm_content=mycontent',
+                'HTML',
+                ['utm_source' => 'newsource', 'utm_medium' => 'newmedium', 'utm_campaign' => 'newcampaign'],
+                'https://mysite.com/index.php?utm_source=newsource&utm_medium=newmedium&utm_campaign=newcampaign&utm_content=HTML',
+            ],
+            'trailing tracking parameters' => [
+                'https://mysite.com/index.php?p1=aaa&utm_source=mysource&utm_medium=mymedium&utm_campaign=mycampaign&utm_content=mycontent',
+                'text',
+                ['utm_source' => 'newsource', 'utm_medium' => 'newmedium', 'utm_campaign' => 'newcampaign'],
+                'https://mysite.com/index.php?p1=aaa&utm_source=newsource&utm_medium=newmedium&utm_campaign=newcampaign&utm_content=text',
+            ],
+            'leading tracking parameters' => [
+                'https://mysite.com/index.php?utm_source=mysource&utm_medium=mymedium&utm_campaign=mycampaign&utm_content=mycontent&p1=aaa',
+                'text',
+                ['utm_source' => 'newsource', 'utm_medium' => 'newmedium', 'utm_campaign' => 'newcampaign'],
+                'https://mysite.com/index.php?p1=aaa&utm_source=newsource&utm_medium=newmedium&utm_campaign=newcampaign&utm_content=text',
+            ],
+            'leading and trailing other parameters' => [
+                'https://mysite.com/index.php?p1=aaa&utm_source=mysource&utm_medium=mymedium&utm_campaign=mycampaign&utm_content=mycontent&p2=bbb',
+                'text',
+                ['utm_source' => 'newsource', 'utm_medium' => 'newmedium', 'utm_campaign' => 'newcampaign'],
+                'https://mysite.com/index.php?p1=aaa&p2=bbb&utm_source=newsource&utm_medium=newmedium&utm_campaign=newcampaign&utm_content=text',
+            ],
+            'leading and trailing other parameters with fragment' => [
+                'https://mysite.com/index.php?p1=aaa&utm_source=mysource&utm_medium=mymedium&utm_campaign=mycampaign&utm_content=mycontent&p2=bbb#fragment',
+                'HTML',
+                ['utm_source' => 'newsource', 'utm_medium' => 'newmedium', 'utm_campaign' => 'newcampaign'],
+                'https://mysite.com/index.php?p1=aaa&p2=bbb&utm_source=newsource&utm_medium=newmedium&utm_campaign=newcampaign&utm_content=HTML#fragment',
+            ],
+            'an empty tracking parameter' => [
+                'https://mysite.com/index.php?utm_source=mysource&utm_medium=mymedium&utm_campaign=mycampaign&utm_content=mycontent',
+                'HTML',
+                ['utm_source' => 'newsource', 'utm_medium' => 'newmedium', 'utm_campaign' => ''],
+                'https://mysite.com/index.php?utm_source=newsource&utm_medium=newmedium&utm_content=HTML',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION


<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
Add Matomo as an alternative to Google Analytics. When selected each URL will have four additional query parameters that are similar to the existing Google Analytics parameters

Google
utm_source - set to 'phpList'
utm_medium - set to 'email'
utm_campaign - set to the campaign subject
utm_content - set to either HTML or text depending on the email format

Matomo
pk_source - set to 'phpList'
pk_medium - set to 'email'
pk_campaign - set to the campaign subject
pk_content - set to either HTML or text depending on the email format

Additionally, the parameters will be displayed and can be edited on the Finish tab when composing a campaign.

The approach is to have a class for Google Analytics that provides the appropriate query parameters. Similary for Matomo. Additionally a plugin can implement the same interface so that it can provide the query parameters instead. A plugin can provide different values for the parameters or different parameters entirely.

There are a few areas that have been changed.

- In defaultconfig.php add a field to the Campaign Settings group on the Settings page to choose Google, Matomo or a plugin.
- In send_core.php when a campaign is being created, on the Finish tab allow the analytic query parameters to be edited. The parameters are hidden when analytics query has not been selected for the campaign. 
- Add some javascript to phplistapp.js to show/hide the query parameters depending on the add analytics tracking code check box.

- In analytics.php create a class to hold the google-specific query parameters, and similarly for Matomo. These classes implement an AnalyticsQuery interface.
- Modify pluginlib.php to allow a plugin to implement the same interface.

- In sendemaillib.php and lt.php the existing code to add and remove query parameters has been refactored to use the selected class.

- There are some phpunit tests to test that query parameters are added and removed correctly.
- Correct existing bug that removed uid parameter from URLs for plain-text format emails.

## Related Issue
<!--- If it fixes an open issue on Mantis (https://mantis.phplist.org), please include a link to the issue here. -->

## Screenshots (if appropriate):
On the Settings page
![Screenshot from 2020-04-08 15-10-46](https://user-images.githubusercontent.com/3147688/78831356-665a0700-79e1-11ea-9b27-386b8232bf61.png)

On the Finish tab
![Screenshot from 2020-04-08 15-13-09](https://user-images.githubusercontent.com/3147688/78831424-87225c80-79e1-11ea-9e6e-750eb9adb681.png)
