### PR TITLE
Don't add entry about being removed from lists to the user history

### DIFF
--- a/public_html/lists/index.php
+++ b/public_html/lists/index.php
@@ -906,7 +906,6 @@ function unsubscribePage($id)
             if (empty($isBlackListed)) { // only process when not already marked as blacklisted
                 // add user to blacklist
                 addUserToBlacklist($email, nl2br(strip_tags($_POST['unsubscribereason'])));
-                addUserHistory($email, 'Unsubscription', "Unsubscribed from $lists");
                 $unsubscribemessage = str_replace('[LISTS]', $lists, getUserConfig("unsubscribemessage:$id", $userid));
                 if (UNSUBSCRIBE_CONFIRMATION) {
                     sendMail($email, getUserConfig("unsubscribesubject:$id"), stripslashes($unsubscribemessage),


### PR DESCRIPTION


<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
Don't add an entry about being removed from lists to the user history when unsubscribing, to avoid cluttering the user history. Currently two entries are added when unsubscribing, there is also an entry for being added to the blacklist.

There was an earlier change https://mantis.phplist.org/view.php?id=17753 to leave the subscriber's list membership intact when unsubscribing. But the code still adds an entry to the user history saying that they have been unsubscribed from all lists

![image](https://user-images.githubusercontent.com/3147688/114296866-6d5c9f00-9aa5-11eb-9a5f-9895bb97453b.png)




## Related Issue
<!--- If it fixes an open issue on Mantis (https://mantis.phplist.org), please include a link to the issue here. -->

## Screenshots (if appropriate):
