### PR TITLE
make message preview configurable

### DIFF
--- a/public_html/lists/admin/init.php
+++ b/public_html/lists/admin/init.php
@@ -369,6 +369,9 @@ if (!defined('UPLOADIMAGES_DIR')) {
 if (!defined('USE_MANUAL_TEXT_PART')) {
     define('USE_MANUAL_TEXT_PART', 0);
 }
+if (!defined('USE_MESSAGE_PREVIEW')) {
+    define('USE_MESSAGE_PREVIEW',false);
+}
 if (!defined('ALLOW_NON_LIST_SUBSCRIBE')) {
     define('ALLOW_NON_LIST_SUBSCRIBE', 0);
 }

--- a/public_html/lists/admin/send_core.php
+++ b/public_html/lists/admin/send_core.php
@@ -708,14 +708,16 @@ if (!$done) {
     <input type="text" name="replyto"
    value="' .htmlspecialchars($messagedata['replyto']).'" size="60" /></div>';
     }
+    if (USE_MESSAGE_PREVIEW) {
     $maincontent .= '
-    <div class="field" id="message-text-preview">
-      <label for="messagepreview">' .s('Message preview').Help('generatetextpreview').'</label>
-      <input type="text" id="messagepreview" name="messagepreview" size="60" readonly />
-      <div id="message-text-preview-button">' .
-        PageLinkAjax('send&tab=Content&id='.$id.'&action=generatetextpreview', $GLOBALS['I18N']->get('Generate')).'</a>
-      </div>
-    </div>';
+        <div class="field" id="message-text-preview">
+        <label for="messagepreview">' .s('Message preview').Help('generatetextpreview').'</label>
+        <input type="text" id="messagepreview" name="messagepreview" size="60" readonly />
+        <div id="message-text-preview-button">' .
+            PageLinkAjax('send&tab=Content&id='.$id.'&action=generatetextpreview', $GLOBALS['I18N']->get('Generate')).'
+        </div>
+        </div>';
+    }
 
     $maincontent .= sprintf('
 

--- a/public_html/lists/config/config_extended.php
+++ b/public_html/lists/config/config_extended.php
@@ -672,6 +672,9 @@ define('EMBEDEXTERNALIMAGES',false);
 // instead of trying to create it by parsing the HTML version into plain text
 define('USE_MANUAL_TEXT_PART', 0);
 
+// Message preview tries to show a small preview of how your campaign will look in email applications
+define('USE_MESSAGE_PREVIEW',true);
+
 // set this to 1 to allow adding attachments to the mails
 // caution, message may become very large. it is generally more
 // acceptable to send a URL for download to users


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
Allow a flag to switch the Message Preview on or off.

## Related Issue
<!--- If it fixes an open issue on Mantis (https://mantis.phplist.org), please include a link to the issue here. -->

## Screenshots (if appropriate):
