### PR TITLE
Update connect.php

### DIFF
--- a/public_html/lists/admin/connect.php
+++ b/public_html/lists/admin/connect.php
@@ -2434,9 +2434,9 @@ class timer
         $this->previous = $end;
 
         if ($seconds) {
-            return sprintf('%0.10f', $elapsed / 1000000);
+            return sprintf('%0.10F', $elapsed / 1000000);
         } else {
-            return sprintf('%0.10f', $elapsed);
+            return sprintf('%0.10F', $elapsed);
         }
     }
 }


### PR DESCRIPTION
the string from elapsed() time method is locale aware;  when used in a language other than English ( as Italian ), php does not recognize it as a float value  ( division by zero in admin/actions/processqueue.php )

<!---Thanks for contributing to phpList!-->

## Description
in some case, as the italian language, the method elapsed() of the class timer don't return a string representing a valid float number
I have modified the sprint format ( form f to F ) i the elapsed() method to return a non-locale number rappresentation

## Related Issue
multiple division by zero in admin/actions/processqueue.php
line 1224 and line 262

## Screenshots (if appropriate):
