### PR TITLE
Avoid php 8 deprecation for a null attribute value

### DIFF
--- a/public_html/lists/admin/inc/userlib.php
+++ b/public_html/lists/admin/inc/userlib.php
@@ -463,7 +463,7 @@ function UserAttributeValue($user = 0, $attribute = 0)
             $res = Sql_Query(sprintf('select value from %s where
         userid = %d and attributeid = %d', $user_att_table, $user, $attribute));
             $row = Sql_Fetch_row($res);
-            $value = $row ? $row[0] : '';
+            $value = $row ? (string) $row[0] : '';
     }
 
     return stripslashes($value);


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->

Using php 8 a deprecation warning is issued when using stripslashes() on a null attribute value

`[Sun Sep 11 21:30:33.465091 2022] [php:notice] [pid 3075] [client 127.0.0.1:44934] PHP Deprecated:  stripslashes(): Passing null to parameter #1 ($string) of type string is deprecated in /home/duncan/www/lists_3.6.8/admin/inc/userlib.php on line 469, referer: http://strontian/lists/admin/?page=send&id=262&tk=834f3409237077f6681686b186501f4e`

The attribute value really is null, so it needs to be converted to a string.

## Related Issue



## Screenshots (if appropriate):
