### PR TITLE
Avoid php 8 fatal error when trying to format an empty date string

### DIFF
--- a/public_html/lists/admin/connect.php
+++ b/public_html/lists/admin/connect.php
@@ -1793,6 +1793,9 @@ function monthName($month, $short = 0)
  */
 function formatDate($date, $short = 0)
 {
+    if ($date == '') {
+        return '';
+    }
     $format = getConfig('date_format');
     $year = substr($date, 0, 4);
     $month = substr($date, 5, 2);


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->

The view admin page gives a fatal error when displaying an admin whose "password changed" date is empty. The error happens in the formatDate() function.

```
[24-Oct-2021 11:08:19 Europe/London]
PHP Fatal error:  Uncaught TypeError: Unsupported operand types: string * int in /home/dcameron/public_html/lists/admin/connect.php:1806

```
Rather than try to ensure that all callers of that function do not pass an empty date field, it is simpler just to return an empty string, which is what the formatDateTime() does already.

## Related Issue



## Screenshots (if appropriate):
