### PR TITLE
Remove leading https as well as http when shortening a URL

### DIFF
--- a/public_html/lists/admin/lib.php
+++ b/public_html/lists/admin/lib.php
@@ -1906,7 +1906,7 @@ function shortenTextDisplay($text, $max = 30)
         return mb_shortenTextDisplay($text, $max);
     }
 
-    $text = str_replace('http://', '', $text);
+    $text = preg_replace('!^https?://!i', '', $text);
     if (strlen($text) > $max) {
         if ($max < 30) {
             $display = substr($text, 0, $max - 4).' ... ';
@@ -1925,7 +1925,7 @@ function shortenTextDisplay($text, $max = 30)
 
 function mb_shortenTextDisplay($text, $max = 30)
 {
-    $text = str_replace('http://', '', $text);
+    $text = preg_replace('!^https?://!i', '', $text);
     if (mb_strlen($text) > $max) {
         if ($max < 30) {
             $display = mb_substr($text, 0, $max - 4).' ... ';


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
Currently when a URL is shortened for display, such as to show link clicks, a leading "http://" is removed but not a leading "https://". 


## Related Issue
<!--- If it fixes an open issue on Mantis (https://mantis.phplist.org), please include a link to the issue here. -->

## Screenshots (if appropriate):
Current 
![Screenshot from 2021-01-20 10-02-46](https://user-images.githubusercontent.com/3147688/105159889-85a4c980-5b07-11eb-9f52-b042dd95b7f4.png)

After this change
![Screenshot from 2021-01-20 10-03-59](https://user-images.githubusercontent.com/3147688/105159975-981f0300-5b07-11eb-85fd-d7d3c5b1c6b4.png)

