### PR TITLE
Support for https only hosts

### DIFF
--- a/public_html/lists/index.php
+++ b/public_html/lists/index.php
@@ -1234,7 +1234,11 @@ END;
         if (isset($regs[1]) && strlen($regs[1])) {
             $url = $regs[1];
             if (!preg_match('/^http/i', $url)) {
-                $url = 'http://'.$url;
+                if(isset($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) == 'on') { // use https URL if protocol is enabled
+                    $url = 'https://'.$url;
+                } else {
+                    $url = 'http://'.$url;
+                }
             }
             $remote_content = fetchUrl($url);
         }


### PR DESCRIPTION
Use https url for remote content when secure protocol is enabled

<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
From the security point of view it looks better using https protocol whenever possible
## Related Issue
If server host support only https, phplist traking links is not working


## Screenshots (if appropriate):
