### PR TITLE
Show list id when displaying lists

### DIFF
--- a/public_html/lists/admin/editlist.php
+++ b/public_html/lists/admin/editlist.php
@@ -135,7 +135,9 @@ if (empty($list['category'])) {
 ?>
 
 <?php echo formStart(' class="editlistSave" ') ?>
-<input type="hidden" name="id" value="<?php echo $id ?>"/>
+<?php if ($id): ?>
+    <div class="label"><label><?php echo s('ID'); ?>:</label><?php echo $id ?></div>
+<?php endif;?>
 <div class="label"><label for="listname"><?php echo s('List name'); ?>:</label></div>
 <div class="field"><input type="text" name="listname"
                           value="<?php echo htmlspecialchars(stripslashes($list['name'])) ?>"/></div>

--- a/public_html/lists/admin/editlist.php
+++ b/public_html/lists/admin/editlist.php
@@ -191,7 +191,6 @@ foreach ($GLOBALS['plugins'] as $plugin) {
 }
 
 ?>
-<form>
     <label for="description"><?php echo s('List Description'); ?></label>
     <div class="field"><textarea name="description" cols="35" rows="5">
 <?php echo htmlspecialchars(stripslashes($list['description'])) ?></textarea></div>

--- a/public_html/lists/admin/editlist.php
+++ b/public_html/lists/admin/editlist.php
@@ -136,7 +136,7 @@ if (empty($list['category'])) {
 
 <?php echo formStart(' class="editlistSave" ') ?>
 <?php if ($id): ?>
-    <div class="label"><label><?php echo s('ID'); ?>:</label><?php echo $id ?></div>
+    <div class="label"><label><?php echo s('List ID'); ?>:</label><?php echo $id ?></div>
 <?php endif;?>
 <div class="label"><label for="listname"><?php echo s('List name'); ?>:</label></div>
 <div class="field"><input type="text" name="listname"

--- a/public_html/lists/admin/list.php
+++ b/public_html/lists/admin/list.php
@@ -226,6 +226,7 @@ echo '<button type="submit" name="go" id="filterbutton" >'.s('Go').'</button>
 echo '</div> ';
 $ls = new WebblerListing($total.' '.s('Lists'));
 $ls->usePanel($paging);
+$ls->setElementHeading(s('List name'));
 
 /* Always Show a "list" of all subscribers
  * https://mantis.phplist.com/view.php?id=17433
@@ -297,6 +298,7 @@ while ($row = Sql_fetch_array($result)) {
         s('Order'),
         sprintf('<input type="text" name="listorder[%d]" value="%d" size="3" class="listorder" />', $row['id'],
             $row['listorder']));
+    $ls->addColumn($element, s('ID'), $row['id']);
 
     $deletebutton = new ConfirmButton(
         s('Are you sure you want to delete this list?').'\n'.s('This will NOT remove the subscribers that are on this list.').'\n'.s('You can reconnect subscribers to lists on the Reconcile Subscribers page.'),

--- a/public_html/lists/admin/list.php
+++ b/public_html/lists/admin/list.php
@@ -298,7 +298,7 @@ while ($row = Sql_fetch_array($result)) {
         s('Order'),
         sprintf('<input type="text" name="listorder[%d]" value="%d" size="3" class="listorder" />', $row['id'],
             $row['listorder']));
-    $ls->addColumn($element, s('ID'), $row['id']);
+    $ls->addColumn($element, s('List ID'), $row['id']);
 
     $deletebutton = new ConfirmButton(
         s('Are you sure you want to delete this list?').'\n'.s('This will NOT remove the subscribers that are on this list.').'\n'.s('You can reconnect subscribers to lists on the Reconcile Subscribers page.'),


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
When listing the lists or editing a list the list id is not displayed. The id is needed when for example setting up an ajax subscribe form.

Also, removed an unnecessary form start tag, and unused hidden form field for id because id is taken from the GET parameter.
## Related Issue



## Screenshots (if appropriate):
When showing all lists
![image](https://user-images.githubusercontent.com/3147688/137581778-8e32c096-5549-477b-b5e5-debd8e603ced.png)

When editing a list
![image](https://user-images.githubusercontent.com/3147688/137581788-f8dc4b62-889e-49d0-9a62-8127a296e168.png)
