### PR TITLE
Avoid problem with custom PHPMailer 5 path when using PHPMailer 6

### DIFF
--- a/public_html/lists/admin/class.phplistmailerbase.php
+++ b/public_html/lists/admin/class.phplistmailerbase.php
@@ -8,7 +8,7 @@ if (USE_PHPMAILER6) {
             $prefixLength = strlen($prefix);
 
             if (substr($classname, 0, $prefixLength) == $prefix) {
-                $phpmailerPath = defined('PHPMAILER_PATH') && PHPMAILER_PATH != ''
+                $phpmailerPath = defined('PHPMAILER_PATH') && is_dir(PHPMAILER_PATH)
                     ? rtrim(PHPMAILER_PATH, '/') . '/'
                     : 'PHPMailer6/src/';
                 $filename = $phpmailerPath . substr($classname, $prefixLength) . '.php';
@@ -33,7 +33,7 @@ if (USE_PHPMAILER6) {
         }
     }
 } else {
-    if (defined('PHPMAILER_PATH') and PHPMAILER_PATH != '') {
+    if (defined('PHPMAILER_PATH') && is_file(PHPMAILER_PATH)) {
         require_once PHPMAILER_PATH;
     } else {
         require_once __DIR__.'/PHPMailer/PHPMailerAutoload.php';


### PR DESCRIPTION


<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
Use PHPMAILER_PATH only when it appears to be valid. For PHPMailer 5 it should be a file and for PHPMailer 6 it should be a directory.
## Related Issue
<!--- If it fixes an open issue on Mantis (https://mantis.phplist.org), please include a link to the issue here. -->
https://mantis.phplist.org/view.php?id=20286
## Screenshots (if appropriate):
