### PR TITLE
Replace constants in the bounce handling code by config.php settings

### DIFF
--- a/public_html/lists/admin/init.php
+++ b/public_html/lists/admin/init.php
@@ -216,6 +216,15 @@ if (!isset($bounce_mailbox_purge)) {
 if (!isset($bounce_mailbox_purge_unprocessed)) {
     $bounce_mailbox_purge_unprocessed = true;
 }
+if (!isset($bounce_mailbox_maximum)) {
+    $bounce_mailbox_maximum = 100000;
+}
+if (!isset($bounce_rules_batch_size)) {
+    $bounce_rules_batch_size = 500;
+}
+if (!isset($bounce_mailbox_name)) {
+    $bounce_mailbox_name = 'INBOX';
+}
 
 // set some defaults if they are not specified
 if (!defined('REGISTER')) {

--- a/public_html/lists/admin/processbounces.php
+++ b/public_html/lists/admin/processbounces.php
@@ -360,25 +360,36 @@ function processBounceData($bounceid, $msgid, $userid, $bounceDate = null)
 
 function processPop($server, $user, $password)
 {
-    $port = $GLOBALS['bounce_mailbox_port'];
+    global $bounce_mailbox_port, $bounce_mailbox_name, $bounce_mailbox_maximum;
+
+    $port = $bounce_mailbox_port;
     if (!$port) {
         $port = '110/pop3/notls';
     }
     set_time_limit(6000);
 
-    $link = imap_open('{'.$server.':'.$port.'}INBOX', $user, $password);
+    $mailboxNames = explode(',', $bounce_mailbox_name);
+    $report = '';
 
-    if (!$link) {
-        outputProcessBounce($GLOBALS['I18N']->get('Cannot create POP3 connection to')." $server: ".imap_last_error());
+    foreach ($mailboxNames as $mailboxName) {
+        $mailbox = sprintf('{%s:%s}%s', $server, $port, $mailboxName);
+        $link = imap_open($mailbox, $user, $password);
 
-        return false;
+        if (!$link) {
+            outputProcessBounce($GLOBALS['I18N']->get('Cannot create POP3 connection to')." $mailbox: ".imap_last_error());
+
+            return false;
+        }
+        $report .= processMessages($link, $bounce_mailbox_maximum);
     }
 
-    return processMessages($link, 100000);
+    return $report;
 }
 
 function processMbox($file)
 {
+    global $bounce_mailbox_maximum;
+
     set_time_limit(6000);
 
     if (!TEST) {
@@ -392,10 +403,10 @@ function processMbox($file)
         return false;
     }
 
-    return processMessages($link, 100000);
+    return processMessages($link, $bounce_mailbox_maximum);
 }
 
-function processMessages($link, $max = 3000)
+function processMessages($link, $max)
 {
     global $bounce_mailbox_purge_unprocessed, $bounce_mailbox_purge;
     $num = imap_num_msg($link);
@@ -554,7 +565,7 @@ if (count($bouncerules)) {
     $bounceCount = Sql_Fetch_Row_Query(sprintf('select count(*) from %s', $GLOBALS['tables']['user_message_bounce']));
     $total = $bounceCount[0];
     $counter = 0;
-    $batchSize = 500; //# @TODO make a config, to allow tweaking on bigger systems
+    $batchSize = $bounce_rules_batch_size;
     while ($counter < $total) {
         $limit = ' limit '.$counter.', '.$batchSize;
         $counter += $batchSize;

--- a/public_html/lists/config/config_extended.php
+++ b/public_html/lists/config/config_extended.php
@@ -137,6 +137,18 @@ $bounce_unsubscribe_threshold = 5;
 // Set to 0 to received by mail bounce deletions in the advanced bounce processing report
 define('REPORT_DELETED_BOUNCES', 0);
 
+// The name of the POP3 mailbox
+// Multiple mailboxes can be specified separated by comma
+$bounce_mailbox_name = 'INBOX';
+
+// The maximum number of bounces to retrieve from the mailbox
+// This might need to be reduced if the processing times-out
+$bounce_mailbox_maximum = 100000;
+
+// When applying bounce rules the number of bounces to process in each batch
+// This might need to be reduced when there are a large number of bounces to process
+$bounce_rules_batch_size = 500;
+
 /*
 
 =========================================================================


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->

Allow some hard-coded settings to be specifed in config.php

- maximum number of bounces to retrieve from the mailbox, default is 100,000
- the number of bounces to process in one batch for bounce rules, default is 500
- the name of the mailbox, default is INBOX

Further, allow more than one mailbox to be specified. This is useful to be able to retrieve bounces that have been put in a Junk folder on the server. 

## Related Issue



## Screenshots (if appropriate):
