### PR TITLE
Use PHPMailer 6 by default instead of PHPMailer 5.

### DIFF
--- a/public_html/lists/admin/init.php
+++ b/public_html/lists/admin/init.php
@@ -759,7 +759,7 @@ if (!defined('MESSAGEQUEUE_PREPARE')) {
     }
 }
 if (!defined('USE_PHPMAILER6')) {
-    define('USE_PHPMAILER6', false);
+    define('USE_PHPMAILER6', true);
 }
 if (!isset($GLOBALS['export_mimetype'])) {
     $GLOBALS['export_mimetype'] = 'application/csv';


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
It is about a year since PHPMailer 6 was included and could be enabled through config.php https://github.com/phpList/phplist3/pull/608

When installing phplist I have enabled PHPMailer 6 and not seen any problems so it could now be made the default.
This will affect all phplist installations, not just new installations, unless the owner explicitly disables using PHPMailer 6 through config.php
## Related Issue
<!--- If it fixes an open issue on Mantis (https://mantis.phplist.org), please include a link to the issue here. -->

## Screenshots (if appropriate):
