### PR TITLE
Specify MYSQLI_CLIENT_SSL flag when attempting SSL/TLS secured MySQL connections

### DIFF
--- a/public_html/lists/admin/mysqli.inc
+++ b/public_html/lists/admin/mysqli.inc
@@ -20,7 +20,7 @@ function Sql_Connect($host, $user, $password, $database)
     }
     $db = mysqli_init();
     $compress = empty($database_connection_compression) ? 0 : MYSQLI_CLIENT_COMPRESS;
-    $secure = empty($database_connection_ssl) ? 0 : MYSQLI_CLIENT_SSL_DONT_VERIFY_SERVER_CERT;
+    $secure = empty($database_connection_ssl) ? 0 : MYSQLI_CLIENT_SSL;
 
     if (!mysqli_real_connect($db, $host, $user, $password, $database, $database_port, $database_socket, $compress | $secure)) {
         $errno = mysqli_connect_errno();


### PR DESCRIPTION
## Description

`MYSQLI_CLIENT_SSL_DONT_VERIFY_SERVER_CERT` does not seem to imply `MYSQLI_CLIENT_SSL`.
This PR adds the `MYSQLI_CLIENT_SSL` flag when SSL/TLS secured MySQL connections are desired.

## Related Issue

Please see https://github.com/phpList/phplist3/issues/833