### PR TITLE
protect the invocation of the function output()

### DIFF
--- a/public_html/lists/admin/lib.php
+++ b/public_html/lists/admin/lib.php
@@ -959,7 +959,9 @@ function getPageLock($force = 0)
                 cl_output($GLOBALS['I18N']->get('Running commandline, quitting. We\'ll find out what to do in the next run.'));
                 exit;
             }
-            output($GLOBALS['I18N']->get('Sleeping for 20 seconds, aborting will quit'), 0);
+            if (function_exists('output')) {
+                output($GLOBALS['I18N']->get('Sleeping for 20 seconds, aborting will quit'), 0);
+            }
             flush();
             $abort = ignore_user_abort(0);
             sleep(20);
@@ -967,9 +969,9 @@ function getPageLock($force = 0)
         ++$waited;
         if ($waited > 10) {
             // we have waited 10 cycles, abort and quit script
-            output($GLOBALS['I18N']->get('We have been waiting too long, I guess the other process is still going ok'),
-                0);
-
+            if (function_exists('output')) {
+                output($GLOBALS['I18N']->get('We have been waiting too long, I guess the other process is still going ok'), 0);
+            }
             return false;
         }
         $running_req = Sql_query('select now() - modified,id from '.$tables['sendprocess']." where page = \"$thispage\" and alive order by started desc");


### PR DESCRIPTION
during bounce processing the function output() can be called without be defined
this is my call stack ( 3.6.13-RC1 )

( ! ) Error: Call to undefined function output() in /var/www/html/bollettino/lists/admin/lib.php on line 962
Call Stack
#	Time	Memory	Function	Location
1	0.0001	394128	{main}( )	.../index.php:0
2	0.0158	949696	include( '/var/www/html/bollettino/lists/admin/processbounces.php )	.../index.php:759
3	0.0158	933424	getPageLock( $force = ??? )	.../processbounces.php:488

<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
Calling the function only if it was already declared
## Related Issue



## Screenshots (if appropriate):
