### PR TITLE
Use \r\n to split the new attributes textarea field

### DIFF
--- a/public_html/lists/admin/editattributes.php
+++ b/public_html/lists/admin/editattributes.php
@@ -62,7 +62,7 @@ switch ($data['type']) {
         <?php
 
         if (isset($_POST['addnew'])) {
-            $items = explode("\n", $_POST['itemlist']);
+            $items = explode("\r\n", $_POST['itemlist']);
             $query = sprintf('select max(listorder) as listorder from %s', $table);
             $maxitem = Sql_Fetch_Row_Query($query);
             if (!Sql_Affected_Rows() || !is_numeric($maxitem[0])) {


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
The textarea field of new attributes has \r\n as line endings but the code currently splits on only \n.
## Related Issue

https://github.com/phpList/phplist3/issues/839

## Screenshots (if appropriate):
