### PR TITLE
Increase column size (admin table) on DB

### DIFF
--- a/public_html/lists/admin/structure.php
+++ b/public_html/lists/admin/structure.php
@@ -286,7 +286,7 @@ $DBstructphplist = array(
     ),
     'admin' => array(
         'id'              => array('integer not null primary key auto_increment', 'sys:ID'),
-        'loginname'       => array('varchar(25) not null', 'Login Name (max 25 chars)'),
+        'loginname'       => array('varchar(66) not null', 'Login Name (max 66 chars)'),
         'namelc'          => array('varchar(255)', 'sys:Normalised loginname'),
         'email'           => array('varchar(255) not null', 'Email'),
         'created'         => array('datetime', 'sys:Time Created'),

--- a/public_html/lists/admin/upgrade.php
+++ b/public_html/lists/admin/upgrade.php
@@ -452,6 +452,11 @@ if ($dbversion == VERSION && !$force) {
         Sql_Query(sprintf('update %s set template_text="[CONTENT]"',
             $GLOBALS['tables']['template']));
     }
+        //#increase size 'loginname' for the sso plugin
+
+    if (version_compare($dbversion, '3.6.7','<')) {
+        Sql_Query("alter table {$GLOBALS['tables']['admin']} change column loginname varchar(66) default ");
+    }
 
     //# longblobs are better at mixing character encoding. We don't know the encoding of anything we may want to store in cache
     //# before converting, it's quickest to clear the cache


### PR DESCRIPTION
Increase 'loginname' max chars to 66 on admin table.

<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
The following changes are being made in order to solve the issue> `loginname` character limit , related to SSO plugin.

## Related Issue
The discussion can be found here https://github.com/phpList/phplist-plugin-simplesaml/issues/2


## Screenshots (if appropriate):
