### PR TITLE
Avoid php warnings when open_basedir is enabled.

### DIFF
--- a/public_html/lists/admin/pluginlib.php
+++ b/public_html/lists/admin/pluginlib.php
@@ -33,7 +33,7 @@ foreach ($pluginRootDirs as $pluginRootDir) {
                 if (is_file($pluginRootDir.'/'.$file) && preg_match("/\.php$/", $file)) {
                     //          print "ADD $file<br/>";
                     array_push($pluginFiles, $pluginRootDir.'/'.$file);
-                } elseif (is_dir($pluginRootDir.'/'.$file.'/plugins')) {
+                } elseif (is_dir($pluginRootDir.'/'.$file) && is_dir($pluginRootDir.'/'.$file.'/plugins')) {
                     //         print 'SUBROOT'.$pluginRootDir.' '.$file.'<br/>';
                     $subRoot = $pluginRootDir.'/'.$file.'/plugins';
                     $subDir = opendir($subRoot);


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->

The code in pluginlib.php looks for nested "plugins" directories for each file or directory in the plugins directory

`} elseif (is_dir($pluginRootDir.'/'.$file.'/plugins')) {`

When open_basedir is in effect, php issues a number of warnings when $file is a file not a directory.

Not sure whether this code path is now needed. I think that it is there for development when using PLUGIN_ROOTDIRS.
## Related Issue



## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/3147688/198574258-bec05ceb-6500-4735-9e50-07bdfbcf4602.png)
