### PR TITLE
Avoid php 8 notices when trying to access a null value as an array

### DIFF
--- a/public_html/lists/admin/actions/processqueue.php
+++ b/public_html/lists/admin/actions/processqueue.php
@@ -627,8 +627,10 @@ if ($num_messages) {
         ." where status not in ('draft', 'sent', 'prepared', 'suspended')"
         .' and embargo > now()'
         .' order by embargo asc limit 1');
-    $counters['status'] = 'embargo';
-    $counters['delaysend'] = $future['waittime'];
+    if ($future) {
+        $counters['status'] = 'embargo';
+        $counters['delaysend'] = $future['waittime'];
+    }
 }
 
 $script_stage = 2; // we know the messages to process

--- a/public_html/lists/admin/sendemaillib.php
+++ b/public_html/lists/admin/sendemaillib.php
@@ -1281,13 +1281,15 @@ function clickTrackLinkId($messageid, $userid, $url, $link)
             $GLOBALS['tables']['linktrack_ml'], $messageid, $fwdid));
         if (!Sql_Affected_Rows()) {
             //# first time for this link/message
+            $total = 1;
             Sql_Query(sprintf('replace into %s set total = %d,messageid = %d,forwardid = %d',
-                $GLOBALS['tables']['linktrack_ml'], $tot[0] + 1, $messageid, $fwdid));
+                $GLOBALS['tables']['linktrack_ml'], $total, $messageid, $fwdid));
         } else {
+            $total = $tot[0] + 1;
             Sql_Query(sprintf('update %s set total = %d where messageid = %d and forwardid = %d',
-                $GLOBALS['tables']['linktrack_ml'], $tot[0] + 1, $messageid, $fwdid));
+                $GLOBALS['tables']['linktrack_ml'], $total, $messageid, $fwdid));
         }
-        $cached['linktracksent'][$messageid][$fwdid] = $tot[0] + 1;
+        $cached['linktracksent'][$messageid][$fwdid] = $total;
     } else {
         ++$cached['linktracksent'][$messageid][$fwdid];
         //# write every so often, to make sure it's saved when interrupted


### PR DESCRIPTION


<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->

Avoid php notice "Trying to access array offset on value of type null with php 8

```
[Sat Oct 23 07:46:31.488993 2021] [php7:notice] [pid 4211] [client 127.0.0.1:40156]
PHP Notice:  Trying to access array offset on value of type null in /home/duncan/www/lists_3.6.5/admin/sendemaillib.php on line 1293, referer: http://strontian/lists/admin/?page=processqueue&tk=b4c88a1a3bad03da11899675a688835a

[Sat Oct 23 08:11:28.592318 2021] [php7:notice] [pid 3760] [client 127.0.0.1:40404]
PHP Notice:  Trying to access array offset on value of type null in /home/duncan/www/lists_3.6.5/admin/actions/processqueue.php on line 631, referer: http://strontian/lists/admin/?page=processqueue&tk=b4c88a1a3bad03da11899675a688835a
```
## Related Issue



## Screenshots (if appropriate):
