### PR TITLE
Avoid php warning regarding null type

### DIFF
--- a/public_html/lists/admin/languages.php
+++ b/public_html/lists/admin/languages.php
@@ -355,9 +355,10 @@ class phplist_I18N
             $tr = Sql_Fetch_Row_Query(sprintf('select translation from '.$GLOBALS['tables']['i18n'].' where original = "%s" and lan = "%s"',
                 sql_escape(str_replace('"', '\"', $text)), $this->language), 1);
         }
-        $this->setCachedTranslation($text, stripslashes($tr[0]));
+        $translated = !empty($tr[0]) ? stripslashes($tr[0]) : '';
+        $this->setCachedTranslation($text, $translated);
 
-        return stripslashes($tr[0]);
+        return $translated;
     }
 
     public function pageTitle($page)


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
php 8 seems to be more strict about issuing warnings. These are not issued using php 7 with error reporting enabled

`[Sat Feb 27 17:32:29.350478 2021] [php:notice] [pid 15437] [client 127.0.0.1:55392] PHP Warning:  Trying to access array offset on value of type null in /home/duncan/Development/GitHub/phplist3/public_html/lists/admin/languages.php on line 360, referer: http://strontian/lists/admin/?page=home`

## Related Issue
<!--- If it fixes an open issue on Mantis (https://mantis.phplist.org), please include a link to the issue here. -->

## Screenshots (if appropriate):
