### PR TITLE
Update HTTP_Request2 to version 2.4.2 for compatibility with php 8

### DIFF
--- a/public_html/lists/admin/PEAR/HTTP/Request2.php
+++ b/public_html/lists/admin/PEAR/HTTP/Request2.php
@@ -13,7 +13,7 @@
  * @category  HTTP
  * @package   HTTP_Request2
  * @author    Alexey Borzov <avb@php.net>
- * @copyright 2008-2016 Alexey Borzov <avb@php.net>
+ * @copyright 2008-2020 Alexey Borzov <avb@php.net>
  * @license   http://opensource.org/licenses/BSD-3-Clause BSD 3-Clause License
  * @link      http://pear.php.net/package/HTTP_Request2
  */
@@ -21,9 +21,7 @@
 /**
  * A class representing an URL as per RFC 3986.
  */
-if (!class_exists('Net_URL2', true)) {
-    require_once 'Net/URL2.php';
-}
+require_once 'Net/URL2.php';
 
 /**
  * Exception class for HTTP_Request2 package
@@ -37,7 +35,7 @@ require_once 'HTTP/Request2/Exception.php';
  * @package  HTTP_Request2
  * @author   Alexey Borzov <avb@php.net>
  * @license  http://opensource.org/licenses/BSD-3-Clause BSD 3-Clause License
- * @version  Release: 2.3.0
+ * @version  Release: 2.4.2
  * @link     http://pear.php.net/package/HTTP_Request2
  * @link     http://tools.ietf.org/html/rfc2616#section-5
  */
@@ -91,7 +89,7 @@ class HTTP_Request2 implements SplSubject
      * Observers attached to the request (instances of SplObserver)
      * @var  array
      */
-    protected $observers = array();
+    protected $observers = [];
 
     /**
      * Request URL
@@ -116,14 +114,14 @@ class HTTP_Request2 implements SplSubject
      * Request headers
      * @var  array
      */
-    protected $headers = array();
+    protected $headers = [];
 
     /**
      * Configuration parameters
      * @var  array
      * @see  setConfig()
      */
-    protected $config = array(
+    protected $config = [
         'adapter'           => 'HTTP_Request2_Adapter_Socket',
         'connect_timeout'   => 10,
         'timeout'           => 0,
@@ -152,17 +150,17 @@ class HTTP_Request2 implements SplSubject
         'follow_redirects'  => false,
         'max_redirects'     => 5,
         'strict_redirects'  => false
-    );
+    ];
 
     /**
      * Last event in request / response handling, intended for observers
      * @var  array
      * @see  getLastEvent()
      */
-    protected $lastEvent = array(
+    protected $lastEvent = [
         'name' => 'start',
         'data' => null
-    );
+    ];
 
     /**
      * Request body
@@ -175,13 +173,13 @@ class HTTP_Request2 implements SplSubject
      * Array of POST parameters
      * @var  array
      */
-    protected $postParams = array();
+    protected $postParams = [];
 
     /**
      * Array of file uploads (for multipart/form-data POST requests)
      * @var  array
      */
-    protected $uploads = array();
+    protected $uploads = [];
 
     /**
      * Adapter used to perform actual HTTP request
@@ -205,7 +203,7 @@ class HTTP_Request2 implements SplSubject
      * @param array           $config Configuration for this Request instance
      */
     public function __construct(
-        $url = null, $method = self::METHOD_GET, array $config = array()
+        $url = null, $method = self::METHOD_GET, array $config = []
     ) {
         $this->setConfig($config);
         if (!empty($url)) {
@@ -215,7 +213,7 @@ class HTTP_Request2 implements SplSubject
             $this->setMethod($method);
         }
         $this->setHeader(
-            'user-agent', 'HTTP_Request2/2.3.0 ' .
+            'user-agent', 'HTTP_Request2/2.4.2 ' .
             '(http://pear.php.net/package/http_request2) PHP/' . phpversion()
         );
     }
