### PR TITLE
Call the messageReQueued() method when a campaign is resent

### DIFF
--- a/public_html/lists/admin/message.php
+++ b/public_html/lists/admin/message.php
@@ -48,6 +48,10 @@ if (!empty($_POST['resend']) && is_array($_POST['list'])) {
         }
     }
     Sql_Query("update $tables[message] set status = \"submitted\" where id = $id");
+
+    foreach ($GLOBALS['plugins'] as $pluginname => $plugin) {
+        $plugin->messageReQueued($id);
+    }
     $_SESSION['action_result'] = s('campaign requeued');
     $messagedata = loadMessageData($id);
     $finishSending = mktime($messagedata['finishsending']['hour'], $messagedata['finishsending']['minute'], 0,


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->

When a campaign is resent to additional lists on the Message page, the messageReQueued() method is not currently called.

This change adds the same processing as in used when a campaign is requeued on the Campaigns page
## Related Issue



## Screenshots (if appropriate):
