### PR TITLE
Avoid possible divide by zero when calculating message send rate

### DIFF
--- a/public_html/lists/admin/actions/processqueue.php
+++ b/public_html/lists/admin/actions/processqueue.php
@@ -1323,7 +1323,7 @@ while ($message = Sql_fetch_array($messages)) {
          */
 
         $totaltime = $GLOBALS['processqueue_timer']->elapsed(1);
-        if ($counters['sent'] > 0) {
+        if ($counters['sent'] > 0 && $totaltime > 0) {
             $msgperhour = (3600 / $totaltime) * $counters['sent'];
             $secpermsg = $totaltime / $counters['sent'];
             $timeleft = ($counters['total_users_for_message '.$messageid] - $counters['sent']) * $secpermsg;


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
There have been some reports of divide by zero exceptions when using php 8.

https://discuss.phplist.org/t/v-3-6-10-with-php-8-0-x-problems/8526/14

This change fixes one possible cause. I think that if the timer elapsed() call is within the same microsecond as the start() then the elapsed time will be returned as 0.
## Related Issue



## Screenshots (if appropriate):
