### PR TITLE
Avoid php 8 warning about trying to access null variable as an array

### DIFF
--- a/public_html/lists/admin/inc/userlib.php
+++ b/public_html/lists/admin/inc/userlib.php
@@ -129,7 +129,7 @@ function deleteUserBlacklistRecords($id)
 function deleteUserRecordsLeaveBlacklistRecords($id)
 {
     global $tables;
-    
+
     Sql_Query('delete from '.$tables['linktrack_uml_click'].' where userid = '.$id);
     Sql_Query('delete from '.$tables['listuser'].' where userid = '.$id);
     Sql_Query('delete from '.$tables['usermessage'].' where userid = '.$id);
@@ -156,7 +156,7 @@ function deleteUserLeaveBlacklist($id)
  */
 function deleteUserIncludeBlacklist($id)
 {
-    // Note: deleteUserBlacklistRecords() must be executed first, else the ID 
+    // Note: deleteUserBlacklistRecords() must be executed first, else the ID
     // to email lookup fails due to the missing record
     deleteUserBlacklistRecords($id);
     deleteUserRecordsLeaveBlacklistRecords($id);
@@ -312,8 +312,8 @@ function AttributeValue($table, $value)
 function getUserEmail($id)
 {
     global $tables;
-    
-    $userid = Sql_Fetch_Row_Query("select email from {$tables['user']} where id = \"$id\"");    
+
+    $userid = Sql_Fetch_Row_Query("select email from {$tables['user']} where id = \"$id\"");
     return $userid[0];
 }
 
@@ -416,7 +416,7 @@ function UserAttributeValue($user = 0, $attribute = 0)
         case 'checkboxgroup':
             //     print "select value from $user_att_table where userid = $user and attributeid = $attribute";
             $val_ids = Sql_Fetch_Row_Query("select value from $user_att_table where userid = $user and attributeid = $attribute");
-            if ($val_ids[0]) {
+            if ($val_ids && $val_ids[0]) {
                 //       print '<br/>1 <b>'.$val_ids[0].'</b>';
                 if (function_exists('cleancommalist')) {
                     $val_ids[0] = cleanCommaList($val_ids[0]);
@@ -457,13 +457,13 @@ function UserAttributeValue($user = 0, $attribute = 0)
         $table_prefix".'listattr_'.$att['tablename'].".id = $user_att_table".".value and
         $user_att_table".'.attributeid = '.$attribute);
             $row = Sql_Fetch_row($res);
-            $value = $row[0];
+            $value = $row ? $row[0] : '';
             break;
         default:
             $res = Sql_Query(sprintf('select value from %s where
         userid = %d and attributeid = %d', $user_att_table, $user, $attribute));
             $row = Sql_Fetch_row($res);
-            $value = $row[0];
+            $value = $row ? $row[0] : '';
     }
 
     return stripslashes($value);


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
php 8 issues warnings when trying to get the value of an attribute and the user does not have one.

```
[Sun Sep 26 14:42:54.045532 2021] [php:notice] [pid 10637] [client 127.0.0.1:43212]
 PHP Warning:  Trying to access array offset on value of type null in /home/duncan/www/lists_3.6.4/admin/inc/userlib.php on line 419

```
## Related Issue



## Screenshots (if appropriate):
