### PR TITLE
Importing subscriber file from the command line

### DIFF
--- a/public_html/lists/admin/actions/import2.php
+++ b/public_html/lists/admin/actions/import2.php
@@ -2,9 +2,9 @@
 
 verifyCsrfGetToken();
 
-require dirname(__FILE__).'/../structure.php';
-require dirname(__FILE__).'/../inc/importlib.php';
-require dirname(__FILE__).'/../CsvReader.php';
+require_once dirname(__FILE__).'/../structure.php';
+require_once dirname(__FILE__).'/../inc/importlib.php';
+require_once dirname(__FILE__).'/../CsvReader.php';
 
 @ob_end_flush();
 $status = 'FAIL';

--- a/public_html/lists/admin/import.php
+++ b/public_html/lists/admin/import.php
@@ -72,10 +72,15 @@ if ($GLOBALS['commandline']) {
     $_POST['overwrite'] = 'yes';
     $_POST['notify'] = 'no';
     $_POST['omit_invalid'] = 'yes';
+    $_POST['assign_invalid'] = '';
     $_POST['import_field_delimiter'] = "\t";
     $_POST['import_field_delimiter'] = ',';
     $_POST['import_record_delimiter'] = "\n";
+
     require dirname(__FILE__).'/import2.php';
+    ob_end_clean();
+    ob_start();
+    require dirname(__FILE__).'/actions/import2.php';
     ob_end_clean();
     echo "\nAll done\n";
     exit;

--- a/public_html/lists/admin/import2.php
+++ b/public_html/lists/admin/import2.php
@@ -63,7 +63,7 @@ if (!empty($_GET['reset']) && $_GET['reset'] == 'yes') {
     // }
 }
 if (isset($_POST['import'])) {
-    if (!verifyToken()) {
+    if (!$commandline && !verifyToken()) {
         echo Error(s('Invalid security token, please reload the page and try again'),
             'http://resources.phplist.com/documentation/errors/securitytoken');
 


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
The import of a file from the command line currently fails with `Error: Invalid security token, please reload the page and try again`
I suspect this is due to the splitting of import into two pages when adding the "action" page, so has not worked for a long time.
This change is to run the import2 page followed by the actions/import2 page.  Trying to use only the action page doesn't work because it is closely tied to the first page which sets various $_SESSION variables.
Some unnecessary browser output leaks through see screenshot below but isn't too distracting.

## Related Issue



## Screenshots (if appropriate):

```
Reading emails from file .....ok, 3 linesReading emails from file .....ok, 3 lines<script type="text/javascript">
        var parentJQuery = window.parent.jQuery;
        parentJQuery("#progressbar").updateProgress("0,2");
        </script>
All the emails already exist in the database and are member of the lists
Subscriber data was updated for 2 subscribers
0 subscribers were matched by foreign key, 2 by email
All done
```
