### PR TITLE
Add popup help for the website field on the Settings page

### DIFF
--- a/public_html/lists/admin/defaultconfig.php
+++ b/public_html/lists/admin/defaultconfig.php
@@ -59,6 +59,7 @@ $default_config = array(
     'website' => array(
         'value'       => $D_website,
         'description' => s('Website address (without http://)'),
+        'infoicon'    => true,
         'type'        => 'text',
         'allowempty'  => false, //# indication this value cannot be empty (1 being it can be empty)
         'category'    => 'general',


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
Adds an info icon for the website field.

## Related Issue
<!--- If it fixes an open issue on Mantis (https://mantis.phplist.org), please include a link to the issue here. -->
https://mantis.phplist.org/view.php?id=20185

Related to https://github.com/phpList/phplist-lan-help/pull/24
## Screenshots (if appropriate):
