### PR TITLE
Add new message preview field to campaign composer for mail client previews

### DIFF
--- a/public_html/lists/admin/actions/generatetextpreview.php
+++ b/public_html/lists/admin/actions/generatetextpreview.php
@@ -11,35 +11,36 @@ verifyCsrfGetToken();
 $msgid = sprintf('%d', $_GET['id']);
 $messagedata = loadMessageData($msgid);
 // shorten to 90 chars (max message preview length)
-$shortMessageData = substr( $messagedata['message'], 0, 90);
 
 // Check if the campaign content is a 'send as a web page' url, and if so, convert that to text instead
-if (preg_match('/\[URL:(.+)\]/', $shortMessageData, $regs)) {
+if (preg_match('/\[URL:(.+)\]/', $messagedata['message'], $regs)) {
     $content = fetchUrl($regs[1]);
     $previewText = HTML2Text($content);
 } else {
-    $previewText = HTML2Text($shortMessageData);
+    $previewText = HTML2Text($messagedata['message']);
 }
+
+$shortPreviewText = substr( $previewText, 0, 90);
 
 // convert to visual preview
 // FIXME this fails when the text is large, or contains £
 
 // replace newlines with spaces
-$previewText = str_replace("\r", "", $previewText);
-$previewText = str_replace("\n", "", $previewText);
+$shortPreviewText = str_replace("\r", "", $shortPreviewText);
+$shortPreviewText = str_replace("\n", "", $shortPreviewText);
 // replace escaped newlines
-$previewText = trim($previewText);
-$previewText = preg_replace("/\n/", '\\n', $previewText);
-$previewText = preg_replace("/\r/", '', $previewText);
+$shortPreviewText = trim($shortPreviewText);
+$shortPreviewText = preg_replace("/\n/", '\\n', $shortPreviewText);
+$shortPreviewText = preg_replace("/\r/", '', $shortPreviewText);
 
 // fix entities
-$previewText = htmlentities($previewText, ENT_IGNORE, 'UTF-8', true);
+$shortPreviewText = htmlentities($shortPreviewText, ENT_IGNORE, 'UTF-8', true);
 
 // replace quotes
-$previewText = str_replace('"', '&quot;', $previewText);
+$shortPreviewText = str_replace('"', '&quot;', $shortPreviewText);
 
 $status = 
 '<script type="text/javascript">
-    $("#messagepreview").val("' .$previewText.'");
+    $("#messagepreview").val("' .$shortPreviewText.'");
 </script>
 ';

--- a/public_html/lists/admin/actions/generatetextpreview.php
+++ b/public_html/lists/admin/actions/generatetextpreview.php
@@ -12,8 +12,12 @@ $msgid = sprintf('%d', $_GET['id']);
 $messagedata = loadMessageData($msgid);
 // shorten to 90 chars (max message preview length)
 
+// If plaintext campaign content was separately saved, use that
+if (!empty( $messagedata['textmessage'] ) ) {
+    $previewText = $messagedata['textmessage'];
+    
 // Check if the campaign content is a 'send as a web page' url, and if so, convert that to text instead
-if (preg_match('/\[URL:(.+)\]/', $messagedata['message'], $regs)) {
+} elseif (preg_match('/\[URL:(.+)\]/', $messagedata['message'], $regs)) {
     $content = fetchUrl($regs[1]);
     $previewText = HTML2Text($content);
 } else {

--- a/public_html/lists/admin/actions/generatetextpreview.php
+++ b/public_html/lists/admin/actions/generatetextpreview.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * @brief Ajax handler for generating the message body preview line shown in some mail clients below the subject
+ * @note based on generatetext.php
+ */
+
+verifyCsrfGetToken();
+
+// generate text content
+$msgid = sprintf('%d', $_GET['id']);
+$messagedata = loadMessageData($msgid);
+// shorten to 90 chars (max message preview length)
+$shortMessageData = substr( $messagedata['message'], 0, 90);
+
+// Check if the campaign content is a 'send as a web page' url, and if so, convert that to text instead
+if (preg_match('/\[URL:(.+)\]/', $shortMessageData, $regs)) {
+    $content = fetchUrl($regs[1]);
+    $previewText = HTML2Text($content);
+} else {
+    $previewText = HTML2Text($shortMessageData);
+}
+
+// convert to visual preview
+// FIXME this fails when the text is large, or contains £
+
+// replace newlines with spaces
+$previewText = str_replace("\r", "", $previewText);
+$previewText = str_replace("\n", "", $previewText);
+// replace escaped newlines
+$previewText = trim($previewText);
+$previewText = preg_replace("/\n/", '\\n', $previewText);
+$previewText = preg_replace("/\r/", '', $previewText);
+
+// fix entities
+$previewText = htmlentities($previewText, ENT_IGNORE, 'UTF-8', true);
+
+// replace quotes
+$previewText = str_replace('"', '&quot;', $previewText);
+
+$status = 
+'<script type="text/javascript">
+    $("#messagepreview").val("' .$previewText.'");
+</script>
+';

--- a/public_html/lists/admin/actions/generatetextpreview.php
+++ b/public_html/lists/admin/actions/generatetextpreview.php
@@ -25,13 +25,11 @@ $shortPreviewText = substr( $previewText, 0, 90);
 // convert to visual preview
 // FIXME this fails when the text is large, or contains £
 
-// replace newlines with spaces
+// remove newlines
 $shortPreviewText = str_replace("\r", "", $shortPreviewText);
 $shortPreviewText = str_replace("\n", "", $shortPreviewText);
-// replace escaped newlines
+
 $shortPreviewText = trim($shortPreviewText);
-$shortPreviewText = preg_replace("/\n/", '\\n', $shortPreviewText);
-$shortPreviewText = preg_replace("/\r/", '', $shortPreviewText);
 
 // fix entities
 $shortPreviewText = htmlentities($shortPreviewText, ENT_IGNORE, 'UTF-8', true);

--- a/public_html/lists/admin/send_core.php
+++ b/public_html/lists/admin/send_core.php
@@ -4,7 +4,6 @@ require_once dirname(__FILE__).'/accesscheck.php';
 include_once dirname(__FILE__).'/date.php';
 include_once dirname(__FILE__).'/analytics.php';
 
-error_reporting(1);
 $errormsg = '';
 $done = 0;
 $messageid = 0;

--- a/public_html/lists/admin/send_core.php
+++ b/public_html/lists/admin/send_core.php
@@ -4,6 +4,7 @@ require_once dirname(__FILE__).'/accesscheck.php';
 include_once dirname(__FILE__).'/date.php';
 include_once dirname(__FILE__).'/analytics.php';
 
+error_reporting(1);
 $errormsg = '';
 $done = 0;
 $messageid = 0;
@@ -697,12 +698,22 @@ if (!$done) {
     */
 
     $maincontent .= '
-  <div class="field"><label for="subject">' .s('Campaign subject').Help('subject').'</label>'.
-        '<input type="text" name="subject"  id="subjectinput"
-    value="' .htmlentities($utf8_subject, ENT_QUOTES, 'UTF-8').'" size="60" /></div>
+  <div class="field">
+    <label for="subject">' .s('Campaign subject').Help('subject').'</label>'.
+    '<input type="text" name="subject"  id="subjectinput" value="' .htmlentities($utf8_subject, ENT_QUOTES, 'UTF-8').'" size="60" />
+  </div>
+                
   <div class="field"><label for="fromfield">' .$GLOBALS['I18N']->get('From Line').Help('from').'</label>'.'
     <input type="text" name="fromfield"
-   value="' .htmlentities($utf8_from, ENT_QUOTES, 'UTF-8').'" size="60" /></div>';
+   value="' .htmlentities($utf8_from, ENT_QUOTES, 'UTF-8').'" size="60" /></div>
+   
+    <div class="field" id="message-text-preview">
+      <label for="messagepreview">' .s('Message preview').Help('generatetextpreview').'</label>
+      <input type="text" id="messagepreview" name="messagepreview" size="60" readonly />
+      <div id="message-text-preview-button">' .
+        PageLinkAjax('send&tab=Content&id='.$id.'&action=generatetextpreview', $GLOBALS['I18N']->get('Generate')).'</a>
+      </div>
+    </div>';
 
     if ($GLOBALS['can_fetchUrl']) {
         $maincontent .= sprintf('


### PR DESCRIPTION
## Description
~All popular mobile mail clients include a preview of email content as well as the subject line. This is [common functionality](https://sendgrid.com/blog/perfecting-your-email-preview-text/) among other ESPs.

The text preview is currently hard to know using phpList unless you send a test message. Mail clients read the plaintext version of the message and take the first 35-90 chars for preview. In phpList the 'text' tab is optional, and often disabled. In such cases it's not possible to know the mail client preview before sending the campaign (when plaintext version is presumably generated at queue processing time).

Therefore this PR adds a message preview to the html campaign composer page (content tab). It has simple logic, using the existing backend functions for retrieving saved message content and turning into plaintext. It also removes newlines and other problematic characters. Via a new ajax file and call it loads the saved html campaign content and turns into plaintext, abbreviated to 90 chars. This is then shown to the admin in a non-editable input text field.

This implementation seems to work for my and hopefully general use cases. However it has some shortcomings:

- Field order and size isn't ideal; might be better to move the new field below the campaign content area or elsewhere to prevent the top of the form being too cluttered
- It loads the preview from the saved content, not from the html content textarea. That means you have to save your changes before the preview will reflect them. That could be easily changed (and would actually be a simpler approach than the current ajax call which loads content from database). However that approach would also be more limiting in that the preview would only work on the composer page (which it is currently on), and could not be moved to another tab, which may be desirable for UX reasons.
- The whole 90 chars currently isn't visible in the input field without sidescrolling. That's partly by design as I didn't want to take up even more space on the page, but the text field could be replaced with a div or something else.
- Placeholders are not replaced, leading to ugly square braces etc. It'd be better if these were parsed during preview generation and replaced with admin attributes (eg admin first name for [FIRST NAME]. However that would increase the workload of this PR so I avoided it; it'd be nice if others were to add that.
- The 'Generate' link should probably be a button (UX people please improve as desired)
- The 'Generate' link disappears after it's pressed -- this is partly by design (as you need to save changes before regenerating the preview makes sense (see above note on how the preview is retrieved from the backend), and partly becuase this is the default behaviour of phpList's ajax functions, or at least this implementation copied from `lists/admin/actions/generatetext.php`
- Reference to a new help prompt 'generatetextpreview' is made, but I have not added it. I think it's more efficient to check the reaction to this PR before making that, as it will be a separate PR to the help repo which could be orphaned or delayed depending on this PR's fate.
- Ditto 'Campaign preview' English string for translation.

## Related Issue
None that I can find

## Screenshots (if appropriate):
![Peek 2020-05-11 15-04](https://user-images.githubusercontent.com/695422/81564989-e8e73500-9398-11ea-8f33-4491f9a07dd2.gif)
