### PR TITLE
Remove leading/trailing spaces from the entered search value

### DIFF
--- a/public_html/lists/admin/users.php
+++ b/public_html/lists/admin/users.php
@@ -76,7 +76,7 @@ if (isset($_GET['find'])) {
     $_SESSION['userlistfilter']['findby'] = '';
 }
 
-$find = $_SESSION['userlistfilter']['find'];
+$find = trim($_SESSION['userlistfilter']['find']);
 $findby = $_SESSION['userlistfilter']['findby'];
 if (!$findby) {
     $findby = 'email';


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
On the Search Subscribers page the entered search value does not match if it has leading or trailing spaces. This might happen if the email address was copied and pasted inaccurately.
This has been requested in the user forum https://discuss.phplist.org/t/trim-blank-trailing-leading-characters-from-email-addresses-during-search-enter-etc/2359
This change simply removes any leading or trailing spaces.
## Related Issue
<!--- If it fixes an open issue on Mantis (https://mantis.phplist.org), please include a link to the issue here. -->

## Screenshots (if appropriate):
