### PR TITLE
Mantis 18002 Undefined Index when calling via Command-Line

### DIFF
--- a/public_html/lists/admin/index.php
+++ b/public_html/lists/admin/index.php
@@ -540,7 +540,7 @@ if (!$ajax && $page != 'login') {
         if ($updateNotif !== '') {
             Info($updateNotif . '' . $moreInfo);
         }
-        
+
 #   }
 
     if (version_compare(PHP_VERSION, '5.3.3', '<') && WARN_ABOUT_PHP_SETTINGS) {
@@ -854,6 +854,9 @@ function parseCline()
             $clinearg = substr($clinearg, 2, strlen($clinearg));
             // $res[$par] = "";
             $cur = mb_strtolower($par);
+            if (!isset($res[$cur])) {
+                $res[$cur] = '';
+            }
             $res[$cur] .= $clinearg;
         } elseif ($cur) {
             if ($res[$cur]) {


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
Avoid php undefined index notice when parsing command line parameters.
## Related Issue
<!--- If it fixes an open issue on Mantis (https://mantis.phplist.org), please include a link to the issue here. -->
https://mantis.phplist.org/view.php?id=18002
## Screenshots (if appropriate):
