### PR TITLE
Use config.php in the default location when using command line

### DIFF
--- a/public_html/lists/admin/index.php
+++ b/public_html/lists/admin/index.php
@@ -48,7 +48,7 @@ if (!isset($_SERVER['SERVER_SOFTWARE']) && (php_sapi_name() == 'cli' || (is_nume
     $dir = dirname($_SERVER['SCRIPT_FILENAME']);
     chdir($dir);
 
-    if (!is_file($cline['c'])) {
+    if (isset($cline['c']) && !is_file($cline['c'])) {
         echo "Cannot find config file\n";
         exit;
     }


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
Currently the -c parameter has to be used when running from the command line. This is now unnecessary because the config file in the default location will be used if it exists and the -c parameter is not present.

## Related Issue

Issue #719 raised the question of using the config file in the default location. That has already been changed but the test for the -c parameter was left in making it mandatory.


## Screenshots (if appropriate):
