### PR TITLE
Allow CLI enable/disable of plugins

### DIFF
--- a/public_html/lists/admin/pluginenable.php
+++ b/public_html/lists/admin/pluginenable.php
@@ -1,0 +1,69 @@
+<?php
+ 
+$disabled_plugins = unserialize(getConfig('plugins_disabled'));
+ 
+function change_plugin_status($plugin_name, $enable_plugin) {
+    $success = false;
+    if (!$enable_plugin) {
+        if (isset($plugins[$plugin_name])) {
+            unset($plugins[$plugin_name]);
+            $disabled_plugins[$plugin_name] = 1;
+        }
+ 
+        // test whether other enabled plugins depend on this one
+        foreach ($plugins as $piName => $pi) {
+            if (!pluginCanEnable($piName)) {
+                unset($plugins[$piName]);
+                $disabled_plugins[$piName] = 1;
+            }
+        }
+        saveConfig('plugins_disabled', serialize($disabled_plugins), 0);
+        saveConfig(md5('plugin-'.$plugin_name.'-initialised'), 0);
+        $success = true;
+    } elseif (!empty($GLOBALS['allplugins'][$plugin_name])) {
+        if (pluginCanEnable($plugin_name)) {
+            if (isset($disabled_plugins[$plugin_name])) {
+                unset($disabled_plugins[$plugin_name]);
+            }
+            if (isset($GLOBALS['allplugins'][$plugin_name])) {
+                $GLOBALS['allplugins'][$plugin_name]->initialise();
+            }
+            //  var_dump($disabled_plugins);
+            saveConfig('plugins_disabled', serialize($disabled_plugins), 0);
+            $success = true;
+        } else {
+            logEvent(s('Failed to enable plugin (%s), dependencies failed', clean($plugin_name)));
+        }
+    }
+    return $success;
+}
+ 
+ 
+if ($GLOBALS['commandline']) {
+    $full_result = true;
+    $cline = parseCline();
+    reset($cline);
+    if (!$cline || !is_array($cline) || !$cline['n']) {
+        clineUsage('-n plugin_name_1 plugin_name_2 [-e [true]|false]');
+        exit;
+    }
+ 
+    $intendedEnableStatus = true;
+    if (($cline['e']) && ($cline['e'] == 'false')) {
+        $intendedEnableStatus = false;
+    }
+ 
+    $pluginnames = explode(' ', $cline['n']);
+    foreach ($pluginnames as $pluginname) {
+        cl_output('Setting plugin '.$pluginname.' status to '.var_export($intendedEnableStatus, true).'.');
+        $result = change_plugin_status($pluginname, $intendedEnableStatus);
+        $full_result = $full_result && $result;
+        $result_display = $result ? "succeeded" : "FAILED";
+        cl_output('Changing '.$pluginname.' status ' .$result_display.".");
+    }
+    if (!$full_result) {
+        exit(1);
+    } else {
+        exit(0);
+    }
+}


### PR DESCRIPTION
In order to support enabling/disabling plugins via CLI for use cases including containers.

Usage:

enable a plugin
/usr/bin/phplist -p pluginenable -n CommonPlugin -e true

disable a plugin
/usr/bin/phplist -p pluginenable -n CommonPlugin -e false

A non-0 exit code is returned if it fails to perform the requested action.

<!---Thanks for contributing to phpList!-->

## Description
I keep receiving the "You can't comment at this time." message from github.  I have logged out/in and turned off ad blocker - to no avail.  So here are my responses

@bramley, I have tested numerous times both enabling and disabling and it has worked without issue for plugins with and without dependencies.  I have tested both via the CLI inside the container and via the docker-entrypoint.sh script called as the container starts.

Are there some docs on these?  I didn't see anything in /public_html/lists/config/config_extended.php nor in Google.
$plugins_autoenable = ['CommonPlugin'];
$plugins_disabled = ['SegmentPlugin'];

I did find the relevant code in /public_html/lists/admin/pluginlib.php so I am testing this now.

$plugins_autoenable=[]; _DOES_ solve my issue - enabling plugins in a container by default.  It works great.  Maybe getting this in the config_extended.php would help others.

Should I create another pull request for changes to config_extended.php?

## Related Issue



## Screenshots (if appropriate):
