### PR TITLE
Ajax subscription: access-control-allow-origin for multiple websites

### DIFF
--- a/public_html/lists/admin/init.php
+++ b/public_html/lists/admin/init.php
@@ -653,7 +653,9 @@ if (!defined('PHPLIST_POWEREDBY_URLROOT')) {
 if (!isset($allowed_referrers) || !is_array($allowed_referrers)) {
     $allowed_referrers = array();
 }
-if (!defined('ACCESS_CONTROL_ALLOW_ORIGIN')) {
+if (defined('ACCESS_CONTROL_ALLOW_ORIGINS') && in_array($_SERVER['HTTP_ORIGIN'], ACCESS_CONTROL_ALLOW_ORIGINS)) {
+    define('ACCESS_CONTROL_ALLOW_ORIGIN', $_SERVER['HTTP_ORIGIN']);
+} elseif (!defined('ACCESS_CONTROL_ALLOW_ORIGIN')) {
     define('ACCESS_CONTROL_ALLOW_ORIGIN', $GLOBALS['scheme'].'://'.$_SERVER['HTTP_HOST']);
 }
 

--- a/public_html/lists/config/config_extended.php
+++ b/public_html/lists/config/config_extended.php
@@ -874,3 +874,7 @@ define('ALLOW_UPDATER', true);
 // When feedback loop is configured in Google mail according to https://support.google.com/mail/answer/6254652?hl=en
 // adds constant to email headers
 define('GOOGLE_SENDERID', '');
+
+// For ajax based signup forms (https://discuss.phplist.org/t/solved-ajax-subscribe-api/974) the access-control-allow-origin header has to be set properly.
+// Add the addresses of the websites you want to allow to perform ajax requests to PHPList.
+define('ACCESS_CONTROL_ALLOW_ORIGINS', ['https://example.com','https://example.org']);

--- a/public_html/lists/index.php
+++ b/public_html/lists/index.php
@@ -54,7 +54,7 @@ include_once dirname(__FILE__).'/admin/lib.php';
 
 $I18N = new phplist_I18N();
 header('Access-Control-Allow-Origin: '.ACCESS_CONTROL_ALLOW_ORIGIN);
-//header('Vary', 'Origin');
+header('Vary: Origin'); // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin#CORS_and_caching
 
 if (!empty($GLOBALS['SessionTableName'])) {
     require_once dirname(__FILE__).'/admin/sessionlib.php';

--- a/public_html/lists/index.php
+++ b/public_html/lists/index.php
@@ -54,7 +54,9 @@ include_once dirname(__FILE__).'/admin/lib.php';
 
 $I18N = new phplist_I18N();
 header('Access-Control-Allow-Origin: '.ACCESS_CONTROL_ALLOW_ORIGIN);
-header('Vary: Origin'); // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin#CORS_and_caching
+if (defined('ACCESS_CONTROL_ALLOW_ORIGINS') && count('ACCESS_CONTROL_ALLOW_ORIGINS') > 1) {
+    header('Vary: Origin'); // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin#CORS_and_caching
+}
 
 if (!empty($GLOBALS['SessionTableName'])) {
     require_once dirname(__FILE__).'/admin/sessionlib.php';

--- a/public_html/lists/index.php
+++ b/public_html/lists/index.php
@@ -54,6 +54,7 @@ include_once dirname(__FILE__).'/admin/lib.php';
 
 $I18N = new phplist_I18N();
 header('Access-Control-Allow-Origin: '.ACCESS_CONTROL_ALLOW_ORIGIN);
+//header('Vary', 'Origin');
 
 if (!empty($GLOBALS['SessionTableName'])) {
     require_once dirname(__FILE__).'/admin/sessionlib.php';


### PR DESCRIPTION
## Description
I needed my ajax-based PHPList subscription forms to be working on multiple websites, so I added a new config constant called "ACCESS_CONTROL_ALLOW_ORIGINS" which is an array where you can put in your different origins you want to allow.
I also added a new header "Vary: Origin" in order to optimize cache control. (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin#CORS_and_caching)