### PR TITLE
Remove obsolete code from languages.php

### DIFF
--- a/public_html/lists/admin/languages.php
+++ b/public_html/lists/admin/languages.php
@@ -207,19 +207,6 @@ class phplist_I18N
         //# as we're including things, let's make sure it's clean
         $page = preg_replace('/\W/', '', $page);
 
-        if (!empty($_GET['pi'])) {
-            $plugin_languagedir = $this->getPluginBasedir();
-            if (is_dir($plugin_languagedir)) {
-                $this->basedir = $plugin_languagedir;
-                if (isset($GLOBALS['plugins'][$_GET['pi']])) {
-                    $plugin = $GLOBALS['plugins'][$_GET['pi']];
-                    if ($plugin->enabled && $plugin->needI18N && $plugin->i18nLanguageDir()) {
-                        $this->basedir = $plugin->i18nLanguageDir();
-                    }
-                }
-            }
-        }
-
         $lan = array();
 
         if (is_file($this->basedir.$this->language.'/'.$page.'.php')) {

--- a/public_html/lists/admin/languages.php
+++ b/public_html/lists/admin/languages.php
@@ -196,41 +196,6 @@ class phplist_I18N
         } else {
             $_SESSION['hasI18Ntable'] = false;
         }
-
-        if (isset($_GET['origpage']) && !empty($_GET['ajaxed'])) { //# used in ajaxed requests
-            $page = basename($_GET['origpage']);
-        } elseif (isset($_GET['page'])) {
-            $page = basename($_GET['page']);
-        } else {
-            $page = 'home';
-        }
-        //# as we're including things, let's make sure it's clean
-        $page = preg_replace('/\W/', '', $page);
-
-        $lan = array();
-
-        if (is_file($this->basedir.$this->language.'/'.$page.'.php')) {
-            @include $this->basedir.$this->language.'/'.$page.'.php';
-        } elseif (!isset($GLOBALS['developer_email'])) {
-            @include $this->basedir.$this->defaultlanguage.'/'.$page.'.php';
-        }
-        $this->lan = $lan;
-        $lan = array();
-
-        if (is_file($this->basedir.$this->language.'/common.php')) {
-            @include $this->basedir.$this->language.'/common.php';
-        } elseif (!isset($GLOBALS['developer_email'])) {
-            @include $this->basedir.$this->defaultlanguage.'/common.php';
-        }
-        $this->lan += $lan;
-        $lan = array();
-
-        if (is_file($this->basedir.$this->language.'/frontend.php')) {
-            @include $this->basedir.$this->language.'/frontend.php';
-        } elseif (!isset($GLOBALS['developer_email'])) {
-            @include $this->basedir.$this->defaultlanguage.'/frontend.php';
-        }
-        $this->lan += $lan;
     }
 
     public function gettext($text)
@@ -560,24 +525,6 @@ $lan = array(
             if (!empty($gettext)) {
                 return $this->formatText($gettext);
             }
-        }
-
-        $lan = $this->lan;
-
-        if (trim($text) == '') {
-            return '';
-        }
-        if (strip_tags($text) == '') {
-            return $text;
-        }
-        if (isset($lan[$text])) {
-            return $this->formatText($lan[$text]);
-        }
-        if (isset($lan[strtolower($text)])) {
-            return $this->formatText($lan[strtolower($text)]);
-        }
-        if (isset($lan[strtoupper($text)])) {
-            return $this->formatText($lan[strtoupper($text)]);
         }
 
         return '';

--- a/public_html/lists/admin/languages.php
+++ b/public_html/lists/admin/languages.php
@@ -458,21 +458,6 @@ $lan = array(
         file_put_contents($file, $filecontents);
     }
 
