### PR TITLE
Avoid possible warning about $pageroot when phplist is installed in the web root

### DIFF
--- a/public_html/lists/admin/index.php
+++ b/public_html/lists/admin/index.php
@@ -712,7 +712,11 @@ if (defined('USE_PDF') && USE_PDF && !defined('FPDF_VERSION')) {
 
 if (WARN_ABOUT_PHP_SETTINGS && !$GLOBALS['commandline']) {
     if (strpos(getenv('REQUEST_URI'), $pageroot.'/admin') !== 0) {
-        Warn($GLOBALS['I18N']->get('The pageroot in your config does not match the current locationCheck your config file.'));
+        Warn(s(
+            'The pageroot in your config "%s" does not match the current location "%s". Check your config file.',
+            $pageroot,
+            strstr(getenv('REQUEST_URI'), '/admin', true)
+        ));
     }
 }
 clearstatcache();

--- a/public_html/lists/admin/init.php
+++ b/public_html/lists/admin/init.php
@@ -687,14 +687,15 @@ if (!isset($attachment_repository)) {
     $attachment_repository = $tmpdir;
 }
 
-if (!isset($pageroot)) {
+if (isset($pageroot)) {
+    if ($pageroot == '/') {
+        $pageroot = '';
+    }
+} else {
     $pageroot = '/lists';
-    $GLOBALS['pageroot'] = '/lists';
 }
-//# as the "admin" in adminpages is hardcoded, don't put it in the config file
+// as the "admin" in adminpages is hardcoded, don't put it in the config file
 $adminpages = $GLOBALS['pageroot'].'/admin';
-//# remove possibly duplicated // at the beginning
-$adminpages = preg_replace('~^//~', '/', $adminpages);
 
 $GLOBALS['homepage'] = 'home';
 


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
When phplist is installed in the web root directory, instead of '/lists', $pageroot should be set to an empty string otherwise there is a warning about it not being correct. Despite being explained in config_extended.php there is still a recurring problem of $pageroot being set to '/'.

It is probably simplest just to silently change a value of '/' to an empty string.

Also improve the warning message by including the values that do not match.
## Related Issue
<!--- If it fixes an open issue on Mantis (https://mantis.phplist.org), please include a link to the issue here. -->

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/3147688/84259320-3679cd80-ab10-11ea-96e3-02075b52e373.png)
