### PR TITLE
Fix vcard cut and paste error

### DIFF
--- a/public_html/lists/admin/locale/en/phplist.po
+++ b/public_html/lists/admin/locale/en/phplist.po
@@ -8282,7 +8282,7 @@ msgstr "URL for forwarding messages"
 #: public_html/lists/admin/defaultconfig.php:358
 #, fuzzy
 msgid "URL for downloading vcf card"
-msgstr "URL for forwarding messages"
+msgstr "URL for downloading vcf card"
 
 #: public_html/lists/admin/defaultconfig.php:365
 msgid ""


### PR DESCRIPTION
The text for forwarding URL appears to have been pasted over the vcard download URL

<!---Thanks for contributing to phpList!-->

## Description
Simple typo correction

## Related Issue
None


## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/11363679/194141992-c685a43e-8407-4490-98d0-255094556969.png)
