### PR TITLE
Changed timer functions in connect.php so that they return numbers to avoid errors when sending rate is computed

### DIFF
--- a/public_html/lists/admin/connect.php
+++ b/public_html/lists/admin/connect.php
@@ -2416,9 +2416,9 @@ class timer
         $end = $now['sec'] * 1000000 + $now['usec'];
         $elapsed = $end - $this->start;
         if ($seconds) {
-            return sprintf('%0.10f', $elapsed / 1000000);
+            return $elapsed / 1000000;
         } else {
-            return sprintf('%0.10f', $elapsed);
+            return $elapsed;
         }
     }
 
@@ -2434,9 +2434,9 @@ class timer
         $this->previous = $end;
 
         if ($seconds) {
-            return sprintf('%0.10f', $elapsed / 1000000);
+            $elapsed / 1000000;
         } else {
-            return sprintf('%0.10f', $elapsed);
+            $elapsed;
         }
     }
 }


### PR DESCRIPTION
Changed `elapsed()` and `interval()` in connect.php so that they return numbers instead of strings
---
I'm managing a phpList installation and noticed that the sending rate had slowed down extremely in recent months (over 12 hours for ~800 messages). I discovered that this was related to switching the server from php 7.4 to php 8.0.

Processing the queue via SSH with error reporting turned on revealed that lines [262](https://github.com/phpList/phplist3/blob/a63845511f982af7fcc76fafe0422e66c70912f2/public_html/lists/admin/actions/processqueue.php#L262) and [1224](https://github.com/phpList/phplist3/blob/a63845511f982af7fcc76fafe0422e66c70912f2/public_html/lists/admin/actions/processqueue.php#L1224) of [admin/processqueue](https://github.com/phpList/phplist3/blob/main/public_html/lists/admin/actions/processqueue.php#L1224) throw errors (division by zero / non-numeric value). This is due to the fact that in the German locale, something like "sprintf('%0.10f', $elapsed / 1000000)" returns a string with a comma.


To resolve the issue, I have removed the sprintf() wrappers from the elapsed() and interval() functions in the timer class, so that they return numbers instead of strings.