### PR TITLE
Small issues with command line export of subscriber list

### DIFF
--- a/public_html/lists/admin/actions/export.php
+++ b/public_html/lists/admin/actions/export.php
@@ -236,5 +236,5 @@ if (!$GLOBALS['commandline']) {
     </script>';
 } else {
     rename($exportfileName,$GLOBALS['tmpdir'].'/'.$filename);
-    cl_output(s('File available as "%s"',$GLOBALS['tmpdir'].'./'.$filename));
+    cl_output(s('File available as "%s"',$GLOBALS['tmpdir'].'/'.$filename));
 }

--- a/public_html/lists/admin/export.php
+++ b/public_html/lists/admin/export.php
@@ -23,13 +23,13 @@ if (isset($_REQUEST['list'])) {
 $access = accessLevel('export');
 
 if ($GLOBALS['commandline']) {
+    cl_output(s('Export subscribers'));
     if (isset($cline['l'])) {
         $list = $cline['l'];
     } else {
         $list = 0;
+        cl_output('*  '.s('Exporting all subscribers. Use -l[listnumber] to export subscribers on a list'));
     }
-    cl_output(s('Export subscribers'));
-    cl_output('*  '.s('Exporting all subscribers. Use -l[listnumber] to export subscribers on a list'));
 
     $_SESSION['export'] = array();
     $cols = array();


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->

When exporting subscribers using the command line and specifying a list id:

1. A message "Exporting all subscribers ..." is issued even when a list has been specified.
2. The message showing the location of the output file has an erroneous '.' character in the file path.

## Related Issue
<!--- If it fixes an open issue on Mantis (https://mantis.phplist.org), please include a link to the issue here. -->

## Screenshots (if appropriate):

```
sudo -u www-data php /home/duncan/www/lists/admin/index.php -p export -l 1 -c /home/duncan/Development/PHP/phplist/config.php

phpList - phpList version 3.6.1-dev (c) 2000-2021 phpList Ltd, https://www.phplist.com

Running DEV version. All emails will be sent to xxx@yyy.co.uk
phpList - Export subscribers
phpList - *  Exporting all subscribers. Use -l[listnumber] to export subscribers on a list
phpList - File available as "/home/duncan/www/tmp./phpList subscribers on test from 2017-02-06 to 2020-12-24 (2021-Mar-04).csv"
```