@@ -236,7 +234,7 @@ class HTTP_Request2 implements SplSubject
     {
         if (is_string($url)) {
             $url = new Net_URL2(
-                $url, array(Net_URL2::OPTION_USE_BRACKETS => $this->config['use_brackets'])
+                $url, [Net_URL2::OPTION_USE_BRACKETS => $this->config['use_brackets']]
             );
         }
         if (!$url instanceof Net_URL2) {
@@ -365,13 +363,13 @@ class HTTP_Request2 implements SplSubject
 
         } elseif ('proxy' == $nameOrConfig) {
             $url = new Net_URL2($value);
-            $this->setConfig(array(
+            $this->setConfig([
                 'proxy_type'     => $url->getScheme(),
                 'proxy_host'     => $url->getHost(),
                 'proxy_port'     => $url->getPort(),
                 'proxy_user'     => rawurldecode($url->getUser()),
                 'proxy_password' => rawurldecode($url->getPassword())
-            ));
+            ]);
 
         } else {
             if (!array_key_exists($nameOrConfig, $this->config)) {
@@ -422,11 +420,11 @@ class HTTP_Request2 implements SplSubject
         if (empty($user)) {
             $this->auth = null;
         } else {
-            $this->auth = array(
+            $this->auth = [
                 'user'     => (string)$user,
                 'password' => (string)$password,
                 'scheme'   => $scheme
-            );
+            ];
         }
 
         return $this;
@@ -551,7 +549,7 @@ class HTTP_Request2 implements SplSubject
     {
         if (!empty($this->cookieJar)) {
             $this->cookieJar->store(
-                array('name' => $name, 'value' => $value), $this->url
+                ['name' => $name, 'value' => $value], $this->url
             );
 
         } else {
@@ -599,7 +597,7 @@ class HTTP_Request2 implements SplSubject
                 $this->setHeader('content-type', $fileData['type']);
             }
         }
-        $this->postParams = $this->uploads = array();
+        $this->postParams = $this->uploads = [];
 
         return $this;
     }
@@ -658,18 +656,18 @@ class HTTP_Request2 implements SplSubject
     ) {
         if (!is_array($filename)) {
             $fileData = $this->fopenWrapper($filename, empty($contentType));
-            $this->uploads[$fieldName] = array(
+            $this->uploads[$fieldName] = [
                 'fp'        => $fileData['fp'],
                 'filename'  => !empty($sendFilename)? $sendFilename
                                 :(is_string($filename)? basename($filename): 'anonymous.blob') ,
                 'size'      => $fileData['size'],
                 'type'      => empty($contentType)? $fileData['type']: $contentType
-            );
+            ];
         } else {
-            $fps = $names = $sizes = $types = array();
+            $fps = $names = $sizes = $types = [];
             foreach ($filename as $f) {
                 if (!is_array($f)) {
-                    $f = array($f);
+                    $f = [$f];
                 }
                 $fileData = $this->fopenWrapper($f[0], empty($f[2]));
                 $fps[]   = $fileData['fp'];
@@ -678,9 +676,9 @@ class HTTP_Request2 implements SplSubject
                 $sizes[] = $fileData['size'];
                 $types[] = empty($f[2])? $fileData['type']: $f[2];
             }
-            $this->uploads[$fieldName] = array(
+            $this->uploads[$fieldName] = [
                 'fp' => $fps, 'filename' => $names, 'size' => $sizes, 'type' => $types
-            );
+            ];
         }
         if (empty($this->headers['content-type'])
             || 'application/x-www-form-urlencoded' == $this->headers['content-type']
@@ -766,10 +764,10 @@ class HTTP_Request2 implements SplSubject
      */
     public function setLastEvent($name, $data = null)
     {
-        $this->lastEvent = array(
+        $this->lastEvent = [
             'name' => $name,
             'data' => $data
-        );
+        ];
         $this->notify();
     }
 
@@ -836,7 +834,7 @@ class HTTP_Request2 implements SplSubject
                 if (false === strpos($adapter, '_')) {
                     $adapter = 'HTTP_Request2_Adapter_' . ucfirst($adapter);
                 }
-                if (!class_exists($adapter, false)
+                if (!class_exists($adapter, true)
                     && preg_match('/^HTTP_Request2_Adapter_([a-zA-Z0-9]+)$/', $adapter)
                 ) {
                     include_once str_replace('_', DIRECTORY_SEPARATOR, $adapter) . '.php';
@@ -876,9 +874,7 @@ class HTTP_Request2 implements SplSubject
      */
     public function setCookieJar($jar = true)
     {
-        if (!class_exists('HTTP_Request2_CookieJar', false)) {
-            require_once 'HTTP/Request2/CookieJar.php';
-        }
+        require_once 'HTTP/Request2/CookieJar.php';
 
         if ($jar instanceof HTTP_Request2_CookieJar) {
             $this->cookieJar = $jar;
@@ -917,7 +913,7 @@ class HTTP_Request2 implements SplSubject
         // Sanity check for URL
         if (!$this->url instanceof Net_URL2
             || !$this->url->isAbsolute()
-            || !in_array(strtolower($this->url->getScheme()), array('https', 'http'))
+            || !in_array(strtolower($this->url->getScheme()), ['https', 'http'])
         ) {
             throw new HTTP_Request2_LogicException(
                 'HTTP_Request2 needs an absolute HTTP(S) request URL, '
@@ -930,11 +926,6 @@ class HTTP_Request2 implements SplSubject
         if (empty($this->adapter)) {
             $this->setAdapter($this->getConfig('adapter'));
         }
-        // magic_quotes_runtime may break file uploads and chunked response
-        // processing; see bug #4543. Don't use ini_get() here; see bug #16440.
-        if ($magicQuotes = get_magic_quotes_runtime()) {
-            set_magic_quotes_runtime(false);
-        }
         // force using single byte encoding if mbstring extension overloads
         // strlen() and substr(); see bug #1781, bug #10605
         if (extension_loaded('mbstring') && (2 & ini_get('mbstring.func_overload'))) {
@@ -943,21 +934,12 @@ class HTTP_Request2 implements SplSubject
         }
 
         try {
-            $response = $this->adapter->sendRequest($this);
-        } catch (Exception $e) {
+            return $this->adapter->sendRequest($this);
+        } finally {
+            if (!empty($oldEncoding)) {
+                mb_internal_encoding($oldEncoding);
+            }
         }
-        // cleanup in either case (poor man's "finally" clause)
-        if ($magicQuotes) {
-            set_magic_quotes_runtime(true);
-        }
-        if (!empty($oldEncoding)) {
-            mb_internal_encoding($oldEncoding);
-        }
-        // rethrow the exception
-        if (!empty($e)) {
-            throw $e;
-        }
-        return $response;
     }
 
     /**
@@ -979,11 +961,11 @@ class HTTP_Request2 implements SplSubject
                 HTTP_Request2_Exception::INVALID_ARGUMENT
             );
         }
-        $fileData = array(
+        $fileData = [
             'fp'   => is_string($file)? null: $file,
             'type' => 'application/octet-stream',
             'size' => 0
-        );
+        ];
         if (is_string($file)) {
             if (!($fileData['fp'] = @fopen($file, 'rb'))) {
                 $error = error_get_last();

--- a/public_html/lists/admin/PEAR/HTTP/Request2/Adapter.php
+++ b/public_html/lists/admin/PEAR/HTTP/Request2/Adapter.php
@@ -13,7 +13,7 @@
  * @category  HTTP
  * @package   HTTP_Request2
  * @author    Alexey Borzov <avb@php.net>
- * @copyright 2008-2016 Alexey Borzov <avb@php.net>
+ * @copyright 2008-2020 Alexey Borzov <avb@php.net>
  * @license   http://opensource.org/licenses/BSD-3-Clause BSD 3-Clause License
  * @link      http://pear.php.net/package/HTTP_Request2
  */
@@ -34,7 +34,7 @@ require_once 'HTTP/Request2/Response.php';
  * @package  HTTP_Request2
  * @author   Alexey Borzov <avb@php.net>
  * @license  http://opensource.org/licenses/BSD-3-Clause BSD 3-Clause License
- * @version  Release: 2.3.0
+ * @version  Release: 2.4.2
  * @link     http://pear.php.net/package/HTTP_Request2
  */
 abstract class HTTP_Request2_Adapter
@@ -43,7 +43,7 @@ abstract class HTTP_Request2_Adapter
      * A list of methods that MUST NOT have a request body, per RFC 2616
      * @var  array
      */
-    protected static $bodyDisallowed = array('TRACE');
+    protected static $bodyDisallowed = ['TRACE'];
 
     /**
      * Methods having defined semantics for request body
@@ -55,7 +55,7 @@ abstract class HTTP_Request2_Adapter
      * @link http://pear.php.net/bugs/bug.php?id=12900
      * @link http://pear.php.net/bugs/bug.php?id=14740
      */
-    protected static $bodyRequired = array('POST', 'PUT');
+    protected static $bodyRequired = ['POST', 'PUT'];
 
     /**
      * Request being sent

--- a/public_html/lists/admin/PEAR/HTTP/Request2/Adapter/Curl.php
+++ b/public_html/lists/admin/PEAR/HTTP/Request2/Adapter/Curl.php
@@ -13,7 +13,7 @@
  * @category  HTTP
  * @package   HTTP_Request2
  * @author    Alexey Borzov <avb@php.net>
- * @copyright 2008-2016 Alexey Borzov <avb@php.net>
+ * @copyright 2008-2020 Alexey Borzov <avb@php.net>
  * @license   http://opensource.org/licenses/BSD-3-Clause BSD 3-Clause License
  * @link      http://pear.php.net/package/HTTP_Request2
  */
@@ -30,7 +30,7 @@ require_once 'HTTP/Request2/Adapter.php';
  * @package  HTTP_Request2
  * @author   Alexey Borzov <avb@php.net>
  * @license  http://opensource.org/licenses/BSD-3-Clause BSD 3-Clause License
- * @version  Release: 2.3.0
+ * @version  Release: 2.4.2
  * @link     http://pear.php.net/package/HTTP_Request2
  */
 class HTTP_Request2_Adapter_Curl extends HTTP_Request2_Adapter
@@ -39,64 +39,64 @@ class HTTP_Request2_Adapter_Curl extends HTTP_Request2_Adapter
      * Mapping of header names to cURL options
      * @var  array
      */
-    protected static $headerMap = array(
+    protected static $headerMap = [
         'accept-encoding' => CURLOPT_ENCODING,
         'cookie'          => CURLOPT_COOKIE,
         'referer'         => CURLOPT_REFERER,
         'user-agent'      => CURLOPT_USERAGENT
-    );
+    ];
 
     /**
      * Mapping of SSL context options to cURL options
      * @var  array
      */
-    protected static $sslContextMap = array(
+    protected static $sslContextMap = [
         'ssl_verify_peer' => CURLOPT_SSL_VERIFYPEER,
         'ssl_cafile'      => CURLOPT_CAINFO,
         'ssl_capath'      => CURLOPT_CAPATH,
         'ssl_local_cert'  => CURLOPT_SSLCERT,
         'ssl_passphrase'  => CURLOPT_SSLCERTPASSWD
-    );
+    ];
 
     /**
      * Mapping of CURLE_* constants to Exception subclasses and error codes
      * @var  array
      */
-    protected static $errorMap = array(
-        CURLE_UNSUPPORTED_PROTOCOL  => array('HTTP_Request2_MessageException',
-                                             HTTP_Request2_Exception::NON_HTTP_REDIRECT),
-        CURLE_COULDNT_RESOLVE_PROXY => array('HTTP_Request2_ConnectionException'),
-        CURLE_COULDNT_RESOLVE_HOST  => array('HTTP_Request2_ConnectionException'),
-        CURLE_COULDNT_CONNECT       => array('HTTP_Request2_ConnectionException'),
+    protected static $errorMap = [
+        CURLE_UNSUPPORTED_PROTOCOL  => ['HTTP_Request2_MessageException',
+                                             HTTP_Request2_Exception::NON_HTTP_REDIRECT],
+        CURLE_COULDNT_RESOLVE_PROXY => ['HTTP_Request2_ConnectionException'],
+        CURLE_COULDNT_RESOLVE_HOST  => ['HTTP_Request2_ConnectionException'],
+        CURLE_COULDNT_CONNECT       => ['HTTP_Request2_ConnectionException'],
         // error returned from write callback
-        CURLE_WRITE_ERROR           => array('HTTP_Request2_MessageException',
-                                             HTTP_Request2_Exception::NON_HTTP_REDIRECT),
-        CURLE_OPERATION_TIMEOUTED   => array('HTTP_Request2_MessageException',
-                                             HTTP_Request2_Exception::TIMEOUT),
-        CURLE_HTTP_RANGE_ERROR      => array('HTTP_Request2_MessageException'),
-        CURLE_SSL_CONNECT_ERROR     => array('HTTP_Request2_ConnectionException'),
-        CURLE_LIBRARY_NOT_FOUND     => array('HTTP_Request2_LogicException',
-                                             HTTP_Request2_Exception::MISCONFIGURATION),
-        CURLE_FUNCTION_NOT_FOUND    => array('HTTP_Request2_LogicException',
-                                             HTTP_Request2_Exception::MISCONFIGURATION),
-        CURLE_ABORTED_BY_CALLBACK   => array('HTTP_Request2_MessageException',
-                                             HTTP_Request2_Exception::NON_HTTP_REDIRECT),
-        CURLE_TOO_MANY_REDIRECTS    => array('HTTP_Request2_MessageException',
-                                             HTTP_Request2_Exception::TOO_MANY_REDIRECTS),
-        CURLE_SSL_PEER_CERTIFICATE  => array('HTTP_Request2_ConnectionException'),
-        CURLE_GOT_NOTHING           => array('HTTP_Request2_MessageException'),
-        CURLE_SSL_ENGINE_NOTFOUND   => array('HTTP_Request2_LogicException',
-                                             HTTP_Request2_Exception::MISCONFIGURATION),
-        CURLE_SSL_ENGINE_SETFAILED  => array('HTTP_Request2_LogicException',
-                                             HTTP_Request2_Exception::MISCONFIGURATION),
-        CURLE_SEND_ERROR            => array('HTTP_Request2_MessageException'),
-        CURLE_RECV_ERROR            => array('HTTP_Request2_MessageException'),
-        CURLE_SSL_CERTPROBLEM       => array('HTTP_Request2_LogicException',
-                                             HTTP_Request2_Exception::INVALID_ARGUMENT),
-        CURLE_SSL_CIPHER            => array('HTTP_Request2_ConnectionException'),
-        CURLE_SSL_CACERT            => array('HTTP_Request2_ConnectionException'),
-        CURLE_BAD_CONTENT_ENCODING  => array('HTTP_Request2_MessageException'),
-    );
+        CURLE_WRITE_ERROR           => ['HTTP_Request2_MessageException',
+                                             HTTP_Request2_Exception::NON_HTTP_REDIRECT],
+        CURLE_OPERATION_TIMEOUTED   => ['HTTP_Request2_MessageException',
+                                             HTTP_Request2_Exception::TIMEOUT],
+        CURLE_HTTP_RANGE_ERROR      => ['HTTP_Request2_MessageException'],
+        CURLE_SSL_CONNECT_ERROR     => ['HTTP_Request2_ConnectionException'],
+        CURLE_LIBRARY_NOT_FOUND     => ['HTTP_Request2_LogicException',
+                                             HTTP_Request2_Exception::MISCONFIGURATION],
+        CURLE_FUNCTION_NOT_FOUND    => ['HTTP_Request2_LogicException',
+                                             HTTP_Request2_Exception::MISCONFIGURATION],
+        CURLE_ABORTED_BY_CALLBACK   => ['HTTP_Request2_MessageException',
+                                             HTTP_Request2_Exception::NON_HTTP_REDIRECT],
+        CURLE_TOO_MANY_REDIRECTS    => ['HTTP_Request2_MessageException',
+                                             HTTP_Request2_Exception::TOO_MANY_REDIRECTS],
+        CURLE_SSL_PEER_CERTIFICATE  => ['HTTP_Request2_ConnectionException'],
+        CURLE_GOT_NOTHING           => ['HTTP_Request2_MessageException'],
+        CURLE_SSL_ENGINE_NOTFOUND   => ['HTTP_Request2_LogicException',
+                                             HTTP_Request2_Exception::MISCONFIGURATION],
+        CURLE_SSL_ENGINE_SETFAILED  => ['HTTP_Request2_LogicException',
+                                             HTTP_Request2_Exception::MISCONFIGURATION],
+        CURLE_SEND_ERROR            => ['HTTP_Request2_MessageException'],
+        CURLE_RECV_ERROR            => ['HTTP_Request2_MessageException'],
+        CURLE_SSL_CERTPROBLEM       => ['HTTP_Request2_LogicException',
+                                             HTTP_Request2_Exception::INVALID_ARGUMENT],
+        CURLE_SSL_CIPHER            => ['HTTP_Request2_ConnectionException'],
+        CURLE_SSL_CACERT            => ['HTTP_Request2_ConnectionException'],
+        CURLE_BAD_CONTENT_ENCODING  => ['HTTP_Request2_MessageException'],
+    ];
 
     /**
      * Response being received
@@ -181,23 +181,18 @@ class HTTP_Request2_Adapter_Curl extends HTTP_Request2_Adapter
 
         try {
             if (false === curl_exec($ch = $this->createCurlHandle())) {
-                $e = self::wrapCurlError($ch);
+                throw self::wrapCurlError($ch);
             }
-        } catch (Exception $e) {
-        }
-        if (isset($ch)) {
-            $this->lastInfo = curl_getinfo($ch);
-            if (CURLE_OK !== curl_errno($ch)) {
-                $this->request->setLastEvent('warning', curl_error($ch));
+        } finally {
+            if (isset($ch)) {
+                $this->lastInfo = curl_getinfo($ch);
+                if (CURLE_OK !== curl_errno($ch)) {
+                    $this->request->setLastEvent('warning', curl_error($ch));
+                }
+                curl_close($ch);
             }
-            curl_close($ch);
-        }
-
-        $response = $this->response;
-        unset($this->request, $this->requestBody, $this->response);
-
-        if (!empty($e)) {
-            throw $e;
+            $response = $this->response;
+            unset($this->request, $this->requestBody, $this->response);
         }
 
         if ($jar = $request->getCookieJar()) {
@@ -231,10 +226,10 @@ class HTTP_Request2_Adapter_Curl extends HTTP_Request2_Adapter
     {
         $ch = curl_init();
 
-        curl_setopt_array($ch, array(
+        curl_setopt_array($ch, [
             // setup write callbacks
-            CURLOPT_HEADERFUNCTION => array($this, 'callbackWriteHeader'),
-            CURLOPT_WRITEFUNCTION  => array($this, 'callbackWriteBody'),
+            CURLOPT_HEADERFUNCTION => [$this, 'callbackWriteHeader'],
+            CURLOPT_WRITEFUNCTION  => [$this, 'callbackWriteBody'],
             // buffer size
             CURLOPT_BUFFERSIZE     => $this->request->getConfig('buffer_size'),
             // connection timeout
@@ -243,7 +238,7 @@ class HTTP_Request2_Adapter_Curl extends HTTP_Request2_Adapter
             CURLINFO_HEADER_OUT    => true,
             // request url
             CURLOPT_URL            => $this->request->getUrl()->getUrl()
-        ));
+        ]);
 
         // set up redirects
         if (!$this->request->getConfig('follow_redirects')) {
@@ -387,7 +382,7 @@ class HTTP_Request2_Adapter_Curl extends HTTP_Request2_Adapter
         }
 
         // set headers not having special keys
-        $headersFmt = array();
+        $headersFmt = [];
         foreach ($headers as $name => $value) {
             $canonicalName = implode('-', array_map('ucfirst', explode('-', $name)));
             $headersFmt[]  = $canonicalName . ': ' . $value;
@@ -417,7 +412,7 @@ class HTTP_Request2_Adapter_Curl extends HTTP_Request2_Adapter
                 || HTTP_Request2::AUTH_DIGEST != $auth['scheme'])
             || HTTP_Request2::METHOD_POST !== $this->request->getMethod()
         ) {
-            curl_setopt($ch, CURLOPT_READFUNCTION, array($this, 'callbackReadBody'));
+            curl_setopt($ch, CURLOPT_READFUNCTION, [$this, 'callbackReadBody']);
 
         } else {
             // rewind may be needed, read the whole body into memory
@@ -525,7 +520,7 @@ class HTTP_Request2_Adapter_Curl extends HTTP_Request2_Adapter
 
                     // for versions lower than 5.2.10, check the redirection URL protocol
                     if (!defined('CURLOPT_REDIR_PROTOCOLS') && $redirectUrl->isAbsolute()
-                        && !in_array($redirectUrl->getScheme(), array('http', 'https'))
+                        && !in_array($redirectUrl->getScheme(), ['http', 'https'])
                     ) {
                         return -1;
                     }

--- a/public_html/lists/admin/PEAR/HTTP/Request2/Adapter/Mock.php
+++ b/public_html/lists/admin/PEAR/HTTP/Request2/Adapter/Mock.php
@@ -13,7 +13,7 @@
  * @category  HTTP
  * @package   HTTP_Request2
  * @author    Alexey Borzov <avb@php.net>
- * @copyright 2008-2016 Alexey Borzov <avb@php.net>
+ * @copyright 2008-2020 Alexey Borzov <avb@php.net>
  * @license   http://opensource.org/licenses/BSD-3-Clause BSD 3-Clause License
  * @link      http://pear.php.net/package/HTTP_Request2
  */
@@ -44,7 +44,7 @@ require_once 'HTTP/Request2/Adapter.php';
  * @package  HTTP_Request2
  * @author   Alexey Borzov <avb@php.net>
  * @license  http://opensource.org/licenses/BSD-3-Clause BSD 3-Clause License
- * @version  Release: 2.3.0
+ * @version  Release: 2.4.2
  * @link     http://pear.php.net/package/HTTP_Request2
  */
 class HTTP_Request2_Adapter_Mock extends HTTP_Request2_Adapter
@@ -53,7 +53,7 @@ class HTTP_Request2_Adapter_Mock extends HTTP_Request2_Adapter
      * A queue of responses to be returned by sendRequest()
      * @var  array
      */
-    protected $responses = array();
+    protected $responses = [];
 
     /**
      * Returns the next response from the queue built by addResponse()
@@ -115,7 +115,7 @@ class HTTP_Request2_Adapter_Mock extends HTTP_Request2_Adapter
         ) {
             throw new HTTP_Request2_Exception('Parameter is not a valid response');
         }
-        $this->responses[] = array($response, $url);
+        $this->responses[] = [$response, $url];
     }
 
     /**

--- a/public_html/lists/admin/PEAR/HTTP/Request2/ConnectionException.php
+++ b/public_html/lists/admin/PEAR/HTTP/Request2/ConnectionException.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Exception classes for HTTP_Request2 package
+ *
+ * PHP version 5
+ *
+ * LICENSE
+ *
+ * This source file is subject to BSD 3-Clause License that is bundled
+ * with this package in the file LICENSE and available at the URL
+ * https://raw.github.com/pear/HTTP_Request2/trunk/docs/LICENSE
+ *
+ * @category  HTTP
+ * @package   HTTP_Request2
+ * @author    Alexey Borzov <avb@php.net>
+ * @copyright 2008-2020 Alexey Borzov <avb@php.net>
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD 3-Clause License
+ * @link      http://pear.php.net/package/HTTP_Request2
+ */
+
+/**
+ * Exception thrown when connection to a web or proxy server fails
+ *
+ * The exception will not contain a package error code, but will contain
+ * native error code, as returned by stream_socket_client() or curl_errno().
+ *
+ * @category HTTP
+ * @package  HTTP_Request2
+ * @author   Alexey Borzov <avb@php.net>
+ * @license  http://opensource.org/licenses/BSD-3-Clause BSD 3-Clause License
+ * @version  Release: 2.4.2
+ * @link     http://pear.php.net/package/HTTP_Request2
+ */
+class HTTP_Request2_ConnectionException extends HTTP_Request2_Exception
+{
+}
+
+?>

--- a/public_html/lists/admin/PEAR/HTTP/Request2/CookieJar.php
+++ b/public_html/lists/admin/PEAR/HTTP/Request2/CookieJar.php
@@ -13,7 +13,7 @@
  * @category  HTTP
  * @package   HTTP_Request2
  * @author    Alexey Borzov <avb@php.net>
- * @copyright 2008-2016 Alexey Borzov <avb@php.net>
+ * @copyright 2008-2020 Alexey Borzov <avb@php.net>
  * @license   http://opensource.org/licenses/BSD-3-Clause BSD 3-Clause License
  * @link      http://pear.php.net/package/HTTP_Request2
  */
@@ -47,7 +47,7 @@ class HTTP_Request2_CookieJar implements Serializable
      *
      * @var array
      */
-    protected $cookies = array();
+    protected $cookies = [];
 
     /**
      * Whether session cookies should be serialized when serializing the jar
@@ -72,7 +72,7 @@ class HTTP_Request2_CookieJar implements Serializable
      * @var  array
      * @link http://publicsuffix.org/
      */
-    protected static $psl = array();
+    protected static $psl = [];
 
     /**
      * Class constructor, sets various options
@@ -131,7 +131,7 @@ class HTTP_Request2_CookieJar implements Serializable
      */
     protected function checkAndUpdateFields(array $cookie, Net_URL2 $setter = null)
     {
-        if ($missing = array_diff(array('name', 'value'), array_keys($cookie))) {
+        if ($missing = array_diff(['name', 'value'], array_keys($cookie))) {
             throw new HTTP_Request2_LogicException(
                 "Cookie array should contain 'name' and 'value' fields",
                 HTTP_Request2_Exception::MISSING_VALUE
@@ -149,7 +149,7 @@ class HTTP_Request2_CookieJar implements Serializable
                 HTTP_Request2_Exception::INVALID_ARGUMENT
             );
         }
-        $cookie += array('domain' => '', 'path' => '', 'expires' => null, 'secure' => false);
+        $cookie += ['domain' => '', 'path' => '', 'expires' => null, 'secure' => false];
 
         // Need ISO-8601 date @ UTC timezone
         if (!empty($cookie['expires'])
@@ -223,10 +223,10 @@ class HTTP_Request2_CookieJar implements Serializable
             && (is_null($cookie['expires']) || $cookie['expires'] > $this->now())
         ) {
             if (!isset($this->cookies[$cookie['domain']])) {
-                $this->cookies[$cookie['domain']] = array();
+                $this->cookies[$cookie['domain']] = [];
             }
             if (!isset($this->cookies[$cookie['domain']][$cookie['path']])) {
-                $this->cookies[$cookie['domain']][$cookie['path']] = array();
+                $this->cookies[$cookie['domain']][$cookie['path']] = [];
             }
             $this->cookies[$cookie['domain']][$cookie['path']][$cookie['name']] = $cookie;
 
@@ -286,7 +286,7 @@ class HTTP_Request2_CookieJar implements Serializable
         $path   = $url->getPath();
         $secure = 0 == strcasecmp($url->getScheme(), 'https');
 
-        $matched = $ret = array();
+        $matched = $ret = [];
         foreach (array_keys($this->cookies) as $domain) {
             if ($this->domainMatch($host, $domain)) {
                 foreach (array_keys($this->cookies[$domain]) as $cPath) {
@@ -322,7 +322,7 @@ class HTTP_Request2_CookieJar implements Serializable
      */
     public function getAll()
     {
-        $cookies = array();
+        $cookies = [];
         foreach (array_keys($this->cookies) as $domain) {
             foreach (array_keys($this->cookies[$domain]) as $path) {
                 foreach ($this->cookies[$domain][$path] as $name => $cookie) {
@@ -398,12 +398,12 @@ class HTTP_Request2_CookieJar implements Serializable
                 }
             }
         }
-        return serialize(array(
+        return serialize([
             'cookies'          => $cookies,
             'serializeSession' => $this->serializeSession,
             'useList'          => $this->useList,
             'ignoreInvalid'    => $this->ignoreInvalid
-        ));
+        ]);
     }
 
     /**
@@ -427,10 +427,10 @@ class HTTP_Request2_CookieJar implements Serializable
                 continue;
             }
             if (!isset($this->cookies[$cookie['domain']])) {
-                $this->cookies[$cookie['domain']] = array();
+                $this->cookies[$cookie['domain']] = [];
             }
             if (!isset($this->cookies[$cookie['domain']][$cookie['path']])) {
-                $this->cookies[$cookie['domain']][$cookie['path']] = array();
+                $this->cookies[$cookie['domain']][$cookie['path']] = [];
             }
             $this->cookies[$cookie['domain']][$cookie['path']][$cookie['name']] = $cookie;
         }
@@ -490,7 +490,7 @@ class HTTP_Request2_CookieJar implements Serializable
             $path = '@data_dir@' . DIRECTORY_SEPARATOR . 'HTTP_Request2';
             if (0 === strpos($path, '@' . 'data_dir@')) {
                 $path = realpath(
-                    dirname(__FILE__) . DIRECTORY_SEPARATOR . '..'
+                    __DIR__ . DIRECTORY_SEPARATOR . '..'
                     . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'data'
                 );
             }

--- a/public_html/lists/admin/PEAR/HTTP/Request2/Exception.php
+++ b/public_html/lists/admin/PEAR/HTTP/Request2/Exception.php
@@ -13,7 +13,7 @@
  * @category  HTTP
  * @package   HTTP_Request2
  * @author    Alexey Borzov <avb@php.net>
- * @copyright 2008-2016 Alexey Borzov <avb@php.net>
+ * @copyright 2008-2020 Alexey Borzov <avb@php.net>
  * @license   http://opensource.org/licenses/BSD-3-Clause BSD 3-Clause License
  * @link      http://pear.php.net/package/HTTP_Request2
  */
@@ -30,7 +30,7 @@ require_once 'PEAR/Exception.php';
  * @package  HTTP_Request2
  * @author   Alexey Borzov <avb@php.net>
  * @license  http://opensource.org/licenses/BSD-3-Clause BSD 3-Clause License
- * @version  Release: 2.3.0
+ * @version  Release: 2.4.2
  * @link     http://pear.php.net/package/HTTP_Request2
  * @link     http://pear.php.net/pepr/pepr-proposal-show.php?id=132
  */
@@ -90,71 +90,10 @@ class HTTP_Request2_Exception extends PEAR_Exception
     }
 }
 
-/**
- * Exception thrown in case of missing features
- *
- * @category HTTP
- * @package  HTTP_Request2
- * @author   Alexey Borzov <avb@php.net>
- * @license  http://opensource.org/licenses/BSD-3-Clause BSD 3-Clause License
- * @version  Release: 2.3.0
- * @link     http://pear.php.net/package/HTTP_Request2
- */
-class HTTP_Request2_NotImplementedException extends HTTP_Request2_Exception
-{
-}
+// backwards compatibility, include the child exceptions if installed with PEAR installer
+require_once 'HTTP/Request2/ConnectionException.php';
+require_once 'HTTP/Request2/LogicException.php';
+require_once 'HTTP/Request2/MessageException.php';
+require_once 'HTTP/Request2/NotImplementedException.php';
 
-/**
- * Exception that represents error in the program logic
- *
- * This exception usually implies a programmer's error, like passing invalid
- * data to methods or trying to use PHP extensions that weren't installed or
- * enabled. Usually exceptions of this kind will be thrown before request even
- * starts.
- *
- * The exception will usually contain a package error code.
- *
- * @category HTTP
- * @package  HTTP_Request2
- * @author   Alexey Borzov <avb@php.net>
- * @license  http://opensource.org/licenses/BSD-3-Clause BSD 3-Clause License
- * @version  Release: 2.3.0
- * @link     http://pear.php.net/package/HTTP_Request2
- */
-class HTTP_Request2_LogicException extends HTTP_Request2_Exception
-{
-}
-
-/**
- * Exception thrown when connection to a web or proxy server fails
- *
- * The exception will not contain a package error code, but will contain
- * native error code, as returned by stream_socket_client() or curl_errno().
- *
- * @category HTTP
- * @package  HTTP_Request2
- * @author   Alexey Borzov <avb@php.net>
- * @license  http://opensource.org/licenses/BSD-3-Clause BSD 3-Clause License
- * @version  Release: 2.3.0
- * @link     http://pear.php.net/package/HTTP_Request2
- */
-class HTTP_Request2_ConnectionException extends HTTP_Request2_Exception
-{
-}
-
-/**
- * Exception thrown when sending or receiving HTTP message fails
- *
- * The exception may contain both package error code and native error code.
- *
- * @category HTTP
- * @package  HTTP_Request2
- * @author   Alexey Borzov <avb@php.net>
- * @license  http://opensource.org/licenses/BSD-3-Clause BSD 3-Clause License
- * @version  Release: 2.3.0
- * @link     http://pear.php.net/package/HTTP_Request2
- */
-class HTTP_Request2_MessageException extends HTTP_Request2_Exception
-{
-}
 ?>

--- a/public_html/lists/admin/PEAR/HTTP/Request2/LogicException.php
+++ b/public_html/lists/admin/PEAR/HTTP/Request2/LogicException.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Exception classes for HTTP_Request2 package
+ *
+ * PHP version 5
+ *
+ * LICENSE
+ *
+ * This source file is subject to BSD 3-Clause License that is bundled
+ * with this package in the file LICENSE and available at the URL
+ * https://raw.github.com/pear/HTTP_Request2/trunk/docs/LICENSE
+ *
+ * @category  HTTP
+ * @package   HTTP_Request2
+ * @author    Alexey Borzov <avb@php.net>
+ * @copyright 2008-2020 Alexey Borzov <avb@php.net>
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD 3-Clause License
+ * @link      http://pear.php.net/package/HTTP_Request2
+ */
+
+/**
+ * Exception that represents error in the program logic
+ *
+ * This exception usually implies a programmer's error, like passing invalid
+ * data to methods or trying to use PHP extensions that weren't installed or
+ * enabled. Usually exceptions of this kind will be thrown before request even
+ * starts.
+ *
+ * The exception will usually contain a package error code.
+ *
+ * @category HTTP
+ * @package  HTTP_Request2
+ * @author   Alexey Borzov <avb@php.net>
+ * @license  http://opensource.org/licenses/BSD-3-Clause BSD 3-Clause License
+ * @version  Release: 2.4.2
+ * @link     http://pear.php.net/package/HTTP_Request2
+ */
+class HTTP_Request2_LogicException extends HTTP_Request2_Exception
+{
+}
+
+?>

--- a/public_html/lists/admin/PEAR/HTTP/Request2/MessageException.php
+++ b/public_html/lists/admin/PEAR/HTTP/Request2/MessageException.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Exception classes for HTTP_Request2 package
+ *
+ * PHP version 5
+ *
+ * LICENSE
+ *
+ * This source file is subject to BSD 3-Clause License that is bundled
+ * with this package in the file LICENSE and available at the URL
+ * https://raw.github.com/pear/HTTP_Request2/trunk/docs/LICENSE
+ *
+ * @category  HTTP
+ * @package   HTTP_Request2
+ * @author    Alexey Borzov <avb@php.net>
+ * @copyright 2008-2020 Alexey Borzov <avb@php.net>
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD 3-Clause License
+ * @link      http://pear.php.net/package/HTTP_Request2
+ */
+
+/**
+ * Exception thrown when sending or receiving HTTP message fails
+ *
+ * The exception may contain both package error code and native error code.
+ *
+ * @category HTTP
+ * @package  HTTP_Request2
+ * @author   Alexey Borzov <avb@php.net>
+ * @license  http://opensource.org/licenses/BSD-3-Clause BSD 3-Clause License
+ * @version  Release: 2.4.2
+ * @link     http://pear.php.net/package/HTTP_Request2
+ */
+class HTTP_Request2_MessageException extends HTTP_Request2_Exception
+{
+}
+
+?>

--- a/public_html/lists/admin/PEAR/HTTP/Request2/MultipartBody.php
+++ b/public_html/lists/admin/PEAR/HTTP/Request2/MultipartBody.php
@@ -13,7 +13,7 @@
  * @category  HTTP
  * @package   HTTP_Request2
  * @author    Alexey Borzov <avb@php.net>
- * @copyright 2008-2016 Alexey Borzov <avb@php.net>
+ * @copyright 2008-2020 Alexey Borzov <avb@php.net>
  * @license   http://opensource.org/licenses/BSD-3-Clause BSD 3-Clause License
  * @link      http://pear.php.net/package/HTTP_Request2
  */
@@ -31,7 +31,7 @@ require_once 'HTTP/Request2/Exception.php';
  * @package  HTTP_Request2
  * @author   Alexey Borzov <avb@php.net>
  * @license  http://opensource.org/licenses/BSD-3-Clause BSD 3-Clause License
- * @version  Release: 2.3.0
+ * @version  Release: 2.4.2
  * @link     http://pear.php.net/package/HTTP_Request2
  * @link     http://tools.ietf.org/html/rfc1867
  */
@@ -47,13 +47,13 @@ class HTTP_Request2_MultipartBody
      * Form parameters added via {@link HTTP_Request2::addPostParameter()}
      * @var  array
      */
-    private $_params = array();
+    private $_params = [];
 
     /**
      * File uploads added via {@link HTTP_Request2::addUpload()}
      * @var  array
      */
-    private $_uploads = array();
+    private $_uploads = [];
 
     /**
      * Header for parts with parameters
@@ -75,7 +75,7 @@ class HTTP_Request2_MultipartBody
      *
      * @var  array
      */
-    private $_pos = array(0, 0);
+    private $_pos = [0, 0];
 
 
     /**
@@ -92,13 +92,13 @@ class HTTP_Request2_MultipartBody
         $this->_params = self::_flattenArray('', $params, $useBrackets);
         foreach ($uploads as $fieldName => $f) {
             if (!is_array($f['fp'])) {
-                $this->_uploads[] = $f + array('name' => $fieldName);
+                $this->_uploads[] = $f + ['name' => $fieldName];
             } else {
                 for ($i = 0; $i < count($f['fp']); $i++) {
-                    $upload = array(
+                    $upload = [
                         'name' => ($useBrackets? $fieldName . '[' . $i . ']': $fieldName)
-                    );
-                    foreach (array('fp', 'filename', 'size', 'type') as $key) {
+                    ];
+                    foreach (['fp', 'filename', 'size', 'type'] as $key) {
                         $upload[$key] = $f[$key][$i];
                     }
                     $this->_uploads[] = $upload;
@@ -199,7 +199,7 @@ class HTTP_Request2_MultipartBody
                 $length  -= min(strlen($closing) - $this->_pos[1], $length);
             }
             if ($length > 0) {
-                $this->_pos     = array($this->_pos[0] + 1, 0);
+                $this->_pos     = [$this->_pos[0] + 1, 0];
             } else {
                 $this->_pos[1] += $oldLength;
             }
@@ -214,7 +214,7 @@ class HTTP_Request2_MultipartBody
      */
     public function rewind()
     {
-        $this->_pos = array(0, 0);
+        $this->_pos = [0, 0];
         foreach ($this->_uploads as $u) {
             rewind($u['fp']);
         }
@@ -248,9 +248,9 @@ class HTTP_Request2_MultipartBody
     private static function _flattenArray($name, $values, $useBrackets)
     {
         if (!is_array($values)) {
-            return array(array($name, $values));
+            return [[$name, $values]];
         } else {
-            $ret = array();
+            $ret = [];
             foreach ($values as $k => $v) {
                 if (empty($name)) {
                     $newName = $k;

--- a/public_html/lists/admin/PEAR/HTTP/Request2/NotImplementedException.php
+++ b/public_html/lists/admin/PEAR/HTTP/Request2/NotImplementedException.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Exception classes for HTTP_Request2 package
+ *
+ * PHP version 5
+ *
+ * LICENSE
+ *
+ * This source file is subject to BSD 3-Clause License that is bundled
+ * with this package in the file LICENSE and available at the URL
+ * https://raw.github.com/pear/HTTP_Request2/trunk/docs/LICENSE
+ *
+ * @category  HTTP
+ * @package   HTTP_Request2
+ * @author    Alexey Borzov <avb@php.net>
+ * @copyright 2008-2020 Alexey Borzov <avb@php.net>
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD 3-Clause License
+ * @link      http://pear.php.net/package/HTTP_Request2
+ */
+
+/**
+ * Exception thrown in case of missing features
+ *
+ * @category HTTP
+ * @package  HTTP_Request2
+ * @author   Alexey Borzov <avb@php.net>
+ * @license  http://opensource.org/licenses/BSD-3-Clause BSD 3-Clause License
+ * @version  Release: 2.4.2
+ * @link     http://pear.php.net/package/HTTP_Request2
+ */
+class HTTP_Request2_NotImplementedException extends HTTP_Request2_Exception
+{
+}
+
+?>

--- a/public_html/lists/admin/PEAR/HTTP/Request2/Observer/Log.php
+++ b/public_html/lists/admin/PEAR/HTTP/Request2/Observer/Log.php
@@ -14,7 +14,7 @@
  * @package   HTTP_Request2
  * @author    David Jean Louis <izi@php.net>
  * @author    Alexey Borzov <avb@php.net>
- * @copyright 2008-2016 Alexey Borzov <avb@php.net>
+ * @copyright 2008-2020 Alexey Borzov <avb@php.net>
  * @license   http://opensource.org/licenses/BSD-3-Clause BSD 3-Clause License
  * @link      http://pear.php.net/package/HTTP_Request2
  */
@@ -64,7 +64,7 @@ require_once 'HTTP/Request2/Exception.php';
  * @author   David Jean Louis <izi@php.net>
  * @author   Alexey Borzov <avb@php.net>
  * @license  http://opensource.org/licenses/BSD-3-Clause BSD 3-Clause License
- * @version  Release: 2.3.0
+ * @version  Release: 2.4.2
  * @link     http://pear.php.net/package/HTTP_Request2
  */
 class HTTP_Request2_Observer_Log implements SplObserver
@@ -83,14 +83,14 @@ class HTTP_Request2_Observer_Log implements SplObserver
      *
      * @var array $events
      */
-    public $events = array(
+    public $events = [
         'connect',
         'sentHeaders',
         'sentBody',
         'receivedHeaders',
         'receivedBody',
         'disconnect',
-    );
+    ];
 
     // }}}
     // __construct() {{{
@@ -104,7 +104,7 @@ class HTTP_Request2_Observer_Log implements SplObserver
      *
      * @return void
      */
-    public function __construct($target = 'php://output', array $events = array())
+    public function __construct($target = 'php://output', array $events = [])
     {
         if (!empty($events)) {
             $this->events = $events;

--- a/public_html/lists/admin/PEAR/HTTP/Request2/Observer/UncompressingDownload.php
+++ b/public_html/lists/admin/PEAR/HTTP/Request2/Observer/UncompressingDownload.php
@@ -14,7 +14,7 @@
  * @package   HTTP_Request2
  * @author    Delian Krustev <krustev@krustev.net>
  * @author    Alexey Borzov <avb@php.net>
- * @copyright 2008-2016 Alexey Borzov <avb@php.net>
+ * @copyright 2008-2020 Alexey Borzov <avb@php.net>
  * @license   http://opensource.org/licenses/BSD-3-Clause BSD 3-Clause License
  * @link      http://pear.php.net/package/HTTP_Request2
  */
@@ -95,7 +95,7 @@ require_once 'HTTP/Request2/Response.php';
  * @author   Delian Krustev <krustev@krustev.net>
  * @author   Alexey Borzov <avb@php.net>
  * @license  http://opensource.org/licenses/BSD-3-Clause BSD 3-Clause License
- * @version  Release: 2.3.0
+ * @version  Release: 2.4.2
  * @link     http://pear.php.net/package/HTTP_Request2
  */
 class HTTP_Request2_Observer_UncompressingDownload implements SplObserver

--- a/public_html/lists/admin/PEAR/HTTP/Request2/SOCKS5.php
+++ b/public_html/lists/admin/PEAR/HTTP/Request2/SOCKS5.php
@@ -13,7 +13,7 @@
  * @category  HTTP
  * @package   HTTP_Request2
  * @author    Alexey Borzov <avb@php.net>
- * @copyright 2008-2016 Alexey Borzov <avb@php.net>
+ * @copyright 2008-2020 Alexey Borzov <avb@php.net>
  * @license   http://opensource.org/licenses/BSD-3-Clause BSD 3-Clause License
  * @link      http://pear.php.net/package/HTTP_Request2
  */
@@ -28,7 +28,7 @@ require_once 'HTTP/Request2/SocketWrapper.php';
  * @package  HTTP_Request2
  * @author   Alexey Borzov <avb@php.net>
  * @license  http://opensource.org/licenses/BSD-3-Clause BSD 3-Clause License
- * @version  Release: 2.3.0
+ * @version  Release: 2.4.2
  * @link     http://pear.php.net/package/HTTP_Request2
  * @link     http://pear.php.net/bugs/bug.php?id=19332
  * @link     http://tools.ietf.org/html/rfc1928
@@ -49,7 +49,7 @@ class HTTP_Request2_SOCKS5 extends HTTP_Request2_SocketWrapper
      * @throws HTTP_Request2_MessageException
      */
     public function __construct(
-        $address, $timeout = 10, array $contextOptions = array(),
+        $address, $timeout = 10, array $contextOptions = [],
         $username = null, $password = null
     ) {
         parent::__construct($address, $timeout, $contextOptions);

--- a/public_html/lists/admin/PEAR/HTTP/Request2/SocketWrapper.php
+++ b/public_html/lists/admin/PEAR/HTTP/Request2/SocketWrapper.php
@@ -13,7 +13,7 @@
  * @category  HTTP
  * @package   HTTP_Request2
  * @author    Alexey Borzov <avb@php.net>
- * @copyright 2008-2016 Alexey Borzov <avb@php.net>
+ * @copyright 2008-2020 Alexey Borzov <avb@php.net>
  * @license   http://opensource.org/licenses/BSD-3-Clause BSD 3-Clause License
  * @link      http://pear.php.net/package/HTTP_Request2
  */
@@ -31,7 +31,7 @@ require_once 'HTTP/Request2/Exception.php';
  * @package  HTTP_Request2
  * @author   Alexey Borzov <avb@php.net>
  * @license  http://opensource.org/licenses/BSD-3-Clause BSD 3-Clause License
- * @version  Release: 2.3.0
+ * @version  Release: 2.4.2
  * @link     http://pear.php.net/package/HTTP_Request2
  * @link     http://pear.php.net/bugs/bug.php?id=19332
  * @link     http://tools.ietf.org/html/rfc1928
@@ -42,7 +42,7 @@ class HTTP_Request2_SocketWrapper
      * PHP warning messages raised during stream_socket_client() call
      * @var array
      */
-    protected $connectionWarnings = array();
+    protected $connectionWarnings = [];
 
     /**
      * Connected socket
@@ -52,7 +52,7 @@ class HTTP_Request2_SocketWrapper
 
     /**
      * Sum of start time and global timeout, exception will be thrown if request continues past this time
-     * @var  integer
+     * @var float
      */
     protected $deadline;
 
@@ -73,39 +73,33 @@ class HTTP_Request2_SocketWrapper
      * @throws HTTP_Request2_LogicException
      * @throws HTTP_Request2_ConnectionException
      */
-    public function __construct($address, $timeout, array $contextOptions = array())
+    public function __construct($address, $timeout, array $contextOptions = [])
     {
         if (!empty($contextOptions)
             && !isset($contextOptions['socket']) && !isset($contextOptions['ssl'])
         ) {
             // Backwards compatibility with 2.1.0 and 2.1.1 releases
-            $contextOptions = array('ssl' => $contextOptions);
+            $contextOptions = ['ssl' => $contextOptions];
         }
         if (isset($contextOptions['ssl'])) {
-            $contextOptions['ssl'] += array(
+            $contextOptions['ssl'] += [
                 // Using "Intermediate compatibility" cipher bundle from
                 // https://wiki.mozilla.org/Security/Server_Side_TLS
-                'ciphers' => 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:'
-                             . 'ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:'
-                             . 'DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:'
-                             . 'ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:'
-                             . 'ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:'
-                             . 'ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:'
-                             . 'ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:'
-                             . 'DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:'
-                             . 'DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:'
-                             . 'ECDHE-RSA-DES-CBC3-SHA:ECDHE-ECDSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:'
-                             . 'AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:'
-                             . 'AES128-SHA:AES256-SHA:AES:CAMELLIA:DES-CBC3-SHA:'
-                             . '!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA'
-            );
-            if (version_compare(phpversion(), '5.4.13', '>=')) {
-                $contextOptions['ssl']['disable_compression'] = true;
-                if (version_compare(phpversion(), '5.6', '>=')) {
-                    $contextOptions['ssl']['crypto_method'] = STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT
-                                                              | STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT;
-                }
-            }
+                'ciphers' =>             'TLS_AES_128_GCM_SHA256:'
+                                         . 'TLS_AES_256_GCM_SHA384:'
+                                         . 'TLS_CHACHA20_POLY1305_SHA256:'
+                                         . 'ECDHE-ECDSA-AES128-GCM-SHA256:'
+                                         . 'ECDHE-RSA-AES128-GCM-SHA256:'
+                                         . 'ECDHE-ECDSA-AES256-GCM-SHA384:'
+                                         . 'ECDHE-RSA-AES256-GCM-SHA384:'
+                                         . 'ECDHE-ECDSA-CHACHA20-POLY1305:'
+                                         . 'ECDHE-RSA-CHACHA20-POLY1305:'
+                                         . 'DHE-RSA-AES128-GCM-SHA256:'
+                                         . 'DHE-RSA-AES256-GCM-SHA384',
+                'disable_compression' => true,
+                'crypto_method'       => STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT
+                                         | STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT
+            ];
         }
         $context = stream_context_create();
         foreach ($contextOptions as $wrapper => $options) {
@@ -117,7 +111,7 @@ class HTTP_Request2_SocketWrapper
                 }
             }
         }
-        set_error_handler(array($this, 'connectionWarningsHandler'));
+        set_error_handler([$this, 'connectionWarningsHandler']);
         $this->socket = stream_socket_client(
             $address, $errno, $errstr, $timeout, STREAM_CLIENT_CONNECT, $context
         );
@@ -135,6 +129,9 @@ class HTTP_Request2_SocketWrapper
                 "Unable to connect to {$address}. Error: {$error}", 0, $errno
             );
         }
+        // Run socket in non-blocking mode, to prevent possible problems with
+        // HTTPS requests not timing out properly (see bug #21229)
+        stream_set_blocking($this->socket, false);
     }
 
     /**
@@ -150,16 +147,28 @@ class HTTP_Request2_SocketWrapper
      *
      * @param int $length Reads up to this number of bytes
      *
-     * @return   string Data read from socket
+     * @return   string|false Data read from socket by fread()
      * @throws   HTTP_Request2_MessageException     In case of timeout
      */
     public function read($length)
     {
-        if ($this->deadline) {
-            stream_set_timeout($this->socket, max($this->deadline - time(), 1));
-        }
-        $data = fread($this->socket, $length);
-        $this->checkTimeout();
+        // Looks like stream_select() may return true, but then fread() will return an empty string...
+        // For some reason or other happens mostly with servers behind Cloudflare.
+        // Let's do the fread() call in a loop until either an error/eof or non-empty string:
+        do {
+            $data     = false;
+            $timeouts = $this->_getTimeoutsForStreamSelect();
+
+            $r = [$this->socket];
+            $w = [];
+            $e = [];
+            if (stream_select($r, $w, $e, $timeouts[0], $timeouts[1])) {
+                $data = fread($this->socket, $length);
+            }
+
+            $this->checkTimeout();
+        } while ('' === $data && !$this->eof());
+
         return $data;
     }
 
@@ -181,29 +190,25 @@ class HTTP_Request2_SocketWrapper
         $line = '';
         while (!feof($this->socket)) {
             if (null !== $localTimeout) {
-                stream_set_timeout($this->socket, $localTimeout);
-            } elseif ($this->deadline) {
-                stream_set_timeout($this->socket, max($this->deadline - time(), 1));
+                $timeouts = [$localTimeout, 0];
+                $started  = microtime(true);
+            } else {
+                $timeouts = $this->_getTimeoutsForStreamSelect();
             }
 
-            $line .= @fgets($this->socket, $bufferSize);
+            $r = [$this->socket];
+            $w = [];
+            $e = [];
+            if (stream_select($r, $w, $e, $timeouts[0], $timeouts[1])) {
+                $line .= @fgets($this->socket, $bufferSize);
+            }
 
             if (null === $localTimeout) {
                 $this->checkTimeout();
-
-            } else {
-                $info = stream_get_meta_data($this->socket);
-                // reset socket timeout if we don't have request timeout specified,
-                // prevents further calls failing with a bogus Exception
-                if (!$this->deadline) {
-                    $default = (int)@ini_get('default_socket_timeout');
-                    stream_set_timeout($this->socket, $default > 0 ? $default : PHP_INT_MAX);
-                }
-                if ($info['timed_out']) {
-                    throw new HTTP_Request2_MessageException(
-                        "readLine() call timed out", HTTP_Request2_Exception::TIMEOUT
-                    );
-                }
+            } elseif (microtime(true) - $started > $localTimeout) {
+                throw new HTTP_Request2_MessageException(
+                    "readLine() call timed out", HTTP_Request2_Exception::TIMEOUT
+                );
             }
             if (substr($line, -1) == "\n") {
                 return rtrim($line, "\r\n");
@@ -222,16 +227,29 @@ class HTTP_Request2_SocketWrapper
      */
     public function write($data)
     {
-        if ($this->deadline) {
-            stream_set_timeout($this->socket, max($this->deadline - time(), 1));
+        $totalWritten = 0;
+        while (strlen($data)) {
+            $written  = 0;
+            $timeouts = $this->_getTimeoutsForStreamSelect();
+
+            $r = [];
+            $w = [$this->socket];
+            $e = [];
+            if (stream_select($r, $w, $e, $timeouts[0], $timeouts[1])) {
+                // Notice: fwrite(): send of #### bytes failed with errno=10035
+                // A non-blocking socket operation could not be completed immediately.
+                $written = @fwrite($this->socket, $data);
+            }
+            $this->checkTimeout();
+
+            // http://www.php.net/manual/en/function.fwrite.php#96951
+            if (0 === (int)$written) {
+                throw new HTTP_Request2_MessageException('Error writing request');
+            }
+            $data = substr($data, $written);
+            $totalWritten += $written;
         }
-        $written = fwrite($this->socket, $data);
-        $this->checkTimeout();
-        // http://www.php.net/manual/en/function.fwrite.php#96951
-        if ($written < strlen($data)) {
-            throw new HTTP_Request2_MessageException('Error writing request');
-        }
-        return $written;
+        return $totalWritten;
     }
 
     /**
@@ -247,13 +265,20 @@ class HTTP_Request2_SocketWrapper
     /**
      * Sets request deadline
      *
-     * @param int $deadline Exception will be thrown if request continues
-     *                      past this time
-     * @param int $timeout  Original request timeout value, to use in
-     *                      Exception message
+     * If null is passed for $deadline then deadline will be calculated based
+     * on default_socket_timeout PHP setting. This is done to keep BC with previous
+     * versions that used blocking sockets.
+     *
+     * @param float|null $deadline Exception will be thrown if request continues
+     *                             past this time
+     * @param int $timeout         Original request timeout value, to use in
+     *                             Exception message
      */
     public function setDeadline($deadline, $timeout)
     {
+        if (null === $deadline && 0 < ($defaultTimeout = (int)ini_get('default_socket_timeout'))) {
+            $deadline = microtime(true) + $defaultTimeout;
+        }
         $this->deadline = $deadline;
         $this->timeout  = $timeout;
     }
@@ -265,17 +290,18 @@ class HTTP_Request2_SocketWrapper
      */
     public function enableCrypto()
     {
-        if (version_compare(phpversion(), '5.6', '<')) {
-            $cryptoMethod = STREAM_CRYPTO_METHOD_TLS_CLIENT;
-        } else {
-            $cryptoMethod = STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT
-                            | STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT;
-        }
+        $cryptoMethod = STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT
+                        | STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT;
 
-        if (!stream_socket_enable_crypto($this->socket, true, $cryptoMethod)) {
-            throw new HTTP_Request2_ConnectionException(
-                'Failed to enable secure connection when connecting through proxy'
-            );
+        try {
+            stream_set_blocking($this->socket, true);
+            if (!stream_socket_enable_crypto($this->socket, true, $cryptoMethod)) {
+                throw new HTTP_Request2_ConnectionException(
+                    'Failed to enable secure connection when connecting through proxy'
+                );
+            }
+        } finally {
+            stream_set_blocking($this->socket, false);
         }
     }
 
@@ -287,14 +313,35 @@ class HTTP_Request2_SocketWrapper
     protected function checkTimeout()
     {
         $info = stream_get_meta_data($this->socket);
-        if ($info['timed_out'] || $this->deadline && time() > $this->deadline) {
-            $reason = $this->deadline
+        if ($info['timed_out'] || $this->deadline && microtime(true) > $this->deadline) {
+            $reason = $this->timeout
                 ? "after {$this->timeout} second(s)"
                 : 'due to default_socket_timeout php.ini setting';
             throw new HTTP_Request2_MessageException(
                 "Request timed out {$reason}", HTTP_Request2_Exception::TIMEOUT
             );
         }
+    }
+
+    /**
+     * Returns timeouts based on deadline for use with stream_select()
+     *
+     * @return array First element is $tv_sec parameter for stream_select(),
+     *               second element is $tv_usec
+     */
+    private function _getTimeoutsForStreamSelect()
+    {
+        if (!$this->deadline) {
+            return [null, null];
+        }
+        $parts = array_map(
+            'intval',
+            explode('.', sprintf('%.6F', $this->deadline - microtime(true)))
+        );
+        if (0 > $parts[0] || 0 === $parts[0] && $parts[1] < 50000) {
+            return [0, 50000];
+        }
+        return $parts;
     }
 
     /**

--- a/public_html/lists/admin/PEAR/PEAR/Exception.php
+++ b/public_html/lists/admin/PEAR/PEAR/Exception.php
@@ -88,7 +88,7 @@
  * @author    Greg Beaver <cellog@php.net>
  * @copyright 1997-2009 The Authors
  * @license   http://opensource.org/licenses/bsd-license.php New BSD License
- * @version   Release: 1.0.0
+ * @version   Release: 1.0.2
  * @link      http://pear.php.net/package/PEAR_Exception
  * @since     Class available since Release 1.0.0
  */


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
The version of the HTTP_Request2 package, which is used as a fall-back when curl is not enabled, is not compatible with php 8 because it uses get_magic_quotes_runtime(). This change updates the package to the latest version.

Tested with php 7.2 and php 8.0.5.
## Related Issue
<!--- If it fixes an open issue on Mantis (https://mantis.phplist.org), please include a link to the issue here. -->

## Screenshots (if appropriate):
