### PR TITLE
Travis setup fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,8 @@ before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -y -qq postfix
   - sudo apt-get install --reinstall dpkg
+  - wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+  - sudo dpkg -i google-chrome-stable_current_amd64.deb
   - google-chrome --version
   - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 2000x2000x16"
   - phpenv config-rm xdebug.ini || echo "xdebug not available"

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,11 +29,8 @@ matrix:
           env: BROWSER=chrome TAGS="~javascript && ~@first-run && ~@wip"
 
 apt:
-  sources:
-    - google-chrome
   packages:
     - dpkg  # see https://github.com/travis-ci/travis-ci/issues/9361
-    - google-chrome-stable
 
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,9 +46,10 @@ addons:
   chrome: stable
 
 before_install:
+  - sudo apt-get clean
   - sudo apt-get update -qq
   - sudo apt-get install -y -qq postfix
-  - sudo apt-get install -y dpkg
+  - sudo apt-get install --reinstall dpkg
   - google-chrome --version
   - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 2000x2000x16"
   - phpenv config-rm xdebug.ini || echo "xdebug not available"


### PR DESCRIPTION
Dpkg was failing to download the latest version of Chrome so, this re-installs dpkg, removes the addons section and uses wget to install the stable version of chrome.   
