### PR TITLE
Use custom attributes in email subject

### DIFF
--- a/public_html/lists/admin/sendemaillib.php
+++ b/public_html/lists/admin/sendemaillib.php
@@ -909,6 +909,8 @@ function sendEmail($messageid, $email, $hash, $htmlpref = 0, $rssitems = array()
             $subject = $GLOBALS['strFwd'].': '.$cached[$messageid]['subject'];
             $mail->AddReplyTo($forwardedby['email'], $forwardedby['subscriberName']);
         }
+        
+        $subject = parsePlaceHolders($subject, $user_att_values);
 
         if ($getspeedstats) {
             output('build End '.$GLOBALS['processqueue_timer']->interval(1));


### PR DESCRIPTION
At the moment, custom attributes do not work in the email subject. If you want to put a more individual subject on your emails, this small code addition gives you the opportunity to do so ;-)