### PR TITLE
Updating and deleting a plugin

### DIFF
--- a/public_html/lists/admin/plugins.php
+++ b/public_html/lists/admin/plugins.php
@@ -319,7 +319,7 @@ foreach ($GLOBALS['allplugins'] as $pluginname => $plugin) {
             $details .= '</span></div>';
         }
     }
-    if (!empty($pluginDetails['installUrl']) && is_writable($pluginDestination.'/'.$pluginname)) {
+    if (!empty($pluginDetails['installUrl']) && is_writable($pluginDestination.'/'.$pluginname.'.php')) {
         //# we can only delete the ones that were installed from the interface
         $ls->addColumn($pluginname, s('delete'),
             '<span class="delete"><a href="javascript:deleteRec(\'./?page=plugins&delete='.$pluginname.'\');" class="button" title="'.s('delete this plugin').'">'.s('delete').'</a></span>');

--- a/public_html/lists/admin/plugins.php
+++ b/public_html/lists/admin/plugins.php
@@ -404,7 +404,7 @@ function getLatestTag($developer, $repository)
     }
     $tags = json_decode($content);
 
-    if ($tags === null) {
+    if ($tags === null || count($tags) == 0) {
         return null;
     }
 


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
Two small fixes to managing plugins
1) When getting a list of tags from GitHub the code doesn't handle an empty array being returned, which causes a php error to be issued.

2) A plugin installed through the admin interface can be deleted only when it has a subdirectory. Some plugins, such as phplist-plugin-campaignslicer do not have such a subdirectory. This change allows the plugin to be deleted.
## Related Issue
<!--- If it fixes an open issue on Mantis (https://mantis.phplist.org), please include a link to the issue here. -->

## Screenshots (if appropriate):
