### PR TITLE
Add Constant For Suppressing Welcome Message Globally and Per Subscribe Page

### DIFF
--- a/public_html/lists/index.php
+++ b/public_html/lists/index.php
@@ -750,8 +750,12 @@ function confirmPage($id)
                 getUserConfig("confirmationmessage:$id", $userdata['id']));
 
             if (!TEST) {
-                sendMail($userdata['email'], getConfig("confirmationsubject:$id"), $confirmationmessage,
-                    system_messageheaders(), $envelope);
+                if( !defined("SUBSCRIBE_CONFIRMATION") || ( defined("SUBSCRIBE_CONFIRMATION") && ( SUBSCRIBE_CONFIRMATION == true ) ) ){
+					if( !defined("SUBSCRIBE_CONFIRMATION_{$id}") || ( defined("SUBSCRIBE_CONFIRMATION_{$id}") && ( constant("SUBSCRIBE_CONFIRMATION_{$id}") == true ) ) ){
+						sendMail($userdata['email'], getConfig("confirmationsubject:$id"), $confirmationmessage,
+							system_messageheaders(), $envelope);
+					}
+				}
                 $adminmessage = $userdata['email'].' has confirmed their subscription';
                 if ($blacklisted) {
                     $adminmessage .= "\n\n".s('Subscriber has been removed from blacklist');


### PR DESCRIPTION
Partial feature implementation for #18433 in Mantis, defined a constant that can disable the welcome message, either globally or per subscribe form

<!---Thanks for contributing to phpList!-->

## Description
A fairly simple statement and new constant that allows the welcome message to be suppressed, after a subscriber has confirmed their subscription. This can be done globally or on a per subscription page basis.

## Related Issue
<!--- If it fixes an open issue on Mantis (https://mantis.phplist.org), please include a link to the issue here. -->
This is a partial fix to an issue on Mantis (https://mantis.phplist.org/view.php?id=18433)
