### PR TITLE
Add 'n' specifier to format month without leading 0.

### DIFF
--- a/public_html/lists/admin/connect.php
+++ b/public_html/lists/admin/connect.php
@@ -1774,6 +1774,7 @@ function monthName($month, $short = 0)
  *      j   day without leading zero
  *      F   long representation of month
  *      m   2-digit month with leading zero
+ *      n   month without leading zero
  *      M   short representation of month
  *      y   2-digit year
  *      Y   4-digit year
@@ -1796,6 +1797,7 @@ function formatDate($date, $short = 0)
         'F' => monthName($month, $short),
         'M' => monthName($month, true),
         'm' => $month,
+        'n' => +$month,
         'd' => $day,
         'j' => +$day,
     );


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
The specifier 'n' to format a month without leading 0 should have been included in the original change, #639
## Related Issue
<!--- If it fixes an open issue on Mantis (https://mantis.phplist.org), please include a link to the issue here. -->

## Screenshots (if appropriate):
