### PR TITLE
Use the content of the body element when including message into a template

### DIFF
--- a/public_html/lists/admin/sendemaillib.php
+++ b/public_html/lists/admin/sendemaillib.php
@@ -309,6 +309,10 @@ function sendEmail($messageid, $email, $hash, $htmlpref = 0, $rssitems = array()
 
     if ($cached[$messageid]['template']) {
         // template used
+        // use only the content of the body element if it is present
+        if (preg_match('|<body.*?>(.+)</body>|is', $htmlcontent, $matches)) {
+            $htmlcontent = $matches[1];
+        }
         $htmlmessage = str_replace('[CONTENT]', $htmlcontent, $cached[$messageid]['template']);
     } else {
         // no template used


### PR DESCRIPTION


<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
This change is to try to fix a problem with the CKEditor plugin when people want to edit messages as HTML full pages.

The default for CKEditor is to allow only limited html. If you want to edit a full page including head, body elements etc, then a configuration option needs to be set `fullPage: true`. Currently the plugin allows that to be set for templates or for messages but not both, on the basis that structural html (head, body elements etc) would appear twice when a message is included into a template.

That option can be set for editing a template as that will always be an HTML page, but can create a difficulty when editing a message. It is fine if the admin always uses templates as the option for messages can be turned-off, and is fine if the admin never uses templates in which case the option for messages can be turned-on. But if the admin wants sometimes to use a template with a message, and other times wants to create a full page HTML message without a template, then the option needs to be changed first, which seems to be unnecessarily complex and non-intuitive.

To try to avoid this muddle with the option, it now seems simpler to just allow an HTML full page be created by the editor, even when it is to be embedded into a template, but remove the surrounding body element in that case. When the message is to be sent without using a template then there is no change.

With this change, I can then modify the plugin to remove the restriction on full page being allowed for only for editing templates or only for editing messages.

## Related Issue



## Screenshots (if appropriate):
