### PR TITLE
Correct the URL to phpmailer SMTP debug documentation

### DIFF
--- a/public_html/lists/config/config_extended.php
+++ b/public_html/lists/config/config_extended.php
@@ -619,7 +619,7 @@ define('PHPMAILERHOST', '');
 
 //# SMTP debugging
 // Enable debugging output by phpmailer when sending test emails
-// See https://phpmailer.github.io/PHPMailer/classes/PHPMailer.PHPMailer.PHPMailer.html#property_SMTPDebug
+// See https://phpmailer.github.io/PHPMailer/classes/PHPMailer-PHPMailer-PHPMailer.html#property_SMTPDebug
 // define('PHPMAILER_SMTP_DEBUG', 0);
 
 //# Smtp Timeout


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
In config_extended.php the URL to the phpmailer documentation is out of date.

## Related Issue



## Screenshots (if appropriate):