-    public function getPluginBasedir()
-    {
-        $pl = $_GET['pi'];
-        $pl = preg_replace('/\W/', '', $pl);
-        $pluginroot = '';
-        if (isset($GLOBALS['plugins'][$pl]) && is_object($GLOBALS['plugins'][$pl])) {
-            $pluginroot = $GLOBALS['plugins'][$pl]->coderoot;
-        }
-        if (is_dir($pluginroot.'/lan/')) {
-            return $pluginroot.'/lan/';
-        } else {
-            return $pluginroot.'/';
-        }
-    }
-
     public function initFSTranslations($language = '')
     {
         if (empty($language)) {
@@ -497,7 +482,7 @@ $lan = array(
         saveConfig('lastlanguageupdate-'.$language, $time, 0);
     }
 
-    public function getTranslation($text, $page, $basedir)
+    public function getTranslation($text, $page)
     {
 
         //# try DB, as it will be the latest
@@ -549,18 +534,7 @@ $lan = array(
             $page = 'home';
         }
         $page = preg_replace('/\W/', '', $page);
-
-        if (!empty($_GET['pi'])) {
-            $plugin_languagedir = $this->getPluginBasedir();
-            if (is_dir($plugin_languagedir)) {
-                $translation = $this->getTranslation($text, $page, $plugin_languagedir);
-            }
-        }
-
-        //# if a plugin did not return the translation, find it in core
-        if (empty($translation)) {
-            $translation = $this->getTranslation($text, $page, $this->basedir);
-        }
+        $translation = $this->getTranslation($text, $page);
 
         //   print $this->language.' '.$text.' '.$translation. '<br/>';
 

--- a/public_html/lists/admin/languages.php
+++ b/public_html/lists/admin/languages.php
@@ -482,7 +482,7 @@ $lan = array(
         saveConfig('lastlanguageupdate-'.$language, $time, 0);
     }
 
-    public function getTranslation($text, $page)
+    public function getTranslation($text)
     {
 
         //# try DB, as it will be the latest
@@ -523,25 +523,12 @@ $lan = array(
         if (strip_tags($text) == '') {
             return $text;
         }
-        $translation = '';
-
-        $this->basedir = dirname(__FILE__).'/lan/';
-        if (isset($_GET['origpage']) && !empty($_GET['ajaxed'])) { //# used in ajaxed requests
-            $page = basename($_GET['origpage']);
-        } elseif (isset($_GET['page'])) {
-            $page = basename($_GET['page']);
-        } else {
-            $page = 'home';
-        }
-        $page = preg_replace('/\W/', '', $page);
-        $translation = $this->getTranslation($text, $page);
-
-        //   print $this->language.' '.$text.' '.$translation. '<br/>';
 
         // spelling mistake, retry with old spelling
         if ($text == 'over threshold, user marked unconfirmed' && empty($translation)) {
             return $this->get('over treshold, user marked unconfirmed');
         }
+        $translation = $this->getTranslation($text);
 
         if (!empty($translation)) {
             return $translation;


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
A few commits to tidy-up the languages.php file by removing redundant or obsolete code.

With open_basedir() in effect, I noticed warnings about trying to access the root directory
```
PHP Warning:  is_dir(): open_basedir restriction in effect. File(/lan/) is not within the allowed path(s):
PHP Warning:  is_dir(): open_basedir restriction in effect. File(/) is not within the allowed path(s):
```

Looking into this, it was caused by trying to derive a plugin's own language directory, which I think is now obsolete.
For clarity, there are four commits each removing some code that I think is not needed now.

1) Plugins have not yet been created when the `phplist_I18N` constructor is called. So the chunk of code trying to derive the
plugins basedir is redundant.

2) The code in the constructor looking for common.php, frontend.php etc is now obsolete. Those files have not existed for quite a while. Removing that chunk of code allows all other references to `$this->lan` to be removed as well.

3) The method getTranslation() takes a `$basedir` parameter that isn't used. Removing that parameter allows code that sets-up the parameter to be removed as well, particularly the `getPluginBasedir`() method.

4) The method getTranslation() takes a `$page` parameter that also isn't used. Removing that parameter allows code that sets-up the parameter to be removed as well.

## Related Issue



## Screenshots (if appropriate):
