### PR TITLE
Change default value of UNSUBSCRIBE_JUMPOFF

### DIFF
--- a/doc/README.robots
+++ b/doc/README.robots
@@ -1,0 +1,8 @@
+Placing a robots.txt file in the web root directory can help stop anti-malware software or email servers
+"following" links in an email. That can lead to unauthorised unsubscriptions when UNSUBSCRIBE_JUMPOFF is set to 1.
+
+Create a robots.txt file in the web root directory with these lines or add to an existing robots.txt file
+adjusting if necessary to the actual directory in which phplist is installed.
+
+user-agent: *
+disallow: /lists/

--- a/public_html/lists/config/config_extended.php
+++ b/public_html/lists/config/config_extended.php
@@ -177,9 +177,13 @@ define('HASH_ALGO', 'sha256');
 // to 1 for this to have an effect
 define('UNSUBSCRIBE_REQUIRES_PASSWORD', 0);
 
-// if a user should immediately be unsubscribed, when using their personal URL, instead of
-// the default way, which will ask them for a reason, set this to 1
-define('UNSUBSCRIBE_JUMPOFF', 0);
+// Immediately unsubscribe a subscriber when using their personal URL.
+// To display a confirmation page asking them for a reason set this to 0.
+// Be aware that setting to 1 might lead to unauthorised unsubscriptions due to a receiving mail server
+// "following" links in an email. If that happens then set this to 0.
+// Also, see the file README.robots in the phplist distribution doc directory for another way to try to
+// stop unauthorised unsubscriptions.
+define('UNSUBSCRIBE_JUMPOFF', 1);
 
 // To not send confirmation of unsubscription , instead of
 // the default way, which will send it, set this to false


### PR DESCRIPTION

<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
The default value of UNSUBSCRIBE_JUMPOFF , when not specified in config.php, is 1, i.e. an unsubscribe confirmation page is **not** displayed. This is different to the explanation in config_extended.php which suggests that the default is 0.

There have been reports in the user forum and Mantis about unauthorised unsubscriptions possibly due to "link following" by anti-malware software. So it seems safer to make the default not to jumpoff.

Include an explanation of how robots.txt might be used to try to stop "link following".

## Related Issue
<!--- If it fixes an open issue on Mantis (https://mantis.phplist.org), please include a link to the issue here. -->

## Screenshots (if appropriate):
