### PR TITLE
Set mysql error reporting to the pre-8.1 value

### DIFF
--- a/public_html/lists/admin/mysqli.inc
+++ b/public_html/lists/admin/mysqli.inc
@@ -22,6 +22,8 @@ function Sql_Connect($host, $user, $password, $database)
     $compress = empty($database_connection_compression) ? 0 : MYSQLI_CLIENT_COMPRESS;
     $secure = empty($database_connection_ssl) ? 0 : MYSQLI_CLIENT_SSL_DONT_VERIFY_SERVER_CERT;
 
+    mysqli_report(MYSQLI_REPORT_OFF);
+
     if (!mysqli_real_connect($db, $host, $user, $password, $database, $database_port, $database_socket, $compress | $secure)) {
         $errno = mysqli_connect_errno();
 


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->

In php 8.1 there is a change to the mysql default error mode. An exception is now thrown instead of silencing the error.
See https://php.watch/versions/8.1/mysqli-error-mode for an explanation.

This causes a problem for code that, for example, inserts a row without checking whether a row with the key already exists.
The simple import page has such code, and with php 8.1 trying to insert an email address that already exists causes a fatal error.

`[Fri Feb 04 17:59:19.730045 2022] [php:notice] [pid 2005] [client 127.0.0.1:53550] PHP Fatal error:  Uncaught mysqli_sql_exception: Duplicate entry 'foo1@test.com' for key 'email' in /home/duncan/Development/GitHub/phplist3/public_html/lists/admin/mysqli.inc:179`

This PR changes the default mode to that used prior to php 8.1 so that the current error handling approach can continue to work.

## Related Issue



## Screenshots (if appropriate):
