### PR TITLE
Avoid php 8.2 warning about dynamic properties

### DIFF
--- a/public_html/lists/admin/defaultplugin.php
+++ b/public_html/lists/admin/defaultplugin.php
@@ -48,6 +48,12 @@ class phplistPlugin
 
     public $needI18N = 0;
 
+    // Configuration items for the Settings page
+    public $settings = [];
+
+    // File system path to the plugin file
+    public $origin = '';
+
     /**
      * set to true, if this plugin provides the WYSIWYG editor for the send page
      * the plugin will then need to implement:.
@@ -237,11 +243,9 @@ class phplistPlugin
      */
     public function activate()
     {
-        if (isset($this->settings)) {
-            foreach ($this->settings as $item => $itemDetails) {
-                $GLOBALS['default_config'][$item] = $itemDetails;
-                $GLOBALS['default_config'][$item]['hidden'] = false;
-            }
+        foreach ($this->settings as $item => $itemDetails) {
+            $GLOBALS['default_config'][$item] = $itemDetails;
+            $GLOBALS['default_config'][$item]['hidden'] = false;
         }
     }
 
@@ -1091,7 +1095,7 @@ class phplistPlugin
       * @param string $emailaddress
       * @return bool true if email address should is considered blacklisted
      */
-    public function isBlackListedEmail($email = '') 
+    public function isBlackListedEmail($email = '')
     {
         return false;
     }

--- a/public_html/lists/admin/onyxrss/onyx-rss.php
+++ b/public_html/lists/admin/onyxrss/onyx-rss.php
@@ -42,6 +42,8 @@ class ONYX_RSS
     public $data;
     public $type;
     public $lasterror;
+
+    private $context;
    /* For when PHP v.5 is released
     * http://www.phpvolcano.com/eide/php5.php?page=variables
     * private $parser;


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
In php 8.2 using an undeclared class variable is deprecated. 

`PHP Deprecated:  Creation of dynamic property CKEditorPlugin::$origin is deprecated in /home/duncan/www/lists_3.6.10/admin/pluginlib.php on line 81`


## Related Issue



## Screenshots (if appropriate):
