### PR TITLE
Allow gap between async requests

### DIFF
--- a/public_html/lists/admin/init.php
+++ b/public_html/lists/admin/init.php
@@ -786,9 +786,13 @@ if (!defined('USE_PHPMAILER6')) {
 }
 if (!defined('HTTP_PROXY_HOST')) {
     define('HTTP_PROXY_HOST', false);
-} 
+}
 if (!defined('HTTP_PROXY_PORT')) {
     define('HTTP_PROXY_PORT', false);
+}
+// interval in milliseconds between asynchronous requests
+if (!defined('ASYNC_REQUEST_INTERVAL')) {
+    define('ASYNC_REQUEST_INTERVAL', 0);
 }
 
 if (!isset($GLOBALS['export_mimetype'])) {

--- a/public_html/lists/admin/js/phplistapp.js
+++ b/public_html/lists/admin/js/phplistapp.js
@@ -77,8 +77,12 @@ function loadDivContent(index) {
         div = asyncLoadDiv[index];
         url = asyncLoadUrl[index];
         $("#"+div).html(busyImage + '<span class="loadingprogressbanner"></span>');
-        $("#"+div).load(url, function() {
-            loadDivContent(index + 1);
+        $("#"+div).load(url, function(response, status, xhr) {
+            if (status == "error") {
+                $("#"+div).html('');
+            } else {
+                setTimeout(() => loadDivContent(index + 1), asyncRequestInterval);
+            }
         });
     }
 }

--- a/public_html/lists/admin/lib.php
+++ b/public_html/lists/admin/lib.php
@@ -2385,6 +2385,7 @@ function asyncLoadContentDiv($url,$divname)
         if (typeof asyncLoadDiv == "undefined") {
             var asyncLoadDiv = new Array();
             var asyncLoadUrl = new Array();
+            var asyncRequestInterval = ' . ASYNC_REQUEST_INTERVAL . ';
         }
         asyncLoadDiv[asyncLoadDiv.length] = "'.$divname.'";
         asyncLoadUrl[asyncLoadUrl.length] = "'.$url.'";


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
After the change in #909 to speed up the list page a problem was reported regarding the page returning http 403 when navigating to the next page https://discuss.phplist.org/t/php-8-0-403-access-issues/8781

Investigation showed that the last 3 or 4 of the 10 asynchronous requests were failing in the same way. Presumably the number and rate of requests was being treated as some kind of attack https://discuss.phplist.org/t/php-8-0-403-access-issues/8781/16

This change adds a configurable delay between sending each asynchronous request, with a default of 0.
Also, if a request fails then the sequence is stopped rather than continuing with the likelihood of the remaining requests also failing.

## Related Issue

https://github.com/phpList/phplist3/pull/909

## Screenshots (if appropriate):
