### PR TITLE
Security enhancement: min length for password change

### DIFF
--- a/public_html/lists/admin/login.php
+++ b/public_html/lists/admin/login.php
@@ -100,9 +100,9 @@ if (isset($_POST['password1']) && isset($_POST['password2'])) {
 //      echo "    <tr><td><span class=\"general\">".$GLOBALS['I18N']->get('Name').":</span></td></tr>\n";
 //      echo "    <tr><td>".$row[0]."</td></tr>";
         echo '    <tr><td><span class="general">'.$GLOBALS['I18N']->get('New password').":</span></td></tr>\n";
-        echo '    <tr><td><input type="password" name="password1" value="" size="30" /></td></tr>';
+        echo '    <tr><td><input type="password" name="password1" value="" size="30" pattern=".{15,}" required title="15 characters minimum" /></td></tr>';
         echo '    <tr><td><span class="general">'.$GLOBALS['I18N']->get('Confirm password').':</span></td></tr>';
-        echo '    <tr><td><input type="password" name="password2" value="" size="30" /></td></tr>';
+        echo '    <tr><td><input type="password" name="password2" value="" size="30" pattern=".{15,}" required title="15 characters minimum" /></td></tr>';
         echo '    <tr><td><input class="submit" type="submit" name="process" value="'.$GLOBALS['I18N']->get('Continue').'" /></td></tr>';
         echo '  </table>';
         echo '</form>';

--- a/public_html/lists/admin/login.php
+++ b/public_html/lists/admin/login.php
@@ -100,9 +100,9 @@ if (isset($_POST['password1']) && isset($_POST['password2'])) {
 //      echo "    <tr><td><span class=\"general\">".$GLOBALS['I18N']->get('Name').":</span></td></tr>\n";
 //      echo "    <tr><td>".$row[0]."</td></tr>";
         echo '    <tr><td><span class="general">'.$GLOBALS['I18N']->get('New password').":</span></td></tr>\n";
-        echo '    <tr><td><input type="password" name="password1" value="" size="30" pattern=".{15,}" required title="15 characters minimum" /></td></tr>';
+        echo '    <tr><td><input type="password" name="password1" value="" size="30" pattern=".{8,}" required title="'.$GLOBALS['I18N']->get('Password must be at least 8 characters').'" /></td></tr>';
         echo '    <tr><td><span class="general">'.$GLOBALS['I18N']->get('Confirm password').':</span></td></tr>';
-        echo '    <tr><td><input type="password" name="password2" value="" size="30" pattern=".{15,}" required title="15 characters minimum" /></td></tr>';
+        echo '    <tr><td><input type="password" name="password2" value="" size="30" pattern=".{8,}" required title="'.$GLOBALS['I18N']->get('Password must be at least 8 characters').'" /></td></tr>';
         echo '    <tr><td><input class="submit" type="submit" name="process" value="'.$GLOBALS['I18N']->get('Continue').'" /></td></tr>';
         echo '  </table>';
         echo '</form>';


### PR DESCRIPTION
If you add a new admin user, there is at least a small password policy of having at least 8 characters. If the admin then decides to change the password on his own via password change request, he could in theory set just a 1 character password. This fix introduces a basic input validation of the string length of both new password input fields in order to fix this security issue.

