### PR TITLE
Add analytics parameters only for http and ftp URLs

### DIFF
--- a/public_html/lists/admin/sendemaillib.php
+++ b/public_html/lists/admin/sendemaillib.php
@@ -616,9 +616,12 @@ function sendEmail($messageid, $email, $hash, $htmlpref = 0, $rssitems = array()
         for ($i = 0; $i < count($links[3]); ++$i) {
             $link = cleanUrl($links[3][$i]);
             $link = str_replace('"', '', $link);
-            $newurl = addAnalyticsTracking($link, $trackingParameters, $prefix);
-            $newlink = sprintf('<a %shref="%s" %s>%s</a>', $links[1][$i], $newurl, $links[4][$i], $links[5][$i]);
-            $htmlmessage = str_replace($links[0][$i], $newlink, $htmlmessage);
+
+            if (preg_match('/^http|ftp/i', $link)) {
+                $newurl = addAnalyticsTracking($link, $trackingParameters, $prefix);
+                $newlink = sprintf('<a %shref="%s" %s>%s</a>', $links[1][$i], $newurl, $links[4][$i], $links[5][$i]);
+                $htmlmessage = str_replace($links[0][$i], $newlink, $htmlmessage);
+            }
         }
         /*
          * process plain-text format email

--- a/public_html/lists/admin/sendemaillib.php
+++ b/public_html/lists/admin/sendemaillib.php
@@ -602,8 +602,9 @@ function sendEmail($messageid, $email, $hash, $htmlpref = 0, $rssitems = array()
         output('click track end');
     }
 //exit;
-    //# if we're not tracking clicks, we should add Google tracking here
-    //# otherwise, we can add it when redirecting on the click
+    // if we're not tracking clicks, we should add Google tracking here
+    // otherwise, we can add it when redirecting on the click
+    // Add analytics tracking parameters only to http and https URLs
     if (!CLICKTRACK && !empty($cached[$messageid]['google_track'])) {
         /*
          * process html format email
@@ -617,7 +618,7 @@ function sendEmail($messageid, $email, $hash, $htmlpref = 0, $rssitems = array()
             $link = cleanUrl($links[3][$i]);
             $link = str_replace('"', '', $link);
 
-            if (preg_match('/^http|ftp/i', $link)) {
+            if (preg_match('/^http/i', $link)) {
                 $newurl = addAnalyticsTracking($link, $trackingParameters, $prefix);
                 $newlink = sprintf('<a %shref="%s" %s>%s</a>', $links[1][$i], $newurl, $links[4][$i], $links[5][$i]);
                 $htmlmessage = str_replace($links[0][$i], $newlink, $htmlmessage);
@@ -636,13 +637,9 @@ function sendEmail($messageid, $email, $hash, $htmlpref = 0, $rssitems = array()
             if (preg_match('/\.$/', $link)) {
                 $link = substr($link, 0, -1);
             }
-
-            if (preg_match('/^http|ftp/i', $link)) {
-                // && !strpos($link,$clicktrack_root)) {
-                $newurl = addAnalyticsTracking($link, $trackingParameters, $prefix);
-                $newlinks[$i] = $newurl;
-                $textmessage = str_replace($links[1][$i], '[%%%'.$i.'%%%]', $textmessage);
-            }
+            $newurl = addAnalyticsTracking($link, $trackingParameters, $prefix);
+            $newlinks[$i] = $newurl;
+            $textmessage = str_replace($links[1][$i], '[%%%'.$i.'%%%]', $textmessage);
         }
         foreach ($newlinks as $linkid => $newlink) {
             $textmessage = str_replace('[%%%'.$linkid.'%%%]', $newlink, $textmessage);

--- a/public_html/lists/lt.php
+++ b/public_html/lists/lt.php
@@ -241,7 +241,8 @@ if (!isset($_SESSION['entrypoint'])) {
     $_SESSION['entrypoint'] = $url;
 }
 
-if (!empty($messagedata['google_track'])) {
+// Add analytics tracking parameters only to http and https URLs
+if (!empty($messagedata['google_track']) && preg_match('/^http/i', $url)) {
     require __DIR__ . '/admin/analytics.php';
 
     $analytics = getAnalyticsQuery();


### PR DESCRIPTION

<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
Add analytics parameters only for http and ftp URLs when click tracking is not enabled.

When click tracking is enabled only http and ftp links are tracked. Analytic parameters are added when a link is clicked, therefore are added only to the http and ftp links, not to mailto: for example.

When click tracking is not enabled then analytic parameters are added to all links. That isn't necessary or even sensible for other protocols such as mailto:.

It also isn't wanted for a link to an element within the email itself.  The RSS Feed plugin now generates a table of contents with links like this, and doesn't want analytic query parameters to be added

    <a href="#item_0">Kraft Heinz says people must get used to higher food prices</a>


## Related Issue



## Screenshots (if appropriate):
