### PR TITLE
Use the original From address when forwarding a campaign email

### DIFF
--- a/public_html/lists/admin/defaultFrontendTexts.php
+++ b/public_html/lists/admin/defaultFrontendTexts.php
@@ -91,7 +91,7 @@ $strForgotPasswordEmailBody = '
     Could you reset it to something and let me know what it is?
 
     Thanks
-';    
+';
 
 $strPassword           = 'Password';
 $strPassword2           = 'Confirm Password';
@@ -140,6 +140,7 @@ $strForwardFooter = 'This message has been forwarded to you by [FORWARDEDBY].
   To subscribe to this newsletter go to';
 $strForward = 'Forward';
 $strFwd = 'Fwd'; # short version of forward for email subject
+$strForwardForwardingName = 'Please enter your full name';
 $strContactAdmin = 'Contact the administrator';
 $strContactMessage     = 'Add us to your address book';
 

--- a/public_html/lists/admin/sendemaillib.php
+++ b/public_html/lists/admin/sendemaillib.php
@@ -889,19 +889,20 @@ function sendEmail($messageid, $email, $hash, $htmlpref = 0, $rssitems = array()
 //  print htmlspecialchars($htmlmessage);exit;
 
     if (!TEST) {
+        $fromname = $cached[$messageid]['fromname'];
+        $fromemail = $cached[$messageid]['fromemail'];
+
         if ($hash != 'forwarded' || !count($forwardedby)) {
-            $fromname = $cached[$messageid]['fromname'];
-            $fromemail = $cached[$messageid]['fromemail'];
             $subject = $cached[$messageid]['subject'];
+
+            if (!empty($cached[$messageid]['replytoemail'])) {
+                $mail->AddReplyTo($cached[$messageid]['replytoemail'], $cached[$messageid]['replytoname']);
+            }
         } else {
-            $fromname = '';
-            $fromemail = $forwardedby['email'];
             $subject = $GLOBALS['strFwd'].': '.$cached[$messageid]['subject'];
+            $mail->AddReplyTo($forwardedby['email']);
         }
 
-        if (!empty($cached[$messageid]['replytoemail'])) {
-            $mail->AddReplyTo($cached[$messageid]['replytoemail'], $cached[$messageid]['replytoname']);
-        }
         if ($getspeedstats) {
             output('build End '.$GLOBALS['processqueue_timer']->interval(1));
         }

--- a/public_html/lists/admin/sendemaillib.php
+++ b/public_html/lists/admin/sendemaillib.php
@@ -889,18 +889,19 @@ function sendEmail($messageid, $email, $hash, $htmlpref = 0, $rssitems = array()
 //  print htmlspecialchars($htmlmessage);exit;
 
     if (!TEST) {
-        $fromname = $cached[$messageid]['fromname'];
         $fromemail = $cached[$messageid]['fromemail'];
 
         if ($hash != 'forwarded' || !count($forwardedby)) {
+            $fromname = $cached[$messageid]['fromname'];
             $subject = $cached[$messageid]['subject'];
 
             if (!empty($cached[$messageid]['replytoemail'])) {
                 $mail->AddReplyTo($cached[$messageid]['replytoemail'], $cached[$messageid]['replytoname']);
             }
         } else {
+            $fromname = $forwardedby['subscriberName'];
             $subject = $GLOBALS['strFwd'].': '.$cached[$messageid]['subject'];
-            $mail->AddReplyTo($forwardedby['email']);
+            $mail->AddReplyTo($forwardedby['email'], $forwardedby['subscriberName']);
         }
 
         if ($getspeedstats) {

--- a/public_html/lists/index.php
+++ b/public_html/lists/index.php
@@ -325,7 +325,7 @@ if ($login_required && empty($_SESSION['userloggedin']) && !$canlogin) {
     echo '<title>'.$GLOBALS['strSubscribeTitle'].'</title>';
     echo $pagedata['header'];
     $req = Sql_Query(sprintf('select * from %s where active', $tables['subscribepage']));
-        
+
     // If active subscribe pages exist then list them
     if (Sql_Affected_Rows()) {
         while ($row = Sql_Fetch_Array($req)) {
@@ -354,7 +354,7 @@ if ($login_required && empty($_SESSION['userloggedin']) && !$canlogin) {
         printf('<p><a href="'.getConfig('unsubscribeurl').'">%s</a></p>', $strUnsubscribeTitle);
     }
     // Print link to contact admin using HTML entities for email obfuscation
-    echo 
+    echo
         '<p class=""><a href="'.
             preg_replace_callback('/./', function($m) {
                 return '&#'.ord($m[0]).';';
@@ -690,7 +690,7 @@ function checkGroup(name,value)
     if (SHOW_UNSUBSCRIBELINK) {
         $html .= ' &nbsp;&nbsp; <a href="'.getConfig('unsubscribeurl').'&id='.$id.'">'.$GLOBALS['strUnsubscribe'].'</a>';
     }
-	$html .='</form>';
+    $html .='</form>';
     $html .= $GLOBALS['PoweredBy'];
     $html .= $GLOBALS['pagedata']['footer'];
     unset($_SESSION['subscriberConfirmed']);
@@ -913,15 +913,15 @@ function unsubscribePage($id)
             }
         }
 
-	if ($userid) {
-	    if (UNSUBSCRIBE_CONFIRMATION) {
-	        $res .= '<h3>' . $GLOBALS['strUnsubscribeDone'] . '</h3>';
-	    } else {
-	        $res .= '<h3>' . $GLOBALS['strUnsubscribedNoConfirm'] . '</h3>';
-	    }
-	}
-        
-	//0013076: Blacklisting posibility for unknown users
+    if ($userid) {
+        if (UNSUBSCRIBE_CONFIRMATION) {
+            $res .= '<h3>' . $GLOBALS['strUnsubscribeDone'] . '</h3>';
+        } else {
+            $res .= '<h3>' . $GLOBALS['strUnsubscribedNoConfirm'] . '</h3>';
+        }
+    }
+
+    //0013076: Blacklisting posibility for unknown users
         //if ($blacklistRequest) {
         //$res .= '<h3>'.$GLOBALS["strYouAreBlacklisted"] ."</h3>";
         //}
@@ -1076,7 +1076,14 @@ function forwardPage($id)
     } else {
         $ok = false;
     }
-
+    // subscriber name
+    if (!empty($_REQUEST['subscriberName'])) {
+        $subscriberName = htmlspecialchars_decode(stripslashes($_REQUEST['subscriberName']));
+        $userdata['subscriberName'] = $subscriberName;
+    } else {
+        $subscriberName = '';
+        $ok = false;
+    }
     //0011996: forward to friend - personal message
     // text cannot be longer than max, to prevent very long text with only linefeeds total cannot be longer than twice max
     if (FORWARD_PERSONAL_NOTE_SIZE && isset($_REQUEST['personalNote'])) {
@@ -1178,22 +1185,36 @@ function forwardPage($id)
     if (!$ok) {
         //0011860: forward to friend, multiple emails
         if (FORWARD_EMAIL_COUNT == 1) {
-            $form .= '<br /><h2>'.$GLOBALS['strForwardEnterEmail'].'</h2>';
-            $form .= sprintf('<input type=text name="email" value="%s" size=50 class="attributeinput">', $forwardemail);
+            $format = <<<'END'
+<div class="required"><label for="email">%s</label></div>
+<input type=text name="email" id="email" value="%s" size=50 class="attributeinput">
+END;
+            $form .= sprintf($format, $GLOBALS['strForwardEnterEmail'], $forwardemail);
         } else {
-            $form .= '<br /><h2>'.sprintf($GLOBALS['strForwardEnterEmails'], FORWARD_EMAIL_COUNT).'</h2>';
-            $form .= sprintf('<textarea name="email" rows="10" cols="50" class="attributeinput">%s</textarea>',
-                $forwardemail);
+            $labelText = sprintf($GLOBALS['strForwardEnterEmails'], FORWARD_EMAIL_COUNT);
+            $format = <<<'END'
+<div class="required"><label for="email">%s</label></div>
+<textarea name="email" id="email" rows="%d" cols="50" class="attributeinput">%s</textarea>
+END;
+            $form .= sprintf($format, $labelText, min(10, FORWARD_EMAIL_COUNT), $forwardemail);
         }
+        $format = <<<'END'
+<div class="required"><label for="subscriberName">%s</label></div>
+<input type=text name="subscriberName" id="subscriberName" value="%s" size=50 class="attributeinput">
+END;
+        $form .= sprintf($format, $GLOBALS['strForwardForwardingName'], htmlspecialchars($subscriberName));
 
         //0011996: forward to friend - personal message
         if (FORWARD_PERSONAL_NOTE_SIZE) {
-            $form .= sprintf('<h2>'.$GLOBALS['strForwardPersonalNote'].'</h2>', FORWARD_PERSONAL_NOTE_SIZE);
+            $labelText= sprintf($GLOBALS['strForwardPersonalNote'], FORWARD_PERSONAL_NOTE_SIZE);
             $cols = 50;
             $rows = min(10, ceil(FORWARD_PERSONAL_NOTE_SIZE / 40));
-
-            $form .= sprintf('<br/><textarea type="text" name="personalNote" rows="%d" cols="%d" class="attributeinput">%s</textarea>',
-                $rows, $cols, $personalNote);
+            $format = <<<'END'
+<div><label for="personalNote">%s</div>
+<textarea type="text" name="personalNote" id="personalNote" rows="%d" cols="%d" class="attributeinput">%s</textarea>
+</label>
+END;
+            $form .= sprintf($format, $labelText, $rows, $cols, $personalNote);
         }
         $form .= sprintf('<br /><input type="submit" value="%s"></form>', $GLOBALS['strContinue']);
     }


### PR DESCRIPTION


<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
When forwarding a campaign email the From address is the subscriber's address not the original From address. This can cause delivery problems when using services such as Amazon SES that require the From address to be verified.

There are two changes affecting forwarding a campaign email

- Use the original From address instead of the subscriber address for the From address
- Use the subscriber address for the Reply-to address

## Related Issue
<!--- If it fixes an open issue on Mantis (https://mantis.phplist.org), please include a link to the issue here. -->
https://mantis.phplist.org/view.php?id=18075
## Screenshots (if appropriate):
