### PR TITLE
Better support for non-latin strings in select dropdown of search subcribers page

### DIFF
--- a/public_html/lists/admin/users.php
+++ b/public_html/lists/admin/users.php
@@ -390,7 +390,7 @@ $filterpanel .= '>'.$GLOBALS['I18N']->get('Unique ID').'</option>';
 $att_req = Sql_Query('select id,name from '.$tables['attribute'].' where type = "hidden" or type = "textline" or type = "select"');
 while ($row = Sql_Fetch_Array($att_req)) {
     $filterpanel .= sprintf('<option value="%d" %s>%s</option>', $row['id'],
-        $row['id'] == $findby ? 'selected="selected"' : '', substr($row['name'], 0, 20));
+        $row['id'] == $findby ? 'selected="selected"' : '', shortentextdisplay($row['name'], 20));
 }
 
 $filterpanel .= '</select><input class="submit" type="submit" value="'.s('Go').'" />&nbsp;&nbsp;<a href="./?page=users&amp;find=NULL" class="reset">'.s('reset').'</a>';


### PR DESCRIPTION
I am using phpList along with attributes in the Greek language and in the search subscribers section the filtering dropdown which shows the available attributes doesn't correctly truncate Greek strings due to the substr command.

I propose to change it with the function shortenTextDisplay (defined in lib.php) which uses the corresponding mb_ versions for substr etc. if available.

**Before:**
![phplist_2](https://user-images.githubusercontent.com/12183504/176670512-784d729c-cffb-4e6d-acd1-ec4c890e76a1.jpg)

**After:**
![phplist_1](https://user-images.githubusercontent.com/12183504/176670506-a93bc19f-2003-4ed7-a318-1770bf81e7fc.jpg)

