### PR TITLE
Split the part of shortening text that needs to be multibyte aware in…

### DIFF
--- a/public_html/lists/admin/lib.php
+++ b/public_html/lists/admin/lib.php
@@ -1924,55 +1924,64 @@ function listCategories()
 }
 
 /*
+ * shortenText
+ *
+ * Shorten text for use by shortenTextDisplay() but also stand-alone.
+ *
+ * Define multibyte-string aware/unaware function depending on whether the mbstring extension is available
+ * see https://github.com/phpList/phplist3/pull/10
+ */
+if (!function_exists('mb_strlen')) {
+    // mbstring unavailable
+    function shortenText($text, $max = 30)
+    {
+        if (strlen($text) > $max) {
+            if ($max < 30) {
+                $shortened = substr($text, 0, $max - 4).' ... ';
+            } else {
+                $shortened = substr($text, 0, 20).' ... '.substr($text, -10);
+            }
+        } else {
+            $shortened = $text;
+        }
+
+        return $shortened;
+    }
+} else {
+    // mbstring available
+    function shortenText($text, $max = 30)
+    {
+        if (mb_strlen($text) > $max) {
+            if ($max < 30) {
+                $shortened = mb_substr($text, 0, $max - 4).' ... ';
+            } else {
+                $shortened = mb_substr($text, 0, 20).' ... '.mb_substr($text, -10);
+            }
+        } else {
+            $shortened = $text;
+        }
+
+        return $shortened;
+    }
+}
+
+/*
  * shortenTextDisplay
  *
  * mostly used for columns in listings to retrict the width, particularly on mobile devices
  * it will show the full text as the title tip but restrict the size of the output
  *
  * will also place a space after / and @ to facilitate wrapping in the browser
+ *
  */
-
 function shortenTextDisplay($text, $max = 30)
 {
-    //# use mb_ version if possible, see https://github.com/phpList/phplist3/pull/10
-    if (function_exists('mb_strlen')) {
-        return mb_shortenTextDisplay($text, $max);
-    }
-
-    $text = preg_replace('!^https?://!i', '', $text);
-    if (strlen($text) > $max) {
-        if ($max < 30) {
-            $display = substr($text, 0, $max - 4).' ... ';
-        } else {
-            $display = substr($text, 0, 20).' ... '.substr($text, -10);
-        }
-    } else {
-        $display = $text;
-    }
+    $display = preg_replace('!^https?://!i', '', $text);
+    $display = shortenText($display, $max);
     $display = str_replace('/', '/&#x200b;', $display);
     $display = str_replace('@', '@&#x200b;', $display);
 
-    return sprintf('<span title="%s">%s</span>', htmlspecialchars($text),
-        htmlspecialchars($text), $display);
-}
-
-function mb_shortenTextDisplay($text, $max = 30)
-{
-    $text = preg_replace('!^https?://!i', '', $text);
-    if (mb_strlen($text) > $max) {
-        if ($max < 30) {
-            $display = mb_substr($text, 0, $max - 4).' ... ';
-        } else {
-            $display = mb_substr($text, 0, 20).' ... '.mb_substr($text, -10);
-        }
-    } else {
-        $display = $text;
-    }
-    $display = str_replace('/', '/&#x200b;', $display);
-    $display = str_replace('@', '@&#x200b;', $display);
-
-    return sprintf('<span title="%s" ondblclick="alert(\'%s\');">%s</span>', htmlspecialchars($text),
-        htmlspecialchars($text), $display);
+    return sprintf('<span title="%s">%s</span>', htmlspecialchars($text), $display);
 }
 
 if (!function_exists('getnicebacktrace')) {


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
`shortenTextDisplay()` currently returns a `span` element which can be used when displaying URLs or email addresses.

This change splits the part of shortening text that needs to be multibyte aware into a separate function so that it can be used on its own to shorten other text, such as an attribute name in a `select` list.

It also fixes a few small issues that were introduced in earlier pull requests

- the non multibyte version of the function had a `sprintf()` with more parameters than %s placeholders
- the multibyte version had an `ondblclick()` handler which had been removed from the non multibyte version
- when a URL had been shortened the title tooltip didn't show the original text but that with leading https:// removed

## Related Issue

The new function `shortenText()` can be used instead of `shortenTextDisplay()` in  PR https://github.com/phpList/phplist3/pull/876

## Screenshots (if appropriate):
