### PR TITLE
Add initialise on commandline

### DIFF
--- a/public_html/lists/admin/connect.php
+++ b/public_html/lists/admin/connect.php
@@ -55,6 +55,7 @@ $checkboxgroup_storesize = 1; // this will allow 10000 options for checkboxes
 
 // identify pages that can be run on commandline
 $commandline_pages = array(
+    'initialise',
     'dbcheck',
     'send',
     'processqueue',

--- a/public_html/lists/admin/inc/userlib.php
+++ b/public_html/lists/admin/inc/userlib.php
@@ -206,7 +206,7 @@ function addNewUser($email, $password = '')
     entered = now(),modified = now(),password = "%s",
     passwordchanged = now(),disabled = 0,
     uniqid = "%s",htmlemail = 1, uuid = "%s"
-    ', $GLOBALS['tables']['user'], $email, $blacklist, $passwordEnc, getUniqid(), (string) uuid::generate(4)));
+    ', $GLOBALS['tables']['user'], sql_escape($email), $blacklist, $passwordEnc, getUniqid(), (string) uuid::generate(4)));
 
     $id = Sql_Insert_Id();
 

--- a/public_html/lists/admin/initialise.php
+++ b/public_html/lists/admin/initialise.php
@@ -17,9 +17,11 @@ function output($message)
     }
     flush();
 }
+cl_output(s('Initialising phpList database structure.'));
 
 $success = 1;
 
+## fall back to environment variables (mostly for CLI)
 if (!isset($_REQUEST['adminname'])) {
     $_REQUEST['adminname'] = getenv('ADMIN_NAME');
 }
@@ -33,11 +35,35 @@ if (!isset($_REQUEST['adminemail'])) {
     $_REQUEST['adminemail'] = getenv('ADMIN_EMAIL');
 }
 
