### PR TITLE
Include new lists in the user history report when importing

### DIFF
--- a/public_html/lists/admin/actions/import2.php
+++ b/public_html/lists/admin/actions/import2.php
@@ -278,6 +278,7 @@ if ($total > 0) {
                     $some = 1;
                 }
 
+                $history_entry = $GLOBALS['admin_scheme'].'://'.getConfig('website').$GLOBALS['adminpages'].'/?page=user&id='.$userid."\n\n";
                 reset($_SESSION['import_attribute']);
                 //   var_dump($_SESSION);exit;
                 if ($new || (!$new && $_SESSION['overwrite'] == 'yes')) {
@@ -286,7 +287,6 @@ if ($total > 0) {
                     $old_data = Sql_Fetch_Array_Query(sprintf('select * from %s where id = %d', $tables['user'],
                         $userid));
                     $old_data = array_merge($old_data, getUserAttributeValues('', $userid));
-                    $history_entry = $GLOBALS['admin_scheme'].'://'.getConfig('website').$GLOBALS['adminpages'].'/?page=user&id='.$userid."\n\n";
                     foreach ($user['systemvalues'] as $column => $value) {
                         if (!empty($column)) { // && !empty($value)) {
                             if ($column == 'groupmapping' || strpos($column, 'grouptype_') === 0) {

--- a/public_html/lists/admin/actions/import2.php
+++ b/public_html/lists/admin/actions/import2.php
@@ -410,9 +410,8 @@ if ($total > 0) {
                         }
                     }
                     if (!$information_changed) {
-                        $history_entry .= "\nNo user details changed";
+                        $history_entry .= "No user details changed\n";
                     }
-                    addUserHistory($user['systemvalues']['email'], 'Import by '.adminName(), $history_entry);
                 }
 
                 //add this user to the lists identified, except when they are blacklisted
@@ -425,7 +424,10 @@ if ($total > 0) {
                         $query = 'insert ignore INTO '.$tables['listuser']." (userid,listid,entered) values($userid,$listid,now())";
                         $result = Sql_query($query, 1);
                         // if the affected rows is 0, the user was already subscribed
-                        $addition = $addition || Sql_Affected_Rows() == 1;
+                        if (Sql_Affected_Rows() == 1) {
+                            $addition = 1;
+                            $history_entry .= s('Subscribed to %s', listName($key))."\n";
+                        }
                         $listoflists .= '  * '.listName($key)."\n"; // $_SESSION["listname"][$key] . "\n";
                     }
                     if ($addition) {
@@ -447,6 +449,8 @@ if ($total > 0) {
                     Sql_Query(sprintf('update %s set blacklisted = 1 where id = %d', $tables['user'], $userid));
                     ++$count['foundblacklisted'];
                 }
+                addUserHistory($user['systemvalues']['email'], 'Import by '.adminName(), $history_entry);
+
                 if (!is_array($_SESSION['groups'])) {
                     $groups = array();
                 } else {

--- a/public_html/lists/admin/lib.php
+++ b/public_html/lists/admin/lib.php
@@ -70,12 +70,26 @@ function cleanListName($name) { ## we allow certain tags in a listname
     return $name;
 }
 
+/**
+ * Returns the name of a list.
+ * The list names are cached because this can be called repeatedly for the same list id.
+ *
+ * @param int $id list id
+ *
+ * @return string the list name
+ */
 function listName($id)
 {
     global $tables;
-    $req = Sql_Fetch_Row_Query(sprintf('select name from %s where id = %d', $tables['list'], $id));
 
-    return $req[0] ? stripslashes(cleanListName($req[0])) : $GLOBALS['I18N']->get('Unnamed List');
+    static $listNames = [];
+
+    if (!isset($listNames[$id])) {
+        $req = Sql_Fetch_Row_Query(sprintf('select name from %s where id = %d', $tables['list'], $id));
+        $listNames[$id] = $req[0] ? stripslashes(cleanListName($req[0])) : $GLOBALS['I18N']->get('Unnamed List');
+    }
+
+    return $listNames[$id];
 }
 
 function setMessageData($msgid, $name, $value)


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
When importing a file of email addresses with attributes, include new lists that have been subscribe to in the user history report.
## Related Issue
<!--- If it fixes an open issue on Mantis (https://mantis.phplist.org), please include a link to the issue here. -->

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/3147688/111904363-8a6df700-8a3e-11eb-9147-1153c95d3651.png)

