### PR TITLE
The update menu item is displayed when it is disabled

### DIFF
--- a/public_html/lists/admin/connect.php
+++ b/public_html/lists/admin/connect.php
@@ -723,7 +723,6 @@ $GLOBALS['pagecategories'] = array(
             'generatebouncerules',
             'initialise',
             'upgrade',
-            'update',
             'processqueue',
             'processbounces',
             'reindex',
@@ -737,7 +736,6 @@ $GLOBALS['pagecategories'] = array(
             'eventlog',
             'initialise',
             'upgrade',
-            'update',
             'bouncemgt',
             'processqueue',
             //     'processbounces',
@@ -799,9 +797,9 @@ $GLOBALS['pagecategories'] = array(
     //'menulinks' => array(),
     //),
 );
-if(!isSuperUser() || !ALLOW_UPDATER) {
-    unset($GLOBALS['pagecategories']['system']['pages']['update']);
-    unset($GLOBALS['pagecategories']['system']['menulinks']['update']);
+if (isSuperUser() && ALLOW_UPDATER) {
+    $GLOBALS['pagecategories']['system']['pages'][] = 'update';
+    $GLOBALS['pagecategories']['system']['menulinks'][] = 'update';
 }
 if (DEVVERSION) {
     $GLOBALS['pagecategories']['develop'] = array(
@@ -1340,7 +1338,7 @@ function ListofLists($current, $fieldname, $subselect)
             $categoryhtml['all'] .= 'checked';
         }
         $categoryhtml['all'] .= ' />'.s('All Lists').'</li>';
-    
+
         $categoryhtml['all'] .= '<li><input type="checkbox" name="'.$fieldname.'[allactive]"';
         if (!empty($current['allactive'])) {
             $categoryhtml['all'] .= 'checked="checked"';


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
The menu item for Update is always displayed, instead of only when enabled. This is caused by a previous change trying to remove the menu item when it is not enabled not working as intended (the arrays are numerically-indexed not associatively).

https://github.com/phpList/phplist3/commit/497d66a6300f2abc286b9dc27ea425c6d1855705#diff-a58d59211ff2a40cdba18a95fa1fc84cf882767d95735f18762085ef7f02823fR809

It seems simpler to add the item when required instead of removing it when not required.
## Related Issue
<!--- If it fixes an open issue on Mantis (https://mantis.phplist.org), please include a link to the issue here. -->

## Screenshots (if appropriate):
