### PR TITLE
Remove redundant code now that phplist can always retrieve remote URLs

### DIFF
--- a/public_html/lists/admin/actions/checkurl.php
+++ b/public_html/lists/admin/actions/checkurl.php
@@ -16,18 +16,13 @@ $url = expandURL($_GET['url']);
 $isOk = true;
 $code = -1;
 
-if ($GLOBALS['can_fetchUrl']) {
-    $code = testUrl($url);
-    if ($code != 200) {
-        if (!empty($url_append)) {
-            $status = $GLOBALS['I18N']->get('Error fetching URL').' '.$GLOBALS['I18N']->get('Check your "remoteurl_append" setting.');
-        } else {
-            $status = $GLOBALS['I18N']->get('Error fetching URL');
-        }
-        $isOk = false;
+$code = testUrl($url);
+if ($code != 200) {
+    if (!empty($url_append)) {
+        $status = $GLOBALS['I18N']->get('Error fetching URL').' '.$GLOBALS['I18N']->get('Check your "remoteurl_append" setting.');
+    } else {
+        $status = $GLOBALS['I18N']->get('Error fetching URL');
     }
-} else {
-    $status = $GLOBALS['I18N']->get('Error fetching URL');
     $isOk = false;
 }
 

--- a/public_html/lists/admin/actions/storemessage.php
+++ b/public_html/lists/admin/actions/storemessage.php
@@ -16,24 +16,20 @@ if (isset($_POST['sendmethod']) && $_POST['sendmethod'] == 'inputhere') {
 }
 
 if (!empty($_POST['sendurl'])) {
-    if (!$GLOBALS['can_fetchUrl']) {
-        echo Warn($GLOBALS['I18N']->get('You are trying to send a remote URL, but PEAR::HTTP_Request is not available, so this will fail'));
+    //# hard overwrite the message content, wipe all that was there.
+    //# check there's a protocol
+    //# @@@ do we want to allow other than http and https? Can't imagine, ppl would want to use ftp or something
+
+    if ($_POST['sendurl'] == 'e.g. https://www.phplist.com/testcampaign.html') {
+        $_POST['sendurl'] = '';
     } else {
-        //# hard overwrite the message content, wipe all that was there.
-        //# check there's a protocol
-        //# @@@ do we want to allow other than http and https? Can't imagine, ppl would want to use ftp or something
-
-        if ($_POST['sendurl'] == 'e.g. https://www.phplist.com/testcampaign.html') {
-            $_POST['sendurl'] = '';
-        } else {
-            if (!preg_match('/^https?:\/\//i', $_POST['sendurl']) && !preg_match('/testcampaign/i',
-                    $_POST['sendurl'])
-            ) {
-                $_POST['sendurl'] = 'http://'.$_POST['sendurl'];
-            }
-
-            $_POST['message'] = '[URL:'.$_POST['sendurl'].']';
+        if (!preg_match('/^https?:\/\//i', $_POST['sendurl']) && !preg_match('/testcampaign/i',
+                $_POST['sendurl'])
+        ) {
+            $_POST['sendurl'] = 'http://'.$_POST['sendurl'];
         }
+
+        $_POST['message'] = '[URL:'.$_POST['sendurl'].']';
     }
 }
 

--- a/public_html/lists/admin/init.php
+++ b/public_html/lists/admin/init.php
@@ -667,9 +667,7 @@ if (!defined('RFC_DIRECT_DELIVERY')) {
 }  //# Request for Confirmation, delivery with SMTP
 
 set_include_path(get_include_path() . PATH_SEPARATOR . __DIR__ . '/PEAR');
-$GLOBALS['has_pear_http_request'] = class_exists('HTTP_Request');
 $GLOBALS['has_curl'] = function_exists('curl_init');
-$GLOBALS['can_fetchUrl'] = true;
 
 $GLOBALS['jQuery'] = 'jquery-3.3.1.min.js';
 

--- a/public_html/lists/admin/lib.php
+++ b/public_html/lists/admin/lib.php
@@ -1370,64 +1370,6 @@ function fetchUrlHttpRequest2($url, $requestParameters)
     return $content;
 }
 
-function fetchUrlPear($url, $request_parameters)
-{
-    if (VERBOSE) {
-        logEvent($url.' fetching with PEAR');
-    }
-
-    if (0 && $GLOBALS['has_pear_http_request'] == 2) {
-        $headreq = new HTTP_Request2($url, $request_parameters);
-        $headreq->setHeader('User-Agent', 'phplist v'.VERSION.'p (https://www.phplist.com)');
-    } else {
-        $headreq = new HTTP_Request($url, $request_parameters);
-        $headreq->addHeader('User-Agent', 'phplist v'.VERSION.'p (https://www.phplist.com)');
-    }
-    if (!PEAR::isError($headreq->sendRequest(false))) {
-        $code = $headreq->getResponseCode();
-        if ($code != 200) {
-            logEvent('Fetching '.$url.' failed, error code '.$code);
-
-            return 0;
-        }
-        $header = $headreq->getResponseHeader();
-
-        if (preg_match('/charset=(.*)/i', $header['content-type'], $regs)) {
-            $remote_charset = strtoupper($regs[1]);
-        }
-
-        $request_parameters['method'] = 'GET';
-        if (0 && $GLOBALS['has_pear_http_request'] == 2) {
-            $req = new HTTP_Request2($url, $request_parameters);
-            $req->setHeader('User-Agent', 'phplist v'.VERSION.'p (https://www.phplist.com)');
-        } else {
-            $req = new HTTP_Request($url, $request_parameters);
-            $req->addHeader('User-Agent', 'phplist v'.VERSION.'p (https://www.phplist.com)');
-        }
-        logEvent('Fetching '.$url);
-        if (VERBOSE && function_exists('output')) {
-            output('Fetching remote: '.$url);
-        }
-        if (!PEAR::isError($req->sendRequest(true))) {
-            $content = $req->getResponseBody();
-
-            if ($remote_charset != 'UTF-8' && function_exists('iconv')) {
-                $content = iconv($remote_charset, 'UTF-8//TRANSLIT', $content);
-            }
-        } else {
-            logEvent('Fetching '.$url.' failed on GET '.$req->getResponseCode());
-
-            return 0;
-        }
-    } else {
-        logEvent('Fetching '.$url.' failed on HEAD');
-
-        return 0;
-    }
-
-    return $content;
-}
-
 function releaseLock($processid)
 {
     global $tables;

--- a/public_html/lists/admin/send_core.php
+++ b/public_html/lists/admin/send_core.php
@@ -242,10 +242,6 @@ if ($send || $sendtest || $prepare || $save || $savedraft) {
 
 //    print "Message ID: $id";
     //    exit;
-    if (!$GLOBALS['can_fetchUrl'] && preg_match("/\[URL:/i", $_POST['message'])) {
-        echo $GLOBALS['can_fetchUrl'].Warn(s('You are trying to send a remote URL, but PEAR::HTTP_Request or CURL is not available, so this will fail'));
-    }
-
     if ($GLOBALS['commandline']) {
         if (isset($_POST['targetlist']) && is_array($_POST['targetlist'])) {
             Sql_query("delete from {$tables['listmessage']} where messageid = $id");
@@ -701,11 +697,11 @@ if (!$done) {
     <label for="subject">' .s('Campaign subject').Help('subject').'</label>'.
     '<input type="text" name="subject"  id="subjectinput" value="' .htmlentities($utf8_subject, ENT_QUOTES, 'UTF-8').'" size="60" />
   </div>
-                
+
   <div class="field"><label for="fromfield">' .$GLOBALS['I18N']->get('From Line').Help('from').'</label>'.'
     <input type="text" name="fromfield"
    value="' .htmlentities($utf8_from, ENT_QUOTES, 'UTF-8').'" size="60" /></div>
-   
+
     <div class="field" id="message-text-preview">
       <label for="messagepreview">' .s('Message preview').Help('generatetextpreview').'</label>
       <input type="text" id="messagepreview" name="messagepreview" size="60" readonly />
@@ -714,29 +710,27 @@ if (!$done) {
       </div>
     </div>';
 
-    if ($GLOBALS['can_fetchUrl']) {
-        $maincontent .= sprintf('
+    $maincontent .= sprintf('
 
       <div id="contentchoice" class="field">
       <label for="sendmethod">' .$GLOBALS['I18N']->get('Content').Help('sendmethod').'</label>'.'
       <input type="radio" name="sendmethod" value="remoteurl" %s />' .$GLOBALS['I18N']->get('Send a Webpage').'
       <input type="radio" name="sendmethod" value="inputhere" %s />' .$GLOBALS['I18N']->get('Compose Message').'
       </div>',
-            $messagedata['sendmethod'] == 'remoteurl' ? 'checked="checked"' : '',
-            $messagedata['sendmethod'] == 'inputhere' ? 'checked="checked"' : ''
+        $messagedata['sendmethod'] == 'remoteurl' ? 'checked="checked"' : '',
+        $messagedata['sendmethod'] == 'inputhere' ? 'checked="checked"' : ''
         );
 
-        if (empty($messagedata['sendurl'])) {
-            $messagedata['sendurl'] = 'e.g. https://www.phplist.com/testcampaign.html';
-        }
+    if (empty($messagedata['sendurl'])) {
+        $messagedata['sendurl'] = 'e.g. https://www.phplist.com/testcampaign.html';
+    }
 
-        $maincontent .= '
+    $maincontent .= '
       <div id="remoteurl" class="field"><label for="sendurl">' .$GLOBALS['I18N']->get('Send a Webpage - URL').Help('sendurl').'</label>'.'
         <input type="text" name="sendurl" id="remoteurlinput"
-       value="' .htmlspecialchars($messagedata['sendurl']).'" size="60" /> <span id="remoteurlstatus"></span></div>';
-        if (isset($messagedata['sendmethod']) && $messagedata['sendmethod'] != 'remoteurl') {
-            $GLOBALS['pagefooter']['hideremoteurl'] = '<script type="text/javascript">$("#remoteurl").hide();</script>';
-        }
+       value="' .$messagedata['sendurl'].'" size="60" /> <span id="remoteurlstatus"></span></div>';
+    if (isset($messagedata['sendmethod']) && $messagedata['sendmethod'] != 'remoteurl') {
+        $GLOBALS['pagefooter']['hideremoteurl'] = '<script type="text/javascript">$("#remoteurl").hide();</script>';
     }
 
 // custom code - end

--- a/public_html/lists/admin/send_core.php
+++ b/public_html/lists/admin/send_core.php
@@ -728,7 +728,7 @@ if (!$done) {
     $maincontent .= '
       <div id="remoteurl" class="field"><label for="sendurl">' .$GLOBALS['I18N']->get('Send a Webpage - URL').Help('sendurl').'</label>'.'
         <input type="text" name="sendurl" id="remoteurlinput"
-       value="' .$messagedata['sendurl'].'" size="60" /> <span id="remoteurlstatus"></span></div>';
+       value="' .htmlspecialchars($messagedata['sendurl']).'" size="60" /> <span id="remoteurlstatus"></span></div>';
     if (isset($messagedata['sendmethod']) && $messagedata['sendmethod'] != 'remoteurl') {
         $GLOBALS['pagefooter']['hideremoteurl'] = '<script type="text/javascript">$("#remoteurl").hide();</script>';
     }

--- a/public_html/lists/admin/sendemaillib.php
+++ b/public_html/lists/admin/sendemaillib.php
@@ -122,7 +122,7 @@ function sendEmail($messageid, $email, $hash, $htmlpref = 0, $rssitems = array()
         }
 
         //# Fetch external content, only if the URL has placeholders
-        if ($GLOBALS['can_fetchUrl'] && preg_match("/\[URL:([^\s]+)\]/i", $content, $regs)) {
+        if (preg_match("/\[URL:([^\s]+)\]/i", $content, $regs)) {
             while (isset($regs[1]) && strlen($regs[1])) {
                 $url = $regs[1];
                 if (!preg_match('/^http/i', $url)) {
@@ -1468,7 +1468,7 @@ function precacheMessage($messageid, $forwardContent = 0)
 
     if (!$cached[$messageid]['userspecific_url']) {
         //# Fetch external content here, because URL does not contain placeholders
-        if ($GLOBALS['can_fetchUrl'] && preg_match("/\[URL:([^\s]+)\]/i", $cached[$messageid]['content'], $regs)) {
+        if (preg_match("/\[URL:([^\s]+)\]/i", $cached[$messageid]['content'], $regs)) {
             $remote_content = fetchUrl($regs[1], array());
             //  $remote_content = fetchUrl($message['sendurl'],array());
 

--- a/public_html/lists/admin/template.php
+++ b/public_html/lists/admin/template.php
@@ -333,17 +333,11 @@ if ($id) {
             <td><input type="checkbox"
                        name="checkfullimages" <?php echo $checkfullimages ? 'checked="checked"' : '' ?> /></td>
         </tr>
-
-        <?php if ($GLOBALS['can_fetchUrl']) {
-                    ?>
-            <tr>
-                <td><?php echo s('Check that all external images exist') ?></td>
-                <td><input type="checkbox"
-                           name="checkimagesexist" <?php echo $checkimagesexist ? 'checked="checked"' : '' ?> /></td>
-            </tr>
-            <?php
-
-                } ?>
+        <tr>
+            <td><?php echo s('Check that all external images exist') ?></td>
+            <td><input type="checkbox"
+                       name="checkimagesexist" <?php echo $checkimagesexist ? 'checked="checked"' : '' ?> /></td>
+        </tr>
         <tr>
             <td colspan="2"><input class="submit" type="submit" name="save"
                                    value="<?php echo s('Save Changes') ?>"/></td>
@@ -352,7 +346,7 @@ if ($id) {
 </div></div>
 <?php $sendtest_content = sprintf('<div class="sendTest" id="sendTest">
     ' .$sendtestresult.'
-    <input class="submit" type="submit" name="sendtest" value="%s"/>  %s: 
+    <input class="submit" type="submit" name="sendtest" value="%s"/>  %s:
     <input type="text" name="testtarget" size="40" value="' .htmlspecialchars($testtarget).'"/><br />%s
     </div>',
     s('Send test message'), s('to email addresses'),


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
The use of the PEAR HTTP_Request2 package as a fall-back when curl is not available means that phplist is always able to retrieve remote URLs. This change tidies-up some code that is now redundant:

- Remove uses of $can_fetchUrl which is now always true.
- Remove function fetchUrlPear() which is not used.


## Related Issue
<!--- If it fixes an open issue on Mantis (https://mantis.phplist.org), please include a link to the issue here. -->

## Screenshots (if appropriate):
