### PR TITLE
Avoid sql error when importing a file with the wrong field delimiter

### DIFF
--- a/public_html/lists/admin/import2.php
+++ b/public_html/lists/admin/import2.php
@@ -171,9 +171,11 @@ if (isset($_POST['import'])) {
 }
 
 if (isset($_GET['delimiter'])) {
-    // Reprocess the file using the selected delimiter
-    $_SESSION['import_field_delimiter'] = $_GET['delimiter'];
-    $_SESSION['import_attribute'] = [];
+    if (is_string($_GET['delimiter']) && strlen($_GET['delimiter']) == 1) {
+        // Reprocess the file using the selected delimiter
+        $_SESSION['import_field_delimiter'] = $_GET['delimiter'];
+        $_SESSION['import_attribute'] = [];
+    }
     unset($_GET['delimiter']);
 }
 
@@ -363,12 +365,12 @@ if (!empty($_SESSION['import_file'])) {
         $ls->addButton($GLOBALS['I18N']->get('Continue'), 'javascript:document.importform.submit()');
 
         if (count($headers) == 1) {
+            echo '<div class="clearfix"></div><div class="note">';
             // try to identify the actual field delimiter from commonly-used values
             if (preg_match('/([,;:|])/', $headers[0], $matches)) {
                 $delimiter = $matches[1];
                 $warning = s(
-                    "The file appears to be using '%s' as the field delimiter. Click Resubmit to use '%s' as the delimiter.",
-                    $delimiter,
+                    "The file appears to be using '%s' as the field delimiter. Click Resubmit to use that delimiter.",
                     $delimiter
                 );
                 $url = sprintf('import2&delimiter=%s', urlencode($delimiter));
@@ -377,6 +379,7 @@ if (!empty($_SESSION['import_file'])) {
                 $warning = s('The entered field delimiter might not be correct.');
                 printf('<p class="information">%s</p>', $warning);
             }
+            echo '</div>';
         }
         echo '<p class="information">'.$GLOBALS['I18N']->get('Please identify the target of the following unknown columns').'</p>';
         echo '<form name="importform" method="post">';

--- a/public_html/lists/admin/import2.php
+++ b/public_html/lists/admin/import2.php
@@ -298,7 +298,8 @@ if (!empty($_SESSION['import_file'])) {
             } else {
                 //# define mapping based on existing attribute or ask for it
                 //@@ Why is $attributes not used
-                $existing = Sql_Fetch_Row_Query('select id from '.$tables['attribute']." where name = \"$column\"");
+                $query = sprintf('select id from %s where name = "%s"', $tables['attribute'], sql_escape($column));
+                $existing = Sql_Fetch_Row_Query($query);
                 $_SESSION['import_attribute'][$column] = array(
                     'index'  => $i,
                     'record' => $existing[0],

--- a/public_html/lists/admin/import2.php
+++ b/public_html/lists/admin/import2.php
@@ -170,6 +170,13 @@ if (isset($_POST['import'])) {
     $_SESSION['throttle_import'] = !empty($_POST['throttle_import']) ? sprintf('%d', $_POST['throttle_import']) : 0;
 }
 
+if (isset($_GET['delimiter'])) {
+    // Reprocess the file using the selected delimiter
+    $_SESSION['import_field_delimiter'] = $_GET['delimiter'];
+    $_SESSION['import_attribute'] = [];
+    unset($_GET['delimiter']);
+}
+
 if (!empty($_GET['confirm'])) {
     $_SESSION['test_import'] = '';
 }
@@ -354,6 +361,23 @@ if (!empty($_SESSION['import_file'])) {
     }
     if ($request_mapping) {
         $ls->addButton($GLOBALS['I18N']->get('Continue'), 'javascript:document.importform.submit()');
+
+        if (count($headers) == 1) {
+            // try to identify the actual field delimiter from commonly-used values
+            if (preg_match('/([,;:|])/', $headers[0], $matches)) {
+                $delimiter = $matches[1];
+                $warning = s(
+                    "The file appears to be using '%s' as the field delimiter. Click Resubmit to use '%s' as the delimiter.",
+                    $delimiter,
+                    $delimiter
+                );
+                $url = sprintf('import2&delimiter=%s', urlencode($delimiter));
+                printf('<p class="information">%s</p>%s', $warning, PageLinkButton($url, s('Resubmit')));
+            } else {
+                $warning = s('The entered field delimiter might not be correct.');
+                printf('<p class="information">%s</p>', $warning);
+            }
+        }
         echo '<p class="information">'.$GLOBALS['I18N']->get('Please identify the target of the following unknown columns').'</p>';
         echo '<form name="importform" method="post">';
         echo $ls->display();


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
This forum topic  https://discuss.phplist.org/t/attributes-not-working-on-import/6768 showed an sql error when trying to import a comma separated file but not changing the field separator from TAB. This change escapes the column name when trying to match it with an attribute name.
## Related Issue
<!--- If it fixes an open issue on Mantis (https://mantis.phplist.org), please include a link to the issue here. -->

## Screenshots (if appropriate):
