### PR TITLE
Fix Incorrect CLICKTRACK description(Wrong default value).

### DIFF
--- a/public_html/lists/config/config_extended.php
+++ b/public_html/lists/config/config_extended.php
@@ -635,10 +635,9 @@ Advanced Features, HTML editor, RSS, Attachments, Plugins. PDF creation
 
 // Click tracking
 // If you set this to 1, all links in your emails will be converted to links that
-// go via phpList. This will make sure that clicks are tracked. This is experimental and
-// all your findings when using this feature should be reported to mantis
-// for now it's off by default until we think it works correctly
-define('CLICKTRACK', 0);
+// go via phpList. This will make sure that clicks are tracked. Default: 1
+// If you disable a URL conversion, set to 0.
+define('CLICKTRACK', 1);
 
 // Click track, list detail
 // if you enable this, you will get some extra statistics about unique users who have clicked the


### PR DESCRIPTION

<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->

The current configuration(`config_extend.php`) describe the following.
This description is incorrect. The correct value is 1.
I wrote the detail #687

> Click track, list detail
> if you enable this, you will get some extra statistics about unique users who have clicked the
> links in your messages, and the breakdown between clicks from text or html messages.
> However, this will slow down the process to view the statistics, so it is
> recommended to leave it off, but if you're very curious, you can enable it


## Related Issue
<!--- If it fixes an open issue on Mantis (https://mantis.phplist.org), please include a link to the issue here. -->

This change fixes #687 issue.

## Screenshots (if appropriate):
