### PR TITLE
Mantis 20354 When marking a message as sent, set the sent field to the current time.

### DIFF
--- a/public_html/lists/admin/messages.php
+++ b/public_html/lists/admin/messages.php
@@ -286,7 +286,7 @@ if (isset($_GET['markSent'])) {
     verifyCsrfGetToken();
     $markSent = sprintf('%d', $_GET['markSent']);
     $action_result .= $GLOBALS['I18N']->get('Marking as sent ')." $markSent ..";
-    $result = Sql_query(sprintf('update %s set status = "sent", repeatinterval = 0,requeueinterval = 0 where id = %d and (status = "suspended") %s',
+    $result = Sql_query(sprintf('update %s set status = "sent", sent = now(), repeatinterval = 0,requeueinterval = 0 where id = %d and (status = "suspended") %s',
         $tables['message'], $markSent, $ownerselect_and));
     $suc6 = Sql_Affected_Rows();
     if ($suc6) {
@@ -314,7 +314,7 @@ if (isset($_GET['action'])) {
             break;
         case 'markallsent':
             $action_result .= $GLOBALS['I18N']->get('Marking all as sent ').'  ..';
-            $result = Sql_query(sprintf('update %s set status = "sent", repeatinterval = 0,requeueinterval = 0 where (status = "suspended") %s',
+            $result = Sql_query(sprintf('update %s set status = "sent", sent = now(), repeatinterval = 0,requeueinterval = 0 where (status = "suspended") %s',
                 $tables['message'], $markSent, $ownerselect_and));
             $suc6 = Sql_Affected_Rows();
             if ($suc6) {


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
When marking a message as sent, set the sent field to the current time. That is what happens when a campaign completes sending normally.
## Related Issue
<!--- If it fixes an open issue on Mantis (https://mantis.phplist.org), please include a link to the issue here. -->
https://mantis.phplist.org/view.php?id=20354
## Screenshots (if appropriate):
