### PR TITLE
Mantis 20247 - Do not replace message fields in a user-specific URL

### DIFF
--- a/public_html/lists/admin/js/phplistapp.js
+++ b/public_html/lists/admin/js/phplistapp.js
@@ -272,7 +272,7 @@ $(document).ready(function () {
             return;
         }
         $("#remoteurlstatus").html(busyImage);
-        $("#remoteurlstatus").load("./?page=pageaction&action=checkurl&ajaxed=true&url=" + this.value);
+        $("#remoteurlstatus").load("./?page=pageaction&action=checkurl&ajaxed=true&url=" + encodeURIComponent(this.value));
     });
     $("#filtertext").on("focus",function () {
         if (this.value == ' --- filter --- ') {

--- a/public_html/lists/admin/sendemaillib.php
+++ b/public_html/lists/admin/sendemaillib.php
@@ -1539,16 +1539,15 @@ function precacheMessage($messageid, $forwardContent = 0)
         output('parse config end');
     }
 
-    //# ##17233 not that many fields are actually useful, so don't blatantly use all
-//  foreach($message as $key => $val) {
     foreach (array('subject', 'id', 'fromname', 'fromemail') as $key) {
         $val = $message[$key];
-        if (!is_array($val)) {
+        // Replace in content except for user-specific URL
+        if (!$cached[$messageid]['userspecific_url']) {
             $cached[$messageid]['content'] = str_ireplace("[$key]", $val, $cached[$messageid]['content']);
-            $cached[$messageid]['textcontent'] = str_ireplace("[$key]", $val, $cached[$messageid]['textcontent']);
-            $cached[$messageid]['textfooter'] = str_ireplace("[$key]", $val, $cached[$messageid]['textfooter']);
-            $cached[$messageid]['htmlfooter'] = str_ireplace("[$key]", $val, $cached[$messageid]['htmlfooter']);
         }
+        $cached[$messageid]['textcontent'] = str_ireplace("[$key]", $val, $cached[$messageid]['textcontent']);
+        $cached[$messageid]['textfooter'] = str_ireplace("[$key]", $val, $cached[$messageid]['textfooter']);
+        $cached[$messageid]['htmlfooter'] = str_ireplace("[$key]", $val, $cached[$messageid]['htmlfooter']);
     }
     /*
      *  cache message owner and list owner attribute values


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
When using a web page for the content of a campaign the URL may contain user placeholders. Currently the [ID] placeholder is  replaced by the message id in earlier processing instead of by the user id. This change avoids trying to replace message fields in the URL.

From the web server log when fetching the remote url
Prior to change, was using the message id
`127.0.0.1 - - [18/Aug/2020:10:41:53 +0100] "GET /webpage.html?email=foo567%40bar.com&id=168 HTTP/1.1" 200 396 "-" "phplist v3.5.6-RC1c (https://www.phplist.com)"`

Now uses the user id
`127.0.0.1 - - [18/Aug/2020:10:44:32 +0100] "GET /webpage.html?email=foo567%40bar.com&id=3012 HTTP/1.1" 200 396 "-" "phplist v3.5.5.1-devc (https://www.phplist.com)"`

Additionally, when testing whether the entered URL is valid by fetching it, the URL needs to be encoded when included as a query parameter in a phplist page URL.

Prior to change the p2 query parameter was being removed
`127.0.0.1 - - [18/Aug/2020:11:21:54 +0100] "GET /webpage.html?p1=foo HTTP/1.1" 200 396 "-" "phplist v3.5.5.1-devc (https://www.phplist.com)"`

Now all query parameters are being kept
`127.0.0.1 - - [18/Aug/2020:11:22:27 +0100] "GET /webpage.html?p1=foo&p2=bar HTTP/1.1" 200 396 "-" "phplist v3.5.5.1-devc (https://www.phplist.com)"`


## Related Issue
<!--- If it fixes an open issue on Mantis (https://mantis.phplist.org), please include a link to the issue here. -->
https://mantis.phplist.org/view.php?id=20247
## Screenshots (if appropriate):
