### PR TITLE
Use htmlentities to output the admin name on subscribe page

### DIFF
--- a/public_html/lists/admin/spageedit.php
+++ b/public_html/lists/admin/spageedit.php
@@ -412,7 +412,7 @@ if (isSuperUser() || accessLevel('spageedit') == 'all') {
     foreach ($admins as $adminid => $adminname) {
         $singleOwner = '<input type="hidden" name="owner" value="'.$adminid.'" />';
         $ownerHTML .= sprintf('<option value="%d" %s>%s</option>', $adminid,
-            $adminid == $data['owner'] ? 'selected="selected"' : '', $adminname);
+            $adminid == $data['owner'] ? 'selected="selected"' : '', htmlentities($adminname));
     }
     $ownerHTML .= '</select>';
 


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
The admin name should be htmlescaped on output. 

To replicate the XSS issue:  
Create an admin where login name is` <script>alert(1)</script>` and go to edit a subscribe page. The javascript will be fired.
