### PR TITLE
adding batching full stop to specific providers.

### DIFF
--- a/public_html/lists/admin/PHPMailer/class.phpmailer.php
+++ b/public_html/lists/admin/PHPMailer/class.phpmailer.php
@@ -1763,9 +1763,41 @@ class PHPMailer
         $hosts = explode(';', $this->Host);
         $lastexception = null;
 
+   
+        $percentages = array();
+        $count = 0;
+
         foreach ($hosts as $hostentry) {
-            $hostinfo = array();
-            if (!preg_match('/^((ssl|tls):\/\/)*([a-zA-Z0-9\.-]*):?([0-9]*)$/', trim($hostentry), $hostinfo)) {
+            $tempHostParamaters = explode(':', $hostentry);
+            $percentages[$count] = $tempHostParamaters[2];
+            $count += 1;
+        }
+
+        $rand = rand(1,100);
+        $sum = 0;
+        $chosenHost;
+
+        $chosenHostInteger = 0;
+        foreach ($percentages as $v) {
+            $sum += $v;
+            if ( $sum >= $rand ) {
+                break;
+        }
+        $chosenHostInteger += 1;
+        }
+
+        $randomlySelectedHost = array();
+        $randomlySelectedHost[0] = $hosts[$chosenHostInteger];
+
+        foreach ($randomlySelectedHost as $hostentry) {
+			$tempHostEntry = explode(':', $hostentry);
+            $removal = $tempHostEntry[2];
+			
+		$hostentry = str_replace(":".$removal, "",$hostentry);
+			
+			//logEvent('rolling through hosts '.$hostentry);
+                $hostinfo = [];
+              if (!preg_match('/^((ssl|tls):\/\/)*([a-zA-Z0-9\.-]*):?([0-9]*)$/', trim($hostentry), $hostinfo)) {
                 // Not a valid host entry
                 continue;
             }

--- a/public_html/lists/admin/PHPMailer/class.phpmaileroauth.php
+++ b/public_html/lists/admin/PHPMailer/class.phpmaileroauth.php
@@ -114,8 +114,41 @@ class PHPMailerOAuth extends PHPMailer
         $hosts = explode(';', $this->Host);
         $lastexception = null;
 
+      
+        $percentages = array();
+        $count = 0;
+
         foreach ($hosts as $hostentry) {
-            $hostinfo = array();
+            $tempHostParamaters = explode(':', $hostentry);
+            $percentages[$count] = $tempHostParamaters[2];
+            $count += 1;
+        }
+
+        $rand = rand(1,100);
+        $sum = 0;
+        $chosenHost;
+
+        $chosenHostInteger = 0;
+        foreach ($percentages as $v) {
+            $sum += $v;
+            if ( $sum >= $rand ) {
+                break;
+        }
+        $chosenHostInteger += 1;
+        }
+
+        $randomlySelectedHost = array();
+        $randomlySelectedHost[0] = $hosts[$chosenHostInteger];
+
+        foreach ($randomlySelectedHost as $hostentry) {
+			$tempHostEntry = explode(':', $hostentry);
+            $removal = $tempHostEntry[2];
+			
+		$hostentry = str_replace(":".$removal, "",$hostentry);
+			
+			//logEvent('rolling through hosts '.$hostentry);
+                $hostinfo = [];
+            
             if (!preg_match('/^((ssl|tls):\/\/)*([a-zA-Z0-9\.-]*):?([0-9]*)$/', trim($hostentry), $hostinfo)) {
                 // Not a valid host entry
                 continue;

--- a/public_html/lists/admin/PHPMailer6/src/PHPMailer.php
+++ b/public_html/lists/admin/PHPMailer6/src/PHPMailer.php
@@ -2097,8 +2097,40 @@ class PHPMailer
         $hosts = explode(';', $this->Host);
         $lastexception = null;
 
+     
+        $percentages = array();
+        $count = 0;
+
         foreach ($hosts as $hostentry) {
-            $hostinfo = [];
+            $tempHostParamaters = explode(':', $hostentry);
+            $percentages[$count] = $tempHostParamaters[2];
+            $count += 1;
+        }
+
+        $rand = rand(1,100);
+        $sum = 0;
+        $chosenHost;
+
+        $chosenHostInteger = 0;
+        foreach ($percentages as $v) {
+            $sum += $v;
+            if ( $sum >= $rand ) {
+                break;
+        }
+        $chosenHostInteger += 1;
+        }
+
+        $randomlySelectedHost = array();
+        $randomlySelectedHost[0] = $hosts[$chosenHostInteger];
+
+        foreach ($randomlySelectedHost as $hostentry) {
+			$tempHostEntry = explode(':', $hostentry);
+            $removal = $tempHostEntry[2];
+			
+		$hostentry = str_replace(":".$removal, "",$hostentry);
+			
+			//logEvent('rolling through hosts '.$hostentry);
+                $hostinfo = [];
             if (
                 !preg_match(
                     '/^(?:(ssl|tls):\/\/)?(.+?)(?::(\d+))?$/',

--- a/public_html/lists/config/config_extended.php
+++ b/public_html/lists/config/config_extended.php
@@ -406,6 +406,14 @@ define('USE_DOMAIN_THROTTLE', 0);
 define('DOMAIN_BATCH_SIZE', 1);
 define('DOMAIN_BATCH_PERIOD', 120);
 
+//allows us to throttle specific providers, while leaving others wide open.
+//Yahoo,Microsoft
+define('DOMAINS_SPECIFIC_TO_THROTTLE', 'Yahoo,Microsoft');
+
+//allows us to completely turn off providers if they have spam complaints about our email.
+//Microsoft
+define('DOMAINS_FULL_STOP', 'Microsoft');
+
 // if you have very large numbers of users on the same domains, this may result in the need
 // to run processqueue many times, when you use domain throttling. You can also tell phplist
 // to simply delay a bit between messages to increase the number of messages sent per queue run
@@ -595,8 +603,12 @@ Message sending options
 define('PHPMAILERHOST', '');
 
 // in the above you can specify multiple SMTP servers like this:
-// 'server1:port1;server2:port2;server3:port3' eg
-//define('PHPMAILERHOST','smtp1.mydomain.com:25;smtp2.mydomain.com:2500;smtp3.phplist.com:5123');
+// 'server1:port1:priority;server2:port2:priority;server3:port3:priority' eg
+//define('PHPMAILERHOST','smtp1.mydomain.com:25:10;smtp2.mydomain.com:2500:30;smtp3.phplist.com:5123:60');
+
+//priority allows you to set how much mail goes through that specific smtp server.  
+//since the server might just be coming online, providers might not know about it yet and therefore
+//limit its use, so we add a priority to limit how much email goes out of it.
 
 // if you want to use smtp authentication when sending the email uncomment the following
 // two lines and set the username and password to be the correct ones


### PR DESCRIPTION
adding auto throttling to specific providers
added random picks based on priority of smtp server. Prioritizing servers based off priority setting.

<!---Thanks for contributing to phpList!-->

## Description
Added changes allow us to throttle very specific providers as a new sender.  We can limit our sending so that we can ramp up on reputation for their servers.

Added changes allow us to actually use more than 1 SMTP server at a time.  The current implementation only allowed for 1 server even if 10 servers were listed.

We can now prioritized servers based upon address.  Old implementation expected to send fairly across ALL servers.  I needed to allow 1 server to only send 5% of the mail and others to send 10% and the last one to send 30%.  So we can again ramp up reputation of our servers.

## Related Issue



## Screenshots (if appropriate):
