### PR TITLE
Use htmlentities to output user controlled data in admin and admins pages

### DIFF
--- a/public_html/lists/admin/admin.php
+++ b/public_html/lists/admin/admin.php
@@ -147,10 +147,10 @@ if ($id) {
     echo '<h3>'.s('Edit Administrator').': ';
     $result = Sql_query("SELECT * FROM {$tables['admin']} where id = $id");
     $data = sql_fetch_assoc($result);
-    echo $data['loginname'].'</h3>';
+    echo htmlentities($data['loginname']).'</h3>';
     if ($data['id'] != $_SESSION['logindetails']['id'] && $accesslevel == 'all') {
         printf("<br /><a href=\"javascript:deleteRec('%s');\">Delete</a> %s\n", PageURL2('admin', '', "delete=$id"),
-            $data['loginname']);
+            htmlentities($data['loginname']));
     }
 } else {
     $addAdmin = true;
@@ -251,7 +251,7 @@ foreach ($struct as $key => $val) {
                         $value = formatDate($data[$key]);
                         break;
                     default:
-                        $value = $data[$key];
+                        $value = htmlentities($data[$key]);
                 }
                 printf('<tr><td>%s</td><td>%s</td></tr>', s($b), $value);
         }
@@ -294,11 +294,12 @@ while ($row = Sql_fetch_array($res)) {
         $checked_index = $checked_index_req[0];
         $checked = $checked_index == $row['value'] ? 'checked="checked"' : '';
         printf('<tr><td>%s</td><td><input class="attributeinput" type="hidden" name="cbattribute[]" value="%d" />
+
 <input class="attributeinput" type="checkbox" name="attribute[%d]" value="Checked" %s /></td></tr>' ."\n",
-            $row['name'], $row['id'], $row['id'], $checked);
+            htmlentities($row['name']), $row['id'], $row['id'], $checked);
     } else {
         printf('<tr><td>%s</td><td><input class="attributeinput" type="text" name="attribute[%d]" value="%s" size="30" /></td></tr>'."\n",
-            $row['name'], $row['id'], htmlspecialchars(stripslashes($row['value'])));
+            htmlentities($row['name']), $row['id'], htmlentities($row['value']));
     }
 }
 

--- a/public_html/lists/admin/admins.php
+++ b/public_html/lists/admin/admins.php
@@ -12,6 +12,8 @@ $start = isset($_GET['start']) ? sprintf('%d', $_GET['start']) : 0;
 $listid = isset($_GET['id']) ? sprintf('%d', $_GET['id']) : 0;
 $find = isset($_REQUEST['find']) ? $_REQUEST['find'] : '';
 
+
+
 if (!empty($find)) {
     $remember_find = '&find='.urlencode($find);
 } else {
@@ -92,7 +94,7 @@ if ($find) {
     <tr>
         <td colspan=4><?php echo formStart('action=""') ?><input type="hidden" name="id" value="<?php echo $listid ?>">
             <?php echo s('Find an admin') ?>: <input type=text name="find"
-                                                                         value="<?php echo htmlspecialchars($find) ?>"
+                                                                         value="<?php echo htmlentities($find) ?>"
                                                                          size="40"><input type="submit"
                                                                                           value="<?php echo s('Go') ?>">
             </form></td>
@@ -105,7 +107,7 @@ $ls->setElementHeading('Login name');
 while ($admin = Sql_fetch_array($result)) {
     $delete_url = sprintf("<a href=\"javascript:deleteRec('%s');\">".s('del').'</a>',
         PageURL2('admins', 'Delete', "start=$start&amp;delete=".$admin['id']));
-    $ls->addElement($admin['loginname'],
+    $ls->addElement(htmlentities($admin['loginname']),
         PageUrl2('admin', s('Show'), "start=$start&amp;id=".$admin['id'].$remember_find));
     $ls->addColumn($admin['loginname'], s('Id'), $admin['id']);
     $ls->addColumn($admin['loginname'], s('email'), $admin['email']);

--- a/public_html/lists/admin/admins.php
+++ b/public_html/lists/admin/admins.php
@@ -12,8 +12,6 @@ $start = isset($_GET['start']) ? sprintf('%d', $_GET['start']) : 0;
 $listid = isset($_GET['id']) ? sprintf('%d', $_GET['id']) : 0;
 $find = isset($_REQUEST['find']) ? $_REQUEST['find'] : '';
 
-
-
 if (!empty($find)) {
     $remember_find = '&find='.urlencode($find);
 } else {


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
Fix #660 and fix other XSS that are in /admin and /admins.

The admin could inject malicious code in the loginname field and also via the admin attribute name.
 To replicate the admin attribute one - > go to /adminattributes page-> add a new attribute-> set the attribute name to `<script>alert(1)</script>` and then go to /admin.

The issue is fixed by using `htmlentities` when outputting user-controlled data.
