### PR TITLE
Set default of 0 for the processed column in the message table.

### DIFF
--- a/public_html/lists/admin/upgrade.php
+++ b/public_html/lists/admin/upgrade.php
@@ -441,6 +441,10 @@ if ($dbversion == VERSION && !$force) {
         Sql_Query("alter table {$GLOBALS['tables']['message']} change column processed processed integer ");
     }
 
+    if (version_compare($dbversion, '3.6.7', '<')) {
+        Sql_Query("alter table {$GLOBALS['tables']['message']} alter column processed set default 0 ");
+    }
+
     if (!Sql_Table_Column_Exists($GLOBALS['tables']['template'], 'template_text')) {
         Sql_Query(sprintf('alter table %s add column template_text longblob after template',
             $GLOBALS['tables']['template']));
@@ -448,7 +452,7 @@ if ($dbversion == VERSION && !$force) {
         Sql_Query(sprintf('update %s set template_text="[CONTENT]"',
             $GLOBALS['tables']['template']));
     }
-    
+
     //# longblobs are better at mixing character encoding. We don't know the encoding of anything we may want to store in cache
     //# before converting, it's quickest to clear the cache
     clearPageCache();


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
I was looking at the message table and noticed that the processed column was set to null, even when campaigns had been sent.

An earlier change had changed the column from medium int to integer, but when upgrading existing databases the "change column" syntax changes the whole column definition, not just the data type. So the previous default value was lost.

https://github.com/phpList/phplist3/commit/ff53c6f66dd63d8b2f98a5ee541a965a52e77360#diff-69b8033d3d4d2e49f71cd4b938df9fbca5ebe89b3ae860927f8748e9854570e9

In my database, all campaigns sent since applying that update had the processed column set to null, which stopped sql statements like this from working

    set processed = processed + 1

This change will restore the default value of 0. Strictly it is needed only for databases that had the previous upgrade applied, but I don't think those can be identified. Databases created using 3.6.0 or later should not have the problem.

## Related Issue



## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/3147688/149296409-4e827438-1380-431b-9d99-759d01a64958.png)