### PR TITLE
bugfix count on a string

### DIFF
--- a/public_html/lists/index.php
+++ b/public_html/lists/index.php
@@ -54,7 +54,7 @@ include_once dirname(__FILE__).'/admin/lib.php';
 
 $I18N = new phplist_I18N();
 header('Access-Control-Allow-Origin: '.ACCESS_CONTROL_ALLOW_ORIGIN);
-if (defined('ACCESS_CONTROL_ALLOW_ORIGINS') && count('ACCESS_CONTROL_ALLOW_ORIGINS') > 1) {
+if (defined('ACCESS_CONTROL_ALLOW_ORIGINS') && count(ACCESS_CONTROL_ALLOW_ORIGINS) > 1) {
     header('Vary: Origin'); // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin#CORS_and_caching
 }
 


### PR DESCRIPTION
3.66, php8
When entering the user subscription page: white screen of death as count is operating on a string, not the array.