### PR TITLE
Log event for fetching URL success only when verbose is enabled

### DIFF
--- a/public_html/lists/admin/lib.php
+++ b/public_html/lists/admin/lib.php
@@ -1275,7 +1275,9 @@ function fetchUrl($url, $userdata = array(), $ttl = REMOTE_URL_REFETCH_TIMEOUT)
 
     if (!empty($content)) {
         $content = addAbsoluteResources($content, $url);
-        logEvent('Fetching '.$url.' success');
+        if (VERBOSE) {
+            logEvent('Fetching '.$url.' success');
+        }
         setPageCache($url, $lastmodified, $content);
 
         $GLOBALS['urlcache'][$url] = array(


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
The function fetchUrl() adds to the event log in several places. In all but one case that is when VERBOSE is enabled.

In some circumstances the code checking for a new phplist release which is run on every page load can cause repeated event log records to be written.

This problem was reported in the user forum https://discuss.phplist.org/t/fetching-https-download-phplist-org-version-json-version-3-6-0-success/6989

To clarify why that particular log record is written so often. The check for a new release is on every page load but version.json should be cached in the urlcache table and retrieved only every 3 days. However, that table is emptied during processqueue. So when someone runs processqueue frequently then version.json can be retrieved much more frequently.

## Related Issue
<!--- If it fixes an open issue on Mantis (https://mantis.phplist.org), please include a link to the issue here. -->

## Screenshots (if appropriate):
