### PR TITLE
Prepend the installation name to the subject of notification emails

### DIFF
--- a/public_html/lists/admin/lib.php
+++ b/public_html/lists/admin/lib.php
@@ -642,7 +642,7 @@ function sendAdminCopy($subject, $message, $lists = array())
         foreach ($mails as $admin_mail) {
             $admin_mail = trim($admin_mail);
             if (!isset($sent[$admin_mail]) && !empty($admin_mail)) {
-                sendMail($admin_mail, $subject, $message, system_messageheaders($admin_mail));
+                sendMail($admin_mail, $GLOBALS['installation_name'].' '.$subject, $message, system_messageheaders($admin_mail));
                 //   logEvent(s('Sending admin copy to').' '.$admin_mail);
                 $sent[$admin_mail] = 1;
             }
@@ -1359,7 +1359,7 @@ function fetchUrlCurl($url, $request_parameters)
     if (HTTP_PROXY_HOST and HTTP_PROXY_PORT) {
         curl_setopt($curl, CURLOPT_PROXY, HTTP_PROXY_HOST);
         curl_setopt($curl, CURLOPT_PROXYPORT, HTTP_PROXY_PORT);
-    }    
+    }
     $raw_result = curl_exec($curl);
     $status = curl_getinfo($curl, CURLINFO_HTTP_CODE);
     curl_close($curl);


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
The report emails sent to an admin, such as process queue report and bounce processing report, include the installation name in the subject. See https://github.com/phpList/phplist3/blob/master/public_html/lists/admin/connect.php#L396

This change is to do the same for the notification emails sent to an admin when a subscriber subscribes, unsubscribes etc.
## Related Issue



## Screenshots (if appropriate):