-$force = !empty($_GET['force']) && $_GET['force'] == 'yes';
+## require some variables on CLI
+if ($GLOBALS['commandline']) {
+  if (empty($_REQUEST['adminname'])) {
+      $_REQUEST['adminname'] = 'admin';
+  }
+  if (empty($_REQUEST['orgname'])) {
+      $_REQUEST['orgname'] = s('Organisation Name');
+  }
+  if (empty($_REQUEST['adminpassword'])) {
+      output(s('Admin password not set, cannot continue'));
+      cl_output(s('set ADMIN_PASSWORD environment variable'));
+      return;
+  }
+  if (empty($_REQUEST['adminemail'])) {
+      output(s('Admin email not set, cannot continue'));
+      cl_output(s('set ADMIN_EMAIL environment variable'));
+      return;
+  }
+  if ($GLOBALS['commandline'] && !is_email($_REQUEST['adminemail'])) {
+    output(s('Unable to validate email address for admin: '.strip_tags($_REQUEST['adminemail'])));
+    return;
+  }
+}
+
+$force = (!empty($_GET['force']) && $_GET['force'] == 'yes') || isset($cline['f']);
 
 if ($force) {
     foreach ($DBstruct as $table => $val) {
-        if ($table == 'attribute') {
+        if ($table == 'attribute' && Sql_Table_Exists('attribute')) {
             $req = Sql_Query("select tablename from {$tables['attribute']}");
             while ($row = Sql_Fetch_Row($req)) {
                 Sql_Query('drop table if exists '.$table_prefix.'listattr_'.$row[0]);
@@ -45,59 +71,67 @@ if ($force) {
         }
         Sql_Query('drop table if exists '.$tables[$table]);
     }
-    session_destroy();
-    Redirect('initialise&firstinstall=1');
-    exit;
+    if (!$GLOBALS['commandline']) {
+      session_destroy();
+      Redirect('initialise&firstinstall=1');
+      exit;
+    }
 }
 @ob_end_flush();
 
-if (empty($_SESSION['hasconf']) && !empty($_REQUEST['firstinstall']) && (empty($_REQUEST['adminemail']) || strlen($_REQUEST['adminpassword']) < 8)) {
-    echo '<noscript>';
-    echo '<div class="error">'.s('To install phpList, you need to enable Javascript').'</div>';
-    echo '</noscript>';
+if (!$GLOBALS['commandline'] && empty($_SESSION['hasconf']) && !empty($_REQUEST['firstinstall']) && (empty($_REQUEST['adminemail']) || strlen($_REQUEST['adminpassword']) < 8)) {
+    $output = '<noscript>';
+    $output .= '<div class="error">'.s('To install phpList, you need to enable Javascript').'</div>';
+    $output .= '</noscript>';
 
     if ($_SESSION['adminlanguage']['iso'] != $GLOBALS['default_system_language'] &&
         in_array($_SESSION['adminlanguage']['iso'], array_keys($GLOBALS['LANGUAGES']))
     ) {
-        echo '<div class="info error">'.s('The default system language is different from your browser language.').'<br/>';
-        echo s('You can set <pre>$default_system_language = "%s";</pre> in your config file, to use your language as the fallback language.',
+        $output .= '<div class="info error">'.s('The default system language is different from your browser language.').'<br/>';
+        $output .= s('You can set <pre>$default_system_language = "%s";</pre> in your config file, to use your language as the fallback language.',
                 $_SESSION['adminlanguage']['iso']).'<br/>';
-        echo s('It is best to do this before initialising the database.');
-        echo '</div>';
+        $output .= s('It is best to do this before initialising the database.');
+        $output .= '</div>';
     }
 
-    echo '<form method="post" action="" class="configForm" id="initialiseform">';
-    echo '<fieldset><legend>'.s('phpList initialisation').' </legend>
+    $output .= '<form method="post" action="" class="configForm" id="initialiseform">';
+    $output .= '<fieldset><legend>'.s('phpList initialisation').' </legend>
     <input type="hidden" name="firstinstall" value="1" />';
-    echo '<input type="hidden" name="page" value="initialise" />';
-    echo '<label for="adminname">'.s('Please enter your name.').'</label>';
-    echo '<div class="field"><input type="text" name="adminname" class="error missing" value="'.htmlspecialchars($_REQUEST['adminname']).'" /></div>';
-    echo '<label for="orgname">'.s('The name of your organisation').'</label>';
-    echo '<input type="text" name="orgname" value="'.htmlspecialchars($_REQUEST['orgname']).'" />';
-    echo '<label for="adminemail">'.s('Please enter your email address.').'</label>';
+    $output .= '<input type="hidden" name="page" value="initialise" />';
+    $output .= '<label for="adminname">'.s('Please enter your name.').'</label>';
+    $output .= '<div class="field"><input type="text" name="adminname" class="error missing" value="'.htmlspecialchars($_REQUEST['adminname']).'" /></div>';
+    $output .= '<label for="orgname">'.s('The name of your organisation').'</label>';
+    $output .= '<input type="text" name="orgname" value="'.htmlspecialchars($_REQUEST['orgname']).'" />';
+    $output .= '<label for="adminemail">'.s('Please enter your email address.').'</label>';
 
-    echo '<input type="text" name="adminemail" value="'.htmlspecialchars($_REQUEST['adminemail']).'" />';
-    echo s('The initial <i>login name</i> will be').' "admin"'.'<br/>';
-    echo '<label for="adminpassword">'.s('Please enter the password you want to use for this account.').' ('.$GLOBALS['I18N']->get('minimum of 8 characters.').')</label>';
-    echo '<input type="text" name="adminpassword" value="" id="initialadminpassword" /><br/><br/>';
-    echo '<input type="submit" value="'.s('Continue').'" id="initialisecontinue" disabled="disabled" />';
-    echo '</fieldset></form>';
-
+    $output .= '<input type="text" name="adminemail" value="'.htmlspecialchars($_REQUEST['adminemail']).'" />';
+    $output .= s('The initial <i>login name</i> will be').' "admin"'.'<br/>';
+    $output .= '<label for="adminpassword">'.s('Please enter the password you want to use for this account.').' ('.$GLOBALS['I18N']->get('minimum of 8 characters.').')</label>';
+    $output .= '<input type="text" name="adminpassword" value="" id="initialadminpassword" /><br/><br/>';
+    $output .= '<input type="submit" value="'.s('Continue').'" id="initialisecontinue" disabled="disabled" />';
+    $output .= '</fieldset></form>';
+    output($output);
     return;
 }
 
 //var_dump($GLOBALS['plugins']);exit;
 
+if ($GLOBALS['commandline'] && $_SESSION['hasconf'] && empty($force)) {
+  cl_output(s('Already initialised. Use -f to force'));
+  return;
+}
+
 output('<h3>'.s('Creating tables')."</h3><br />");
 foreach ($DBstruct as $table => $val) {
     if ($force) {
-        if ($table == 'attribute') {
+        if ($table == 'attribute' &&  Sql_Table_exists('attribute')) {
             $req = Sql_Query("select tablename from {$tables['attribute']}");
             while ($row = Sql_Fetch_Row($req)) {
                 Sql_Query("drop table if exists $table_prefix"."listattr_$row[0]", 1);
             }
         }
         Sql_query("drop table if exists $tables[$table]");
+        unset($_SESSION["dbtables"]);
     }
     $query = "CREATE TABLE $tables[$table] (\n";
     foreach ($DBstruct[$table] as $column => $struct) {
@@ -135,7 +169,7 @@ foreach ($DBstruct as $table => $val) {
                 if (isset($_REQUEST['adminpassword'])) {
                     $adminpass = $_REQUEST['adminpassword'];
                 } else {
-                    $adminpass = 'phplist';
+                    $adminpass = md5(time());
                 }
 
                 Sql_Query(sprintf('insert into %s (loginname,namelc,email,created,modified,password,passwordchanged,superuser,disabled)
@@ -181,6 +215,8 @@ foreach ($GLOBALS['plugins'] as $pluginName => $plugin) {
 if ($success) {
     output( s('Setting default configuration').'<br/>');
     // mark the database to be our current version
+    output(s('Admin = '.$_REQUEST['adminname']));
+    output(s('Admin Email = '.$adminemail));
     SaveConfig('version', VERSION, 0);
     SaveConfig('admin_address', $adminemail, 1);
     SaveConfig('message_from_name', strip_tags($_REQUEST['adminname']), 1);

--- a/public_html/lists/admin/initialise.php
+++ b/public_html/lists/admin/initialise.php
@@ -161,20 +161,11 @@ foreach ($DBstruct as $table => $val) {
             if ($table == 'admin') {
                 // create a default admin
                 $_SESSION['firstinstall'] = 1;
-                if (isset($_REQUEST['adminemail'])) {
-                    $adminemail = $_REQUEST['adminemail'];
-                } else {
-                    $adminemail = '';
-                }
-                if (isset($_REQUEST['adminpassword'])) {
-                    $adminpass = $_REQUEST['adminpassword'];
-                } else {
-                    $adminpass = md5(time());
-                }
-
+                $adminemail = $_REQUEST['adminemail'];
+                $adminpass = $_REQUEST['adminpassword'];
                 Sql_Query(sprintf('insert into %s (loginname,namelc,email,created,modified,password,passwordchanged,superuser,disabled)
                     values("%s","%s","%s",now(),now(),"%s",now(),%d,0)',
-                    $tables['admin'], 'admin', 'admin', $adminemail, encryptPass($adminpass), 1));
+                    $tables['admin'], 'admin', 'admin', sql_escape($adminemail), encryptPass($adminpass), 1));
 
                 //# let's add them as a subscriber as well
                 $userid = addNewUser($adminemail, $adminpass);

--- a/public_html/lists/admin/initialise.php
+++ b/public_html/lists/admin/initialise.php
@@ -215,8 +215,8 @@ foreach ($GLOBALS['plugins'] as $pluginName => $plugin) {
 if ($success) {
     output( s('Setting default configuration').'<br/>');
     // mark the database to be our current version
-    output(s('Admin = '.$_REQUEST['adminname']));
-    output(s('Admin Email = '.$adminemail));
+    output('<strong>'.s('Admin =').'</strong> '.$_REQUEST['adminname'].'<br/>');
+    output('<strong>'.s('Admin Email =').'</strong> '.$adminemail.'<br/>');
     SaveConfig('version', VERSION, 0);
     SaveConfig('admin_address', $adminemail, 1);
     SaveConfig('message_from_name', strip_tags($_REQUEST['adminname']), 1);

--- a/public_html/lists/admin/lib.php
+++ b/public_html/lists/admin/lib.php
@@ -881,6 +881,10 @@ function system_messageHeaders($useremail = '')
 
 function logEvent($msg)
 {
+    global $tables;
+    if (!Sql_Table_Exists($tables['eventlog'])) {
+        return;
+    }
     $logged = false;
     foreach ($GLOBALS['plugins'] as $pluginname => $plugin) {
         $logged = $logged || $plugin->logEvent($msg);
@@ -889,7 +893,6 @@ function logEvent($msg)
         return;
     }
 
-    global $tables;
     if (isset($GLOBALS['page'])) {
         $p = $GLOBALS['page'];
     } elseif (isset($_GET['page'])) {
@@ -898,9 +901,6 @@ function logEvent($msg)
         $p = $_GET['p'];
     } else {
         $p = 'unknown page';
-    }
-    if (!Sql_Table_Exists($tables['eventlog'])) {
-        return;
     }
     Sql_Query(sprintf('insert into %s (entered,page,entry) values(now(),"%s","%s")', $tables['eventlog'],
         $p, sql_escape($msg)));


### PR DESCRIPTION

Allow calling initialise on commandline

required ENV variables:

- ADMIN_PASSWORD - password for admin account
- ADMIN_EMAIL - email address for admin account

Optional ENV variables:

- ADMIN_NAME - name of administrator
- ORGANISATION_NAME - name of organisation

Additionally, the -f parameter will force initialisation

`php public_html/lists/admin/index.php -p initialise -c [configfile] [-f]`


