### PR TITLE
change results display to info, so that the content stays on the page

### DIFF
--- a/public_html/lists/admin/importsimple.php
+++ b/public_html/lists/admin/importsimple.php
@@ -114,7 +114,7 @@ if (!empty($_POST['importcontent'])) {
                 $count['foundonblacklist']).PHP_EOL;
     }
 
-    echo ActionResult(nl2br($report));
+    echo Info(nl2br($report),true);
 
     if ($_GET['page'] == 'importsimple') {
         if (!empty($_GET['list'])) {


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
When importing the results disappear. This will keep them on the page.

## Related Issue
https://mantis.phplist.org/view.php?id=20321

## Screenshots (if appropriate):
