### PR TITLE
Mantis 20239: Sort campaigns in "statistics overview" by sent date

### DIFF
--- a/public_html/lists/admin/actions/statsoverview.php
+++ b/public_html/lists/admin/actions/statsoverview.php
@@ -70,7 +70,7 @@ $timerange = '';
 
 $query = sprintf('select msg.owner,msg.id as messageid, subject, sent, bouncecount as bounced
     from %s msg where msg.status = "sent" %s %s %s
-    group by msg.id order by msg.entered desc',
+    group by msg.id order by msg.sent desc',
     $GLOBALS['tables']['message'], $subselect, $timerange, $ownership);
 $req = Sql_Query($query);
 $total = Sql_Num_Rows($req);
@@ -135,7 +135,7 @@ while ($row = Sql_Fetch_Array($req)) {
         PageURL2('statsoverview&amp;id='.$row['messageid'])); //,PageURL2('message&amp;id='.$row['messageid']));
     $ls->setClass($element, 'row1');
     //   $ls->addColumn($element,s('owner'),$row['owner']);
-    $ls->addColumn($element, s('date'), formatDate($row['sent'], true));
+    $ls->addColumn($element, s('Date sent'), formatDate($row['sent'], true));
     $ls->addColumn($element, s('sent'), number_format((int)$totls[0]));
     $ls->addColumn($element, s('bncs').Help("bounces"), number_format((int)$row['bounced']).$percentBouncedFormatted);
     $ls->addColumn($element, s('fwds').Help("forwards"), number_format((int)$fwded[0]));


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
On the Statistics Overview page order by the sent date.
Change the column heading from "date" to "Date sent" to clarify which date is being displayed.
## Related Issue
<!--- If it fixes an open issue on Mantis (https://mantis.phplist.org), please include a link to the issue here. -->
https://mantis.phplist.org/view.php?id=20239
## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/3147688/89093117-67a7a900-d3af-11ea-998a-567b2acccddd.png)
