### PR TITLE
Make the results of the timer class use period as the decimal point

### DIFF
--- a/public_html/lists/admin/connect.php
+++ b/public_html/lists/admin/connect.php
@@ -2416,9 +2416,9 @@ class timer
         $end = $now['sec'] * 1000000 + $now['usec'];
         $elapsed = $end - $this->start;
         if ($seconds) {
-            return sprintf('%0.10f', $elapsed / 1000000);
+            return sprintf('%0.10F', $elapsed / 1000000);
         } else {
-            return sprintf('%0.10f', $elapsed);
+            return sprintf('%0.10F', $elapsed);
         }
     }
 
@@ -2434,9 +2434,9 @@ class timer
         $this->previous = $end;
 
         if ($seconds) {
-            return sprintf('%0.10f', $elapsed / 1000000);
+            return sprintf('%0.10F', $elapsed / 1000000);
         } else {
-            return sprintf('%0.10f', $elapsed);
+            return sprintf('%0.10F', $elapsed);
         }
     }
 }


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
There have been reports in the user forum about phplist failing after sending only one email https://discuss.phplist.org/t/v-3-6-10-with-php-8-0-x-problems/8526/16 .
One report  https://discuss.phplist.org/t/campaign-stops-after-1-email-if-language-is-not-englisch/8627  narrowed it down to being related to the language, German in his case. Selecting English made the problem stop happening.

Looking more closely at the output provided showed comma being used as the decimal separator

```
Found them: 4 to process
Sending 2 to ab.c@xxx.yy
It took 0,0898380000 seconds to send
```
The timer class is returning the result of sprintf using the %f specifier, which is locale specific, causing a comma to be used for the decimal separator depending on the locale. The specifier %F needs to be used to ensure that a period is used as the decimal separator.

In php 8 the returned values cause a fatal error when used in calculations because they are not numeric. I think in php 7 it just caused a warning and carried on.

## Related Issue



## Screenshots (if appropriate):
