### PR TITLE
Make the default for "Reset click statistics" to be checked

### DIFF
--- a/public_html/lists/admin/lib.php
+++ b/public_html/lists/admin/lib.php
@@ -207,6 +207,7 @@ function loadMessageData($msgid)
         'google_track'   => $default['google_track'] == 'true' || $default['google_track'] === true || $default['google_track'] == '1',
         'excludelist'    => array(),
         'sentastest'     => 0,
+        'resetstats'     => 1,
     );
     if (is_array($prevMsgData)) {
         foreach ($prevMsgData as $key => $val) {


### PR DESCRIPTION


<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
It is easy to forget to check the "Reset click statistics" check box on the Finish tab when composing a campaign.This change makes it checked by default.

## Related Issue
<!--- If it fixes an open issue on Mantis (https://mantis.phplist.org), please include a link to the issue here. -->

## Screenshots (if appropriate):
