### PR TITLE
Text templates

### DIFF
--- a/public_html/lists/admin/class.phplistmailer.php
+++ b/public_html/lists/admin/class.phplistmailer.php
@@ -281,7 +281,7 @@ class phplistMailer extends phplistMailerBase
                     }
                 }
             }
-            if (!parent::Send()) {
+            if (!parent::send()) {
                 logEvent(s('Error sending email to %s', $to_addr).' '.$this->ErrorInfo);
 
                 return 0;

--- a/public_html/lists/admin/defaultsystemtemplate.php
+++ b/public_html/lists/admin/defaultsystemtemplate.php
@@ -413,7 +413,7 @@ if (isset($_POST['Submit'])) {
         echo PageLinkButton('templates', s('Go back to templates'));
         echo '</p>';
     } else {
-        Sql_Query(sprintf('insert into %s (title,template,listorder) values("%s","%s",0)',
+        Sql_Query(sprintf('insert into %s (title,template,template_text,listorder) values("%s","%s","[CONTENT]",0)',
             $GLOBALS['tables']['template'], $title, addslashes($content)));
         $newid = Sql_Insert_Id();
         if ($title === 'System template') {

--- a/public_html/lists/admin/lib.php
+++ b/public_html/lists/admin/lib.php
@@ -482,7 +482,7 @@ function constructSystemMail($message, $subject = '')
             $GLOBALS['tables']['template'], $templateid));
         $htmltemplate = stripslashes($req[0]);
     }
-    if (strpos($htmltemplate, '[CONTENT]')) {
+    if (strpos($htmltemplate, '[CONTENT]') !== false) {
         $htmlcontent = str_replace('[CONTENT]', $htmlmessage, $htmltemplate);
         $htmlcontent = str_replace('[SUBJECT]', $subject, $htmlcontent);
         $htmlcontent = str_replace('[FOOTER]', '', $htmlcontent);

--- a/public_html/lists/admin/lib.php
+++ b/public_html/lists/admin/lib.php
@@ -578,7 +578,7 @@ function sendMailDirect($destinationemail, $subject, $message)
     }
     $mail->add_text($textmessage);
     try {
-        $mail->Send('', $destinationemail, $fromname, $fromemail, $subject);
+        $mail->send('', $destinationemail, $fromname, $fromemail, $subject);
     } catch (Exception $e) {
         $GLOBALS['smtpError'] = $e->getMessage();
 

--- a/public_html/lists/admin/lib.php
+++ b/public_html/lists/admin/lib.php
@@ -450,8 +450,6 @@ function sendMail($to, $subject, $message, $header = '', $parameters = '', $skip
 function constructSystemMail($message, $subject = '')
 {
     $hasHTML = strip_tags($message) != $message;
-    $htmlcontent = '';
-    $textcontent = '';
 
     if ($hasHTML) {
         $message = stripslashes($message);
@@ -476,43 +474,41 @@ function constructSystemMail($message, $subject = '')
         $htmlmessage = str_replace($listsmatch[0], '<ul>'.$listsHTML.'</ul>', $htmlmessage);
     }
 
-    $htmltemplate = '';
-    $texttemplate = '';
+    $htmlcontent = $htmlmessage;
+    $textcontent = $textmessage;
     $templateid = getConfig('systemmessagetemplate');
     if (!empty($templateid)) {
         $req = Sql_Fetch_Row_Query(sprintf('select template, template_text from %s where id = %d',
             $GLOBALS['tables']['template'], $templateid));
-        $htmltemplate = stripslashes($req[0]);
-        $texttemplate = stripslashes($req[1]);
-    }
-    if (strpos($htmltemplate, '[CONTENT]') !== false) {
-        $htmlcontent = str_replace('[CONTENT]', $htmlmessage, $htmltemplate);
-        $htmlcontent = str_replace('[SUBJECT]', $subject, $htmlcontent);
-        $htmlcontent = str_replace('[FOOTER]', '', $htmlcontent);
-        if (!EMAILTEXTCREDITS) {
-            $phpListPowered = preg_replace('/src=".*power-phplist.png"/', 'src="powerphplist.png"',
-                $GLOBALS['PoweredByImage']);
-        } else {
-            $phpListPowered = $GLOBALS['PoweredByText'];
-        }
-        if (strpos($htmlcontent, '[SIGNATURE]')) {
-            $htmlcontent = str_replace('[SIGNATURE]', $phpListPowered, $htmlcontent);
-        } elseif (strpos($htmlcontent, '</body>')) {
-            $htmlcontent = str_replace('</body>', $phpListPowered.'</body>', $htmlcontent);
-        } else {
-            $htmlcontent .= $phpListPowered;
-        }
-        $htmlcontent = parseLogoPlaceholders($htmlcontent);
-    }
-    if (strpos($texttemplate, '[CONTENT]') !== false) {
-        $textcontent = str_replace('[CONTENT]', $textmessage, $texttemplate);
-        $textcontent = str_replace('[SUBJECT]', $subject, $textcontent);
-        $textcontent = str_replace('[FOOTER]', '', $textcontent);
-        $phpListPowered = trim(HTML2Text($GLOBALS['PoweredByText']));
-        if (strpos($textcontent, '[SIGNATURE]')) {
-            $textcontent = str_replace('[SIGNATURE]', $phpListPowered, $textcontent);
-        } else {
-            $textcontent .= "\n\n" . $phpListPowered;
+        if ($req) {
+            $htmltemplate = stripslashes($req[0]);
+            $texttemplate = stripslashes($req[1]);
+            $htmlcontent = str_replace('[CONTENT]', $htmlmessage, $htmltemplate);
+            $htmlcontent = str_replace('[SUBJECT]', $subject, $htmlcontent);
+            $htmlcontent = str_replace('[FOOTER]', '', $htmlcontent);
+            if (!EMAILTEXTCREDITS) {
+                $phpListPowered = preg_replace('/src=".*power-phplist.png"/', 'src="powerphplist.png"',
+                    $GLOBALS['PoweredByImage']);
+            } else {
+                $phpListPowered = $GLOBALS['PoweredByText'];
+            }
+            if (strpos($htmlcontent, '[SIGNATURE]')) {
+                $htmlcontent = str_replace('[SIGNATURE]', $phpListPowered, $htmlcontent);
+            } elseif (strpos($htmlcontent, '</body>')) {
+                $htmlcontent = str_replace('</body>', $phpListPowered.'</body>', $htmlcontent);
+            } else {
+                $htmlcontent .= $phpListPowered;
+            }
+            $htmlcontent = parseLogoPlaceholders($htmlcontent);
+            $textcontent = str_replace('[CONTENT]', $textmessage, $texttemplate);
+            $textcontent = str_replace('[SUBJECT]', $subject, $textcontent);
+            $textcontent = str_replace('[FOOTER]', '', $textcontent);
+            $phpListPowered = trim(HTML2Text($GLOBALS['PoweredByText']));
+            if (strpos($textcontent, '[SIGNATURE]')) {
+                $textcontent = str_replace('[SIGNATURE]', $phpListPowered, $textcontent);
+            } else {
+                $textcontent .= "\n\n" . $phpListPowered;
+            }
         }
     }
 

--- a/public_html/lists/admin/sendemaillib.php
+++ b/public_html/lists/admin/sendemaillib.php
@@ -315,7 +315,13 @@ function sendEmail($messageid, $email, $hash, $htmlpref = 0, $rssitems = array()
         $htmlmessage = $htmlcontent;
         $adddefaultstyle = 1;
     }
-    $textmessage = $textcontent;
+    if ($cached[$messageid]['template_text']) {
+        // text template used
+        $textmessage = str_replace('[CONTENT]', $textcontent, $cached[$messageid]['template_text']);
+    } else {
+        // no text template used
+        $textmessage = $textcontent;
+    }
 
     if (VERBOSE && $getspeedstats) {
         output('merge into template end');
@@ -1444,12 +1450,14 @@ function precacheMessage($messageid, $forwardContent = 0)
     $cached[$messageid]['htmlformatted'] = strip_tags($cached[$messageid]['content']) != $cached[$messageid]['content'];
     $cached[$messageid]['sendformat'] = $message['sendformat'];
     if ($message['template']) {
-        $req = Sql_Fetch_Row_Query("select template from {$GLOBALS['tables']['template']} where id = {$message['template']}");
+        $req = Sql_Fetch_Row_Query("select template, template_text from {$GLOBALS['tables']['template']} where id = {$message['template']}");
         $cached[$messageid]['template'] = stripslashes($req[0]);
+        $cached[$messageid]['template_text'] = stripslashes($req[1]);
         $cached[$messageid]['templateid'] = $message['template'];
         //   dbg("TEMPLATE: ".$req[0]);
     } else {
         $cached[$messageid]['template'] = '';
+        $cached[$messageid]['template_text'] = '';
         $cached[$messageid]['templateid'] = 0;
     }
 
@@ -1484,6 +1492,7 @@ function precacheMessage($messageid, $forwardContent = 0)
 
                 //# 17086 - disregard any template settings when we have a valid remote URL
                 $cached[$messageid]['template'] = null;
+                $cached[$messageid]['template_text'] = null;
                 $cached[$messageid]['templateid'] = null;
             } else {
                 //print Error(s('unable to fetch web page for sending'));

--- a/public_html/lists/admin/structure.php
+++ b/public_html/lists/admin/structure.php
@@ -232,6 +232,7 @@ $DBstructphplist = array(
         'id'        => array('integer not null primary key auto_increment', 'ID'),
         'title'     => array('varchar(255) not null', 'Title'),
         'template'  => array('longblob', 'The template'),
+        'template_text' => array('longblob', 'The template (text version)'),
         'listorder' => array('integer', ''),
         'unique_1'  => array('(title)', ''),
     ),

--- a/public_html/lists/admin/template.php
+++ b/public_html/lists/admin/template.php
@@ -217,10 +217,11 @@ if (!empty($_POST['action']) && $_POST['action'] == 'addimages') {
         }
     } else {
         $actionresult .= s('Some errors were found, template NOT saved!');
-        $data['title'] = $title;
-        $data['template'] = $content;
-        $data['template_text'] = $content_text;
     }
+    $data = array();
+    $data['title'] = $title;
+    $data['template'] = $content;
+    $data['template_text'] = $content_text;
     if (!empty($_POST['sendtest'])) {
         //# check if it's the system message template or a normal one:
 
@@ -267,12 +268,7 @@ if (!empty($_POST['action']) && $_POST['action'] == 'addimages') {
         }
         $testtarget = preg_replace('/, $/', '', $testtarget);
     }
-}
-if (!empty($actionresult)) {
-    echo '<div class="actionresult">'.$actionresult.'</div>';
-}
-
-if ($id) {
+} elseif ($id) {
     $req = Sql_Query("select * from {$tables['template']} where id = $id");
     $data = Sql_Fetch_Array($req);
     //# keep POSTED data, even if not saved
@@ -287,6 +283,9 @@ if ($id) {
     $data['title'] = '';
     $data['template'] = '';
     $data['template_text'] = '[CONTENT]';
+}
+if (!empty($actionresult)) {
+    echo '<div class="actionresult">'.$actionresult.'</div>';
 }
 
 ?>

--- a/public_html/lists/admin/template.php
+++ b/public_html/lists/admin/template.php
@@ -11,7 +11,8 @@ if (!empty($_FILES['file_template']) && is_uploaded_file($_FILES['file_template'
 } else {
     $content = '';
 }
-if (isset($_POST['template_text'])) {
+$enabletexttemplate = !empty($_POST['enabletexttemplate']) ? 1 : 0;
+if ($enabletexttemplate && isset($_POST['template_text'])) {
     $content_text = $_POST['template_text'];
 } else {
     $content_text = '[CONTENT]';
@@ -278,6 +279,9 @@ if (!empty($_POST['action']) && $_POST['action'] == 'addimages') {
     if (!empty($_POST['template_text'])) {
         $data['template_text'] = $content_text;
     }
+    if ($data['template_text'] != '[CONTENT]') {
+        $enabletexttemplate = 1;
+    }
 } else {
     $data = array();
     $data['title'] = '';
@@ -292,6 +296,17 @@ if (!empty($actionresult)) {
 
 <p class="information"><?php echo $msg ?></p>
 <?php echo '<p class="button pull-right">'.PageLink2('templates', s('List of Templates')).'</p><div class="clearfix"></div>'; ?>
+
+<?php echo '<script type="text/javascript" src="js/'.$GLOBALS['jQuery'].'"></script>' ?>
+<script type="text/javascript">
+$(document).ready(function(){
+$(".texttemplatefield").toggle($('#enabletexttemplate').val()=='1');
+});
+function toggletexttemplate(){
+$('#enabletexttemplate').val(($('#enabletexttemplate').val()=='1')?'':'1');
+$('.texttemplatefield').toggle($('#enabletexttemplate').val()=='1');
+}
+</script>
 
 <?php echo formStart(' enctype="multipart/form-data" class="template2" ') ?>
 <input type="hidden" name="id" value="<?php echo $id ?>"/>
@@ -328,11 +343,16 @@ if (!empty($actionresult)) {
             </td>
         </tr>
         <tr>
+            <td colspan="2"><input type="button" value="<?php echo s('Edit text version of the template') ?>" onclick="toggletexttemplate();" />
+            <input type="hidden" name="enabletexttemplate" id="enabletexttemplate" value="<?php echo $enabletexttemplate ? '1' : '' ?>" />
+            <br/><?php echo s('The text version is not automatically generated from the HTML version; its default value is <b>[CONTENT]</b>.'); ?></td>
+        </tr>
+        <tr class="texttemplatefield">
             <td colspan="2"><?php echo s('Text version of the template.') ?>
                 <br/><?php echo s('The content should at least have <b>[CONTENT]</b> somewhere.')
                 ?></td>
         </tr>
-        <tr>
+        <tr class="texttemplatefield">
             <td colspan="2">
                 <textarea name="template_text" id="template_text" cols="65" rows="20"><?php
                 echo stripslashes(htmlspecialchars($data['template_text']));

--- a/public_html/lists/admin/template.php
+++ b/public_html/lists/admin/template.php
@@ -11,6 +11,11 @@ if (!empty($_FILES['file_template']) && is_uploaded_file($_FILES['file_template'
 } else {
     $content = '';
 }
+if (isset($_POST['template_text'])) {
+    $content_text = $_POST['template_text'];
+} else {
+    $content_text = '[CONTENT]';
+}
 $sendtestresult = '';
 $testtarget = getConfig('admin_address');
 $systemTemplateID = getConfig('systemmessagetemplate');
@@ -94,7 +99,7 @@ if (!empty($_POST['action']) && $_POST['action'] == 'addimages') {
     }
 
     $content = disableJavascript($content);
-    if (!empty($title) && strpos($content, '[CONTENT]') !== false) {
+    if (!empty($title) && strpos($content, '[CONTENT]') !== false && strpos($content_text, '[CONTENT]') !== false) {
         $images = getTemplateImages($content);
 
         //   var_dump($images);
@@ -141,8 +146,8 @@ if (!empty($_POST['action']) && $_POST['action'] == 'addimages') {
             Sql_Query(sprintf('insert into %s (title) values("%s")', $tables['template'], sql_escape($title)));
             $id = Sql_Insert_id();
         }
-        Sql_Query(sprintf('update %s set title = "%s",template = "%s" where id = %d',
-            $tables['template'], sql_escape($title), sql_escape($content), $id));
+        Sql_Query(sprintf('update %s set title = "%s",template = "%s",template_text = "%s" where id = %d',
+            $tables['template'], sql_escape($title), sql_escape($content), sql_escape($content_text), $id));
         Sql_Query(sprintf('select * from %s where filename = "%s" and template = %d',
             $tables['templateimage'], 'powerphplist.png', $id));
         if (!Sql_Affected_Rows()) {
@@ -214,6 +219,7 @@ if (!empty($_POST['action']) && $_POST['action'] == 'addimages') {
         $actionresult .= s('Some errors were found, template NOT saved!');
         $data['title'] = $title;
         $data['template'] = $content;
+        $data['template_text'] = $content_text;
     }
     if (!empty($_POST['sendtest'])) {
         //# check if it's the system message template or a normal one:
@@ -273,10 +279,14 @@ if ($id) {
     if (!empty($_POST['template'])) {
         $data['template'] = $content;
     }
+    if (!empty($_POST['template_text'])) {
+        $data['template_text'] = $content_text;
+    }
 } else {
     $data = array();
     $data['title'] = '';
     $data['template'] = '';
+    $data['template_text'] = '[CONTENT]';
 }
 
 ?>
@@ -316,6 +326,18 @@ if ($id) {
                     echo '</textarea>';
                 }
                 ?>
+            </td>
+        </tr>
+        <tr>
+            <td colspan="2"><?php echo s('Text version of the template.') ?>
+                <br/><?php echo s('The content should at least have <b>[CONTENT]</b> somewhere.')
+                ?></td>
+        </tr>
+        <tr>
+            <td colspan="2">
+                <textarea name="template_text" id="template_text" cols="65" rows="20"><?php
+                echo stripslashes(htmlspecialchars($data['template_text']));
+                ?></textarea>
             </td>
         </tr>
 

--- a/public_html/lists/admin/upgrade.php
+++ b/public_html/lists/admin/upgrade.php
@@ -424,6 +424,14 @@ if ($dbversion == VERSION && !$force) {
     if (version_compare($dbversion, '3.6.0','<')) {
         Sql_Query("alter table {$GLOBALS['tables']['message']} change column processed processed integer ");
     }
+
+    if (!Sql_Table_Column_Exists($GLOBALS['tables']['template'], 'template_text')) {
+        Sql_Query(sprintf('alter table %s add column template_text longblob after template',
+            $GLOBALS['tables']['template']));
+        //# no change in behavior for existing templates
+        Sql_Query(sprintf('update %s set template_text="[CONTENT]"',
+            $GLOBALS['tables']['template']));
+    }
     
     //# longblobs are better at mixing character encoding. We don't know the encoding of anything we may want to store in cache
     //# before converting, it's quickest to clear the cache


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description

In https://forums.phplist.com/viewtopic.php?f=7&t=14163 a user needed to add some template-specific text to both HTML and text messages. Another user provided modifications to the code to allow for simple text templates: they were stored in their own table and had to be added manually to the database.
Building on that idea, the change proposed in this PR adds text versions of templates as first-class citizens that can be fully managed within phpList.
The default value for the text version of new templates and the value set for existing templates when the database is updated is set to `[CONTENT]`, so that phpList's behavior remains unchanged unless the user edits the text template.

This PR contains also, as separate commits, a couple of fixes I made along the way.

## Related Issue
<!--- If it fixes an open issue on Mantis (https://mantis.phplist.org), please include a link to the issue here. -->

## Screenshots (if appropriate):
