### PR TITLE
Pre-fill the (first of two) subscriber forms

### DIFF
--- a/public_html/lists/admin/subscribelib2.php
+++ b/public_html/lists/admin/subscribelib2.php
@@ -930,7 +930,7 @@ function ListAttributes($attributes, $attributedata, $htmlchoice = 0, $userid = 
     if (!isset($_GET['page']) || (isset($_GET['page']) && $_GET['page'] != 'import1')) {
         $html = sprintf('
   <tr><td><div class="required"><label for="email">%s *</label></div></td>
-  <td class="attributeinput"><input type=text name=email required="required" placeholder="%s" size="%d" id="email" />
+  <td class="attributeinput"><input type=text name=email required="required" value="%s" size="%d" id="email" />
   <script language="Javascript" type="text/javascript">addFieldToCheck("email","%s");</script></td></tr>',
             $GLOBALS['strEmail'], htmlspecialchars($email), $textlinewidth, $GLOBALS['strEmail']);
     }


### PR DESCRIPTION
# tl;dr
If a developer bothers using the email url parameter, it's likely because they want the form to be pre-filled. Using the "placeholder" doesn't help the user, and just leads to a bad user experience!
This small diff fixes the issue.

# Details

When creating a subscriber form we want to allow users to be sent to it after they've pre-filled another form (say, an html form in a sidebar or a pop-up box).

A solution for doing it is to have the a form on some website (say, blog), with something like this (which should be in the docs, BTW. Might be worth adding):
(notice the use of the id="email" attribute)

```
<form  style="width:202px; float:left;" action="https://my-blog.com/phplist/?p=subscribe&id=1" method="post" target="popupwindow" id="email">

<input type="text" style="width:110px"  onclick="if (this.value == 'Your e-mail here') this.value = '';" value='Your e-mail here' name="email"/>
<input type="hidden" value="my_blog" name="uri"/><input type="hidden" name="loc" value="en_US"/><input type="submit" value="Subscribe" />

</form>
```

When a user filles the form with "test@gmail.com", they are then sent to the subscriber page, before this current change, they would see the following form. Notice how the email seems to be pre-filled, but actually it is not:

![image](https://user-images.githubusercontent.com/976006/134976093-011d1d96-baba-456c-bfbb-b91b9d015fbf.png)


The user would have to now type their email two more times (!), on top of the first time they already typed it.

The reason for this odd behavior is that the form fills the email attribute into the "placeholder" tag, which is a bad practice in general (see here: https://www.smashingmagazine.com/2018/06/placeholder-attribute/).
The better solution is to use the 'value' attribute, to give the desired behavior: the user will now need to type their email only one more time.

Notice how now the email is black, and not greyed out:

![image](https://user-images.githubusercontent.com/976006/134976187-28532397-27ec-4c5b-97bd-4ec409900993.png)


# Related Issue

A similar thing was previously requested here:
https://discuss.phplist.org/t/link-to-subscription-page-with-email-or-userid/6808


