### PR TITLE
Use htmlentities to output the admin name on the edit list page

### DIFF
--- a/public_html/lists/admin/editlist.php
+++ b/public_html/lists/admin/editlist.php
@@ -162,7 +162,7 @@ if (empty($list['category'])) {
         echo '<div class="label"><label for="owner">'.s('Owner').'</label></div><div class="field"><select name="owner">';
         foreach ($admins as $adminid => $adminname) {
             printf('    <option value="%d" %s>%s</option>', $adminid,
-                $adminid == $list['owner'] ? 'selected="selected"' : '', $adminname);
+                $adminid == $list['owner'] ? 'selected="selected"' : '', htmlentities($adminname));
         }
         echo '</select></div>';
     } else {


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
The admin name should be htmlescaped on output.

To replicate the XSS issue:
Create an admin where login name is <script>alert(1)</script> and go to "edit a list" page. The javascript will be fired.