### PR TITLE
Correct display of a select list for a boolean config item

### DIFF
--- a/public_html/lists/admin/actions/configure.php
+++ b/public_html/lists/admin/actions/configure.php
@@ -64,7 +64,7 @@ if ($configItem['type'] == 'textarea') {
     echo $GLOBALS['I18N']->get('Yes');
     echo '  </option>';
     echo '<option value="false" ';
-    if ($value === false || $value == 'false' || $value == 0) {
+    if ($value === false || $value == 'false' || $value == 0 || $value === '') {
         echo 'selected="selected"';
     }
     echo '>';
@@ -112,7 +112,7 @@ echo '<script type="text/javascript">
 
   $(".dontsavebutton").click(function() {
      item = $(this).attr(\'id\');
-     item = item.replace(/dontsave/,\'\'); 
+     item = item.replace(/dontsave/,\'\');
      desc = $("#description"+item).html();
      $("#"+item).html(desc+\' <i>' .str_replace("'", "\'", s('editing cancelled')).'</i>\');
   });


### PR DESCRIPTION

<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
When editing a boolean item on the Settings page, such as "Send notifications about subscribe, update and unsubscribe", the select list of Yes and No should show the current value but shows Yes when the current value is actually No. 
The code to select No is now incorrect due to php 8 being stricter about comparisons.

The value for a boolean seems to be "1" for true and an empty string for false. Previously `$value == 0` would also be true when $value is an empty string.

    if ($value === false || $value == 'false' || $value == 0) {


## Related Issue



## Screenshots (if appropriate):
![image](https://github.com/phpList/phplist3/assets/3147688/cac4c80c-4697-44e3-925d-96be1428e69c)