### PR TITLE
The layout of the Processed section on the List Campaigns page 

### DIFF
--- a/public_html/lists/admin/messages.php
+++ b/public_html/lists/admin/messages.php
@@ -568,7 +568,7 @@ END;
           <tbody>
               %s %s
               <tr><td>' .s('total').'</td><td>'.s('text').'</td><td>'.s('html').'</td>
-                %s
+                %s%s
               </tr>
               <tr><td><b>%s</b></td><td><b>%s</b></td><td><b>%s</b></td>
                 %s %s %s %s
@@ -576,7 +576,6 @@ END;
           </tbody>
       </table>',
                 !empty($started) ? '<tr> <td colspan="'.$colspan.'">'.$started.'</td></tr>' : '',
-
                 !empty($timetosend) ? '<tr> <td colspan="'.$colspan.'">'.$timetosend.'</td></tr>' : '',
                 !empty($msg['aspdf']) ? '<td>'.$GLOBALS['I18N']->get('PDF').'</td>' : '',
                 !empty($msg['astextandpdf']) ? '<td>'.$GLOBALS['I18N']->get('both').'</td>' : '',
@@ -585,7 +584,8 @@ END;
                 $sentStatsFormatted['html'],
                 !empty($msg['aspdf']) ? '<td><b>'.$sentStatsFormatted['pdf'].'</b></td>' : '',
                 !empty($msg['astextandpdf']) ? '<td><b>'.$sentStatsFormatted['textPlusPDF'].'</b></td>' : '',
-                $clicksrow, $bouncedrow
+                $clicksrow,
+                $bouncedrow
             );
         if ($msg['status'] != 'draft') {
             $ls->addRow($listingelement, '', $resultStats.$sendstats);


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
On the List Campaigns page the layout of the Processed section has gone awry.

This seems to be the result of a recent change https://github.com/phpList/phplist3/pull/727/commits/79af4592dc1bdb9c4355e61b922af64f2549af5e that removed what looked like an unnecessary sprintf % character. It turns out that % character was using up one of the parameters to sprintf, so removing it meant that the parameters were displayed in the wrong position.


## Related Issue
<!--- If it fixes an open issue on Mantis (https://mantis.phplist.org), please include a link to the issue here. -->

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/3147688/109557944-ada52680-7ad0-11eb-870d-197129517acd.png)
