### PR TITLE
In the bounce report do not link to a deleted subscriber

### DIFF
--- a/public_html/lists/admin/processbounces.php
+++ b/public_html/lists/admin/processbounces.php
@@ -596,8 +596,7 @@ if (count($bouncerules)) {
                     case 'deleteuser':
                         logEvent('User '.$userdata['email'].' deleted by bounce rule '.PageLink2('bouncerule&amp;id='.$rule['id'],
                                 $rule['id']));
-                        $advanced_report .= 'User '.$userdata['email'].' deleted by bounce rule '.$rule['id'].PHP_EOL;
-                        $advanced_report .= 'User: '.$report_linkroot.'/?page=user&amp;id='.$userdata['id'].PHP_EOL;
+                        $advanced_report .= 'User '.$userdata['email'].' Id '.$userdata['id'].' deleted by bounce rule '.$rule['id'].PHP_EOL;
                         $advanced_report .= 'Rule: '.$report_linkroot.'/?page=bouncerule&amp;id='.$rule['id'].PHP_EOL;
                         deleteUser($row['user']);
                         break;
@@ -618,8 +617,7 @@ if (count($bouncerules)) {
                     case 'deleteuserandbounce':
                         logEvent('User '.$userdata['email'].' deleted by bounce rule '.PageLink2('bouncerule&amp;id='.$rule['id'],
                                 $rule['id']));
-                        $advanced_report .= 'User '.$userdata['email'].' deleted by bounce rule '.$rule['id'].PHP_EOL;
-                        $advanced_report .= 'User: '.$report_linkroot.'/?page=user&amp;id='.$userdata['id'].PHP_EOL;
+                        $advanced_report .= 'User '.$userdata['email'].' Id '.$userdata['id'].' deleted by bounce rule '.$rule['id'].PHP_EOL;
                         $advanced_report .= 'Rule: '.$report_linkroot.'/?page=bouncerule&amp;id='.$rule['id'].PHP_EOL;
                         deleteUser($row['user']);
                         deleteBounce($row['bounce']);


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
Currently when a subscriber is deleted by a bounce rule the bounce report includes a link to the now non-existent subscriber page.
This PR changes the report to show only the email address and also adds the subscriber id, which might be useful extra information.
 
## Related Issue



## Screenshots (if appropriate):
