### PR TITLE
Mantis 0020334: Can't remove email address

### DIFF
--- a/public_html/lists/admin/connect.php
+++ b/public_html/lists/admin/connect.php
@@ -217,25 +217,26 @@ function SaveConfig($item, $value, $editable = 1, $ignore_errors = 0)
             }
             break;
         case 'emaillist':
-            $valid = array();
-            $hasError = false;
-            $emails = explode(',', $value);
-            foreach ($emails as $email) {
-                if (is_email($email)) {
-                    $valid[] = $email;
-                } else {
-                    $hasError = true;
+            if (!empty($value)) {
+                $valid = array();
+                $hasError = false;
+                $emails = explode(',', $value);
+                foreach ($emails as $email) {
+                    if (is_email($email)) {
+                        $valid[] = $email;
+                    } else {
+                        $hasError = true;
+                    }
+                }
+                $value = implode(',', $valid);
+                /*
+                 * hmm, not sure this is good or bad for UX
+                 *
+                  */
+                if ($hasError) {
+                    return $configInfo['description'].': '.s('Invalid value for email address');
                 }
             }
-            $value = implode(',', $valid);
-            /*
-             * hmm, not sure this is good or bad for UX
-             *
-              */
-            if ($hasError) {
-                return $configInfo['description'].': '.s('Invalid value for email address');
-            }
-
             break;
         case 'image':
             include 'class.image.inc';
@@ -1340,7 +1341,7 @@ function ListofLists($current, $fieldname, $subselect)
             $categoryhtml['all'] .= 'checked';
         }
         $categoryhtml['all'] .= ' />'.s('All Lists').'</li>';
-    
+
         $categoryhtml['all'] .= '<li><input type="checkbox" name="'.$fieldname.'[allactive]"';
         if (!empty($current['allactive'])) {
             $categoryhtml['all'] .= 'checked="checked"';

--- a/public_html/lists/admin/connect.php
+++ b/public_html/lists/admin/connect.php
@@ -389,9 +389,11 @@ function checkAccess($page, $pluginName = '')
 //@@TODO centralise the reporting and who gets what
 function sendReport($subject, $message)
 {
-    $report_addresses = explode(',', getConfig('report_address'));
-    foreach ($report_addresses as $address) {
-        sendMail($address, $GLOBALS['installation_name'].' '.$subject, $message);
+    $report_addresses = getConfig('report_address');
+    if ($report_addresses) {
+        foreach (explode(',', $report_addresses) as $address) {
+            sendMail($address, $GLOBALS['installation_name'].' '.$subject, $message);
+        }
     }
     foreach ($GLOBALS['plugins'] as $pluginname => $plugin) {
         $plugin->sendReport($GLOBALS['installation_name'].' '.$subject, $message);


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
Correct the validation of an empty string for an "emaillist" config item.

Correct the use of report_address when it is empty (the same problem of using explode() on an empty string).
## Related Issue
<!--- If it fixes an open issue on Mantis (https://mantis.phplist.org), please include a link to the issue here. -->
https://mantis.phplist.org/view.php?id=20334
## Screenshots (if appropriate):
