### PR TITLE
Prevent password autofill when editing user

### DIFF
--- a/public_html/lists/admin/user.php
+++ b/public_html/lists/admin/user.php
@@ -411,7 +411,7 @@ foreach ($struct as $key => $val) {
                 stripslashes($user[$key]));
         }
     } elseif ($key == 'password') {
-        $userdetailsHTML .= sprintf('<tr><td class="dataname">%s</td><td><input type="text" name="%s" value="%s" size="30" /></td></tr>'."\n",
+        $userdetailsHTML .= sprintf('<tr><td class="dataname">%s</td><td><input type="text" name="%s" value="%s" size="30" autocomplete="new-password" /></td></tr>'."\n",
             $val[1], $key, '');
     } elseif ($key == 'blacklisted') {
         $userdetailsHTML .= sprintf('<tr><td class="dataname">%s</td><td>%s', s($b),


### PR DESCRIPTION
When editing a subscriber, the sys:Password field should be ignored by password managers. Unfortunately, there is no way to completely do that, but at least by adding `autocomplete="new-password"` the field will not be autofilled (although instead it will ask if you want to save the new password)

