### PR TITLE
When importing report an attribute value changing from null.

### DIFF
--- a/public_html/lists/admin/actions/import2.php
+++ b/public_html/lists/admin/actions/import2.php
@@ -284,7 +284,7 @@ if ($total > 0) {
                 if ($new || (!$new && $_SESSION['overwrite'] == 'yes')) {
                     $query = '';
                     ++$count['dataupdate'];
-                    $old_data = Sql_Fetch_Array_Query(sprintf('select * from %s where id = %d', $tables['user'],
+                    $old_data = Sql_Fetch_Assoc_Query(sprintf('select * from %s where id = %d', $tables['user'],
                         $userid));
                     $old_data = array_merge($old_data, getUserAttributeValues('', $userid));
                     foreach ($user['systemvalues'] as $column => $value) {
@@ -397,16 +397,20 @@ if ($total > 0) {
                             }
                         }
                     }
-                    $current_data = Sql_Fetch_Array_Query(sprintf('select * from %s where id = %d', $tables['user'],
+                    $current_data = Sql_Fetch_Assoc_Query(sprintf('select * from %s where id = %d', $tables['user'],
                         $userid));
                     $current_data = array_merge($current_data, getUserAttributeValues('', $userid));
                     $information_changed = 0;
+
                     foreach ($current_data as $key => $val) {
-                        if (!is_numeric($key)) {
-                            if (isset($old_data[$key]) && $old_data[$key] != $val && $old_data[$key] && $key != 'password' && $key != 'modified') {
-                                $information_changed = 1;
-                                $history_entry .= "$key = $val\n*changed* from $old_data[$key]\n";
-                            }
+                        if ($key == 'password' || $key == 'modified') {
+                            continue;
+                        }
+                        $old_value = isset($old_data[$key]) ? $old_data[$key] : '';
+
+                        if ($old_value != $val) {
+                            $information_changed = 1;
+                            $history_entry .= "$key = $val\n*changed* from $old_value\n";
                         }
                     }
                     if (!$information_changed) {


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
Currently when importing an existing subscriber with a new attribute value, i.e. they do not have a value for that attribute, the change is not reported in the user history. This is caused by the code not reporting changes where the old value is "false" such as null or an empty string.

This change is to always report a new or changed attribute value.

## Related Issue



## Screenshots (if appropriate):

Before this code change, the change of attribute value is not reported
![image](https://user-images.githubusercontent.com/3147688/148644238-36680bf8-fc82-475a-a0d9-30b6ebde8f32.png)


After this code change, the change of attribute value is reported with an empty "previous value".

![image](https://user-images.githubusercontent.com/3147688/148644160-57865a01-7bc1-4301-b088-653cc0fad8dd.png)
