### PR TITLE
Add Reply-To header to campaign emails

### DIFF
--- a/public_html/lists/admin/init.php
+++ b/public_html/lists/admin/init.php
@@ -618,6 +618,9 @@ if (!defined('USERSPAGE_MAX')) {
 if (!defined ('ALLOW_UPDATER')){
     define('ALLOW_UPDATER', true);
 }
+if (!defined ('USE_REPLY_TO')){
+    define('USE_REPLY_TO', false);
+}
 if (!isset($plugins_disabled) || !is_array($plugins_disabled)) {
     $plugins_disabled = array();
 }

--- a/public_html/lists/admin/send_core.php
+++ b/public_html/lists/admin/send_core.php
@@ -700,8 +700,15 @@ if (!$done) {
 
   <div class="field"><label for="fromfield">' .$GLOBALS['I18N']->get('From Line').Help('from').'</label>'.'
     <input type="text" name="fromfield"
-   value="' .htmlentities($utf8_from, ENT_QUOTES, 'UTF-8').'" size="60" /></div>
+   value="' .htmlentities($utf8_from, ENT_QUOTES, 'UTF-8').'" size="60" /></div>';
 
+    if (USE_REPLY_TO) {
+        $maincontent .= '
+  <div class="field"><label for="replyto">' .$GLOBALS['I18N']->get('Reply to').Help('from').'</label>'.'
+    <input type="text" name="replyto"
+   value="' .htmlspecialchars($messagedata['replyto']).'" size="60" /></div>';
+    }
+    $maincontent .= '
     <div class="field" id="message-text-preview">
       <label for="messagepreview">' .s('Message preview').Help('generatetextpreview').'</label>
       <input type="text" id="messagepreview" name="messagepreview" size="60" readonly />

--- a/public_html/lists/admin/sendemaillib.php
+++ b/public_html/lists/admin/sendemaillib.php
@@ -1391,7 +1391,7 @@ function precacheMessage($messageid, $forwardContent = 0)
     $message = loadMessageData($messageid);
     $cached[$messageid]['uuid'] = $message['uuid'];
 
-    //# the reply to is actually not in use
+    // parse the reply-to field into its components - email and name
     if (preg_match('/([^ ]+@[^ ]+)/', $message['replyto'], $regs)) {
         // if there is an email in the from, rewrite it as "name <email>"
         $message['replyto'] = str_replace($regs[0], '', $message['replyto']);

--- a/public_html/lists/config/config_extended.php
+++ b/public_html/lists/config/config_extended.php
@@ -549,6 +549,9 @@ define('LANGUAGE_SWITCH', 1);
 //# the contents are displayed "as-is", so it will not run any PHP code in the file.
 define('ERROR404PAGE', '404.html');
 
+// Add a Reply-To header. Set this to true to show a Reply to field on the Compose tab when creating a campaign.
+define('USE_REPLY_TO', false);
+
 /*
 
 =========================================================================


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
Add Reply-To header to campaign emails controlled by a config file setting.

I suspect that most people will not need to set a separate reply-to address therefore the default value of the config setting is not to display the reply-to field on the Compose tab to avoid cluttering the user interface. 

The existing code to handle reply-to allows the same variations as the From address (email address with optional name, or just name on its own) so the same help topic is used. That is updated in a separate pull request  https://github.com/phpList/phplist-lan-help/pull/26

## Related Issue
<!--- If it fixes an open issue on Mantis (https://mantis.phplist.org), please include a link to the issue here. -->
https://mantis.phplist.org/view.php?id=20230
## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/3147688/87242903-ef416e00-c428-11ea-97bc-4b273b8ca190.png)
