### PR TITLE
Correct the link to the PHPMailer documentation

### DIFF
--- a/public_html/lists/config/config_extended.php
+++ b/public_html/lists/config/config_extended.php
@@ -601,7 +601,7 @@ define('PHPMAILERHOST', '');
 
 //# SMTP debugging
 // Enable debugging output by phpmailer when sending test emails
-// See https://phpmailer.github.io/PHPMailer/classes/PHPMailer.html#property_SMTPDebug
+// See https://phpmailer.github.io/PHPMailer/classes/PHPMailer.PHPMailer.PHPMailer.html#property_SMTPDebug
 // define('PHPMAILER_SMTP_DEBUG', 0);
 
 //# Smtp Timeout


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
In config_extended.php the link to the PHPMailer documentation is outdated.
## Related Issue
<!--- If it fixes an open issue on Mantis (https://mantis.phplist.org), please include a link to the issue here. -->

## Screenshots (if appropriate):
