### PR TITLE
Link the link to the actual URL destination for convenience

### DIFF
--- a/public_html/lists/admin/uclicks.php
+++ b/public_html/lists/admin/uclicks.php
@@ -89,7 +89,7 @@ $ls = new WebblerListing(s('URL Click Statistics'));
 
 $urldata = Sql_Fetch_Array_Query(sprintf('select url from %s where id = %d',
     $GLOBALS['tables']['linktrack_forward'], $id));
-echo '<h3>'.s('Click details for a URL').' <b>'.$urldata['url'].'</b></h3><br/>';
+echo '<h3>'.s('Click details for a URL').': <b><a href="'.$urldata['url'].'" target="_blank"><span aria-hidden="true" class="glyphicon glyphicon-new-window"></span> '.$urldata['url'].'</a></b></h3><br/>';
 echo PageLinkButton('userclicks&fwdid='.$id, s('View subscribers'));
 if ($download) {
     header('Content-disposition:  attachment; filename="phpList URL click statistics for '.$urldata['url'].'.csv"');


### PR DESCRIPTION
## Description
Make the link clickable at the top of the click stats page; particularly useful when the links in question are obfuscated or do not communicate the content they relate to (eg tweets).

## Screenshots (if appropriate):

![Selection_801](https://user-images.githubusercontent.com/695422/81682666-4345cb80-9455-11ea-939a-249d137167a2.png)

