### PR TITLE
Improve wrapping of email addresses

### DIFF
--- a/public_html/lists/admin/lib.php
+++ b/public_html/lists/admin/lib.php
@@ -1971,15 +1971,36 @@ if (!function_exists('mb_strlen')) {
  * mostly used for columns in listings to retrict the width, particularly on mobile devices
  * it will show the full text as the title tip but restrict the size of the output
  *
- * will also place a space after / and @ to facilitate wrapping in the browser
- *
  */
 function shortenTextDisplay($text, $max = 30)
 {
+    $display = shortenText($text, $max);
+
+    return sprintf('<span title="%s">%s</span>', htmlspecialchars($text), $display);
+}
+/*
+ * shortenEmailDisplay
+ *
+ * Similar to shortenTextDisplay() but adds a wbr element after @ to allow wrapping
+ */
+function shortenEmailDisplay($text, $max = 30)
+{
+    $display = shortenText($text, $max);
+    $display = str_replace('@', '@<wbr>', $display);
+
+    return sprintf('<span title="%s">%s</span>', htmlspecialchars($text), $display);
+}
+
+/*
+ * shortenUrlDisplay
+ *
+ * Similar to shortenTextDisplay() but adds a wbr element after each / to allow wrapping
+ */
+function shortenUrlDisplay($text, $max = 30)
+{
     $display = preg_replace('!^https?://!i', '', $text);
     $display = shortenText($display, $max);
-    $display = str_replace('/', '/&#x200b;', $display);
-    $display = str_replace('@', '@&#x200b;', $display);
+    $display = str_replace('/', '/<wbr>', $display);
 
     return sprintf('<span title="%s">%s</span>', htmlspecialchars($text), $display);
 }

--- a/public_html/lists/admin/mclicks.php
+++ b/public_html/lists/admin/mclicks.php
@@ -140,7 +140,7 @@ while ($row = Sql_Fetch_Array($req)) {
     );
 
     if (!$download) {
-        $element = shortenTextDisplay($row['url']);
+        $element = shortenUrlDisplay($row['url']);
     } else {
         $element = $row['url'];
     }

--- a/public_html/lists/admin/members.php
+++ b/public_html/lists/admin/members.php
@@ -316,7 +316,7 @@ if (!empty($id) || $listAll) {
     $ls = new WebblerListing($GLOBALS['I18N']->get('Members'));
     $ls->usePanel($paging);
     while ($user = Sql_fetch_array($result)) {
-        $element = shortenTextDisplay($user['email']);
+        $element = shortenEmailDisplay($user['email']);
         $ls->addElement($element, PageUrl2('user&amp;id='.$user['id']));
         $ls->setClass($element, 'row1');
         $ls_delete = '';
@@ -364,14 +364,14 @@ if ($listAll) {
 
 ?>
 <div class="panel">
-	<h3><?php echo s('Actions') ?></h3>
-	<div class=" content well">
-		<div class="row">
-    		<div class="col-sm-6 membersProcess">
-            	<h4 style="margin-bottom:0"><?php echo $GLOBALS['I18N']->get('What to do with "Tagged" users') ?>:</h4>
+    <h3><?php echo s('Actions') ?></h3>
+    <div class=" content well">
+        <div class="row">
+            <div class="col-sm-6 membersProcess">
+                <h4 style="margin-bottom:0"><?php echo $GLOBALS['I18N']->get('What to do with "Tagged" users') ?>:</h4>
                 <h6><?php echo $GLOBALS['I18N']->get('This will only process the users in this page that have the "Tag" checkbox checked') ?></h6>
                 <div class="row col-sm-12"  style="margin:10px 0 5px">
-                	<p><input type="radio" name="tagaction" value="delete"/> <?php echo $GLOBALS['I18N']->get('Delete') ?>
+                    <p><input type="radio" name="tagaction" value="delete"/> <?php echo $GLOBALS['I18N']->get('Delete') ?>
                     (<?php echo $GLOBALS['I18N']->get('from this list') ?>)</p>
                 </div>
                 <div class="clearfix" style="margin-bottom:10px;margin-top:-10px"></div>
@@ -385,26 +385,26 @@ if ($listAll) {
             }
             if ($html) {
                 ?>
-					<div class="row col-sm-12" style="margin:0px 0 10px">
-						<div class="fleft">
-							<input type="radio" name="tagaction" value="move"/> <?php echo $GLOBALS['I18N']->get('Move').'&nbsp;'.$GLOBALS['I18N']->get('to').': &nbsp;&nbsp;' ?>
-    					</div>
-						<div class="fleft">
-	                     	<select name="movedestination">
+                    <div class="row col-sm-12" style="margin:0px 0 10px">
+                        <div class="fleft">
+                            <input type="radio" name="tagaction" value="move"/> <?php echo $GLOBALS['I18N']->get('Move').'&nbsp;'.$GLOBALS['I18N']->get('to').': &nbsp;&nbsp;' ?>
+                        </div>
+                        <div class="fleft">
+                            <select name="movedestination">
                                 <?php echo $html ?>
-	                         </select>
-	                    </div>
+                             </select>
+                        </div>
                      </div>
-                	<div class="row col-sm-12" style="margin:0px 0 10px">
-						<div class="fleft">
-	                		<input type="radio" name="tagaction" value="copy"/> <?php echo $GLOBALS['I18N']->get('Copy').'&nbsp;'.$GLOBALS['I18N']->get('to').':&nbsp;&nbsp;' ?>
-    					</div>
-						<div class="fleft">
-	                    	<select name="copydestination">
+                    <div class="row col-sm-12" style="margin:0px 0 10px">
+                        <div class="fleft">
+                            <input type="radio" name="tagaction" value="copy"/> <?php echo $GLOBALS['I18N']->get('Copy').'&nbsp;'.$GLOBALS['I18N']->get('to').':&nbsp;&nbsp;' ?>
+                        </div>
+                        <div class="fleft">
+                            <select name="copydestination">
                                 <?php echo $html ?>
-	                        </select>
-	                    </div>
-					</div>
+                            </select>
+                        </div>
+                    </div>
                 <div class="row col-sm-12" style="margin:0px 0 10px">
                     <input type="radio" name="tagaction" value="nothing" checked="checked"/><?php echo $GLOBALS['I18N']->get('Nothing') ?>
                 </div>
@@ -413,7 +413,7 @@ if ($listAll) {
             </div>
             <br  class="visible-xs" />
             <div class="col-sm-6 membersProcess">
-            	<h4 style="margin-bottom:0"><?php echo s('What to do with all subscribers') ?></h4>
+                <h4 style="margin-bottom:0"><?php echo s('What to do with all subscribers') ?></h4>
                 <h6><?php echo s('This will process all subscribers on this list, confirmed and unconfirmed') ?></h6>
                 <div class="row col-sm-12" style="margin:10px 0 5px">
                     <p><input type="radio" name="tagaction_all" value="delete"/> <?php echo $GLOBALS['I18N']->get('Delete') ?>
@@ -422,29 +422,29 @@ if ($listAll) {
                 <div class="clearfix" style="margin-bottom:10px;margin-top:-10px"></div>
            <?php if ($html) {
                 ?>
-                	<div class="row col-sm-12"  style="margin:0px 0 10px">
-						<div class="fleft">
-	                		<input type="radio" name="tagaction_all" value="move"/> <?php echo $GLOBALS['I18N']->get('Move').'&nbsp;'.$GLOBALS['I18N']->get('to').':&nbsp;&nbsp' ?>
-						</div>
-						<div class="fleft">
-	                    	<select name="movedestination_all">
+                    <div class="row col-sm-12"  style="margin:0px 0 10px">
+                        <div class="fleft">
+                            <input type="radio" name="tagaction_all" value="move"/> <?php echo $GLOBALS['I18N']->get('Move').'&nbsp;'.$GLOBALS['I18N']->get('to').':&nbsp;&nbsp' ?>
+                        </div>
+                        <div class="fleft">
+                            <select name="movedestination_all">
                                 <?php echo $html ?>
-	                        </select>
-						</div>
+                            </select>
+                        </div>
                     </div>
-                	<div class="row col-sm-12" style="margin:0px 0 10px">
-                		<div class="fleft">
-	                		<input type="radio" name="tagaction_all" value="copy"/> <?php echo $GLOBALS['I18N']->get('Copy').'&nbsp;'.$GLOBALS['I18N']->get('to').':&nbsp;&nbsp' ?>
-						</div>    
-                		<div class="fleft">
-	                    	<select name="copydestination_all">
+                    <div class="row col-sm-12" style="margin:0px 0 10px">
+                        <div class="fleft">
+                            <input type="radio" name="tagaction_all" value="copy"/> <?php echo $GLOBALS['I18N']->get('Copy').'&nbsp;'.$GLOBALS['I18N']->get('to').':&nbsp;&nbsp' ?>
+                        </div>
+                        <div class="fleft">
+                            <select name="copydestination_all">
                                 <?php echo $html ?>
-	                        </select>
-	                    </div>
+                            </select>
+                        </div>
                     </div>
                 <div class="row col-sm-12"  style="margin:0px 0">
-	                <input type="radio" name="tagaction_all" value="nothing" checked="checked"/> <?php echo $GLOBALS['I18N']->get('Nothing') ?>
-	            </div>
+                    <input type="radio" name="tagaction_all" value="nothing" checked="checked"/> <?php echo $GLOBALS['I18N']->get('Nothing') ?>
+                </div>
                 <?php
 
             } ?>

--- a/public_html/lists/admin/mviews.php
+++ b/public_html/lists/admin/mviews.php
@@ -23,11 +23,11 @@ switch ($access) {
         if ($id) {
             $allow = Sql_Fetch_Row_query(
                 sprintf(
-                    'select 
-                        owner 
-                    from 
-                        %s 
-                    where 
+                    'select
+                        owner
+                    from
+                        %s
+                    where
                         id = %d %s'
                 , $GLOBALS['tables']['message']
                 , $id
@@ -78,11 +78,11 @@ if (empty($start)) {
 
 //print '<h3>'.s('View Details for a Message').'</h3>';
 $messagedata = Sql_Fetch_Array_query(
-    "SELECT 
-        * 
-    FROM 
-        {$tables['message']} 
-    WHERE 
+    "SELECT
+        *
+    FROM
+        {$tables['message']}
+    WHERE
         id = $id $subselect"
 );
 echo '<table class="mviewsDetails table table-bordered"><tr><td>' .
@@ -102,16 +102,16 @@ $ls->setElementHeading(s('Subscriber'));
 
 $req = Sql_Query(
     sprintf(
-        'select 
+        'select
             um.userid
-        from 
+        from
             %s um
-            , %s msg 
-        where 
-            um.messageid = %d 
-            and um.messageid = msg.id 
+            , %s msg
+        where
+            um.messageid = %d
+            and um.messageid = msg.id
             and um.viewed is not null %s
-        group by 
+        group by
             userid'
     , $GLOBALS['tables']['usermessage']
     , $GLOBALS['tables']['message']
@@ -150,7 +150,7 @@ if ($total) {
 
 $req = Sql_Query(
     sprintf(
-        'select 
+        'select
             userid
             , email
             , um.entered as sent
@@ -159,21 +159,21 @@ $req = Sql_Query(
             , count(um.viewed) as uniqueviews
             , msg.viewed as totalcampaignviews
             , abs(unix_timestamp(um.entered) - unix_timestamp(um.viewed)) as responsetime
-        from 
+        from
             %s um
             , %s user
-            , %s msg 
-        where 
-            um.messageid = %d 
-            and um.messageid = msg.id 
-            and um.userid = user.id 
-            and um.status = "sent" 
-            and um.viewed is not null 
+            , %s msg
+        where
+            um.messageid = %d
+            and um.messageid = msg.id
+            and um.userid = user.id
+            and um.status = "sent"
+            and um.viewed is not null
             %s
-        group by 
+        group by
             userid
         order by
-            lastview desc 
+            lastview desc
         %s'
         , $GLOBALS['tables']['usermessage']
         , $GLOBALS['tables']['user']
@@ -189,14 +189,14 @@ while ($row = Sql_Fetch_Array($req)) {
 
     $allViewsReq = Sql_Query(
         sprintf(
-            'select 
-                * 
-            from 
-                %s 
-            where 
-                userid = %d 
-                and messageid = %d 
-            order by 
+            'select
+                *
+            from
+                %s
+            where
+                userid = %d
+                and messageid = %d
+            order by
                 viewed'
         , $GLOBALS['tables']['user_message_view']
         , $row['userid']
@@ -209,7 +209,7 @@ while ($row = Sql_Fetch_Array($req)) {
         $element = $row['email'];
         $separator = ',';
     } else {
-        $element = shortenTextDisplay($row['email'], 35);
+        $element = shortenEmailDisplay($row['email'], 35);
         $separator = '<br/>';
     }
     $ls->addElement($element, PageUrl2('user&amp;id='.$row['userid']));

--- a/public_html/lists/admin/uclicks.php
+++ b/public_html/lists/admin/uclicks.php
@@ -57,7 +57,7 @@ if (!$id) {
     while ($row = Sql_Fetch_Array($req)) {
         $some = 1;
         if (!$download) {
-            $element = shortenTextDisplay($row['url'], 30);
+            $element = shortenUrlDisplay($row['url'], 30);
         } else {
             $element = $row['url'];
         }

--- a/public_html/lists/admin/userclicks.php
+++ b/public_html/lists/admin/userclicks.php
@@ -87,7 +87,7 @@ if ($fwdid && $msgid) {
     echo '<div class="fright">'.PageLinkButton('userclicks&fwdid='.$fwdid.'&msgid='.$msgid.'&dl=1',
             s('Download subscribers')).'</div>';
     $query = sprintf('select htmlclicked, textclicked, user.email,user.id as userid,firstclick,latestclick,clicked
-    from %s as uml_click, %s as user where uml_click.userid = user.id 
+    from %s as uml_click, %s as user where uml_click.userid = user.id
     and uml_click.forwardid = %d and uml_click.messageid = %d
     and uml_click.clicked', $GLOBALS['tables']['linktrack_uml_click'], $GLOBALS['tables']['user'], $fwdid, $msgid);
 } elseif ($userid && $msgid) {
@@ -105,7 +105,7 @@ if ($fwdid && $msgid) {
   <tr><td>' .$GLOBALS['I18N']->get('Sent').'<td><td>'.$messagedata['sent'].'</td></tr>
   </table>';
     $query = sprintf('select htmlclicked, textclicked,user.email,user.id as userid,firstclick,latestclick,
-    clicked,messageid,forwardid,url from %s as uml_click, %s as user, %s as forward where uml_click.userid = user.id 
+    clicked,messageid,forwardid,url from %s as uml_click, %s as user, %s as forward where uml_click.userid = user.id
     and uml_click.userid = %d and uml_click.messageid = %d and forward.id = uml_click.forwardid',
         $GLOBALS['tables']['linktrack_uml_click'], $GLOBALS['tables']['user'], $GLOBALS['tables']['linktrack_forward'],
         $userid, $msgid);
@@ -151,7 +151,7 @@ if ($fwdid && $msgid) {
         MAX(latestclick) AS latestclick,
         SUM(clicked) AS clicked
         FROM %s AS uml_click
-        JOIN %s AS user ON uml_click.userid = user.id 
+        JOIN %s AS user ON uml_click.userid = user.id
         WHERE uml_click.messageid = %d
         GROUP BY uml_click.userid
         ',
@@ -177,18 +177,18 @@ if ($fwdid && $msgid) {
                 messageid SEPARATOR \' \') AS messageid,
                 forwardid,
                 url
-        FROM 
+        FROM
             '.$GLOBALS['tables']['linktrack_uml_click'].' AS uml_click
         JOIN
             '.$GLOBALS['tables']['user'].' AS user ON uml_click.userid = user.id
-        JOIN 
+        JOIN
             '.$GLOBALS['tables']['linktrack_forward'].' AS forward ON forward.id = uml_click.forwardid
-        WHERE 
+        WHERE
             uml_click.userid = '.sprintf('%d', $userid).'
-        GROUP BY 
+        GROUP BY
             forwardid
-        ORDER BY 
-            clicked DESC, 
+        ORDER BY
+            clicked DESC,
             url
         ';
 }
@@ -214,13 +214,13 @@ while ($row = Sql_Fetch_Array($req)) {
         $downloadContent .= $row['email'].PHP_EOL;
     } else {
         if (!$userid) {
-            $element = shortenTextDisplay($row['email']);
+            $element = shortenEmailDisplay($row['email']);
             $ls->addElement($element, PageUrl2('user&amp;id='.$row['userid']));
             $ls->setClass($element, 'row1');
         } else {
             //    $link = substr($row['url'],0,50);
             //    $element = PageLink2($link,$link,PageUrl2('uclicks&amp;id='.$row['forwardid']),"",true,$row['url']);
-            $element = shortenTextDisplay($row['url']);
+            $element = shortenUrlDisplay($row['url']);
             $ls->addElement($element, PageUrl2('uclicks&amp;id='.$row['forwardid']));
             $ls->setClass($element, 'row1');
             $messageLinks = preg_replace_callback(


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
This change (by me) from 2013 to use a zero-width space to allow wrapping of an email address seems to have caused a bit of confusion and wasted time https://github.com/phpList/phplist3/commit/996c3ce78ef4dda61916224886cfac48583e5c51  

People have been copying an email address from a statistics page, then pasting that into the search field on the Subscribers page. Because of the zero-width space the subscriber is not found.

A better approach is to use the `<wbr>` element immediately after a character where we want to allow wrapping. Copying/pasting an email address includes only the characters of the email address, not the `<wbr>` element.

This pull request

- changes the shortenTextDisplay() function to handle only text fields
- adds a similar shortenEmailDisplay() function which uses the `<wbr>` element
- adds a similar shortenUrlDisplay() function which uses the `<wbr>` element
- replaces the uses of shortenTextDisplay() for email or URL fields by the new functions


## Related Issue



## Screenshots (if appropriate):
