### PR TITLE
Allow ajax page links to have a title

### DIFF
--- a/public_html/lists/admin/connect.php
+++ b/public_html/lists/admin/connect.php
@@ -1262,10 +1262,10 @@ function PageLinkDialogOnly($name, $desc = '', $url = '', $extraclass = '')
     return $link;
 }
 
-function PageLinkAjax($name, $desc = '', $url = '', $extraclass = '')
+function PageLinkAjax($name, $desc = '', $url = '', $extraclass = '', $title = '')
 {
     //# as PageLink2, but add the option to ajax it in a popover window
-    $link = PageLink2($name, $desc, $url);
+    $link = PageLink2($name, $desc, $url, false, $title ?: $desc);
     if ($link) {
         $link = str_replace('<a ', '<a class="ajaxable '.$extraclass.'" ', $link);
         $link .= '';


### PR DESCRIPTION


<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
Allow ajax page links to have a title, defaulting to the link description. The title is shown when hovering over the link.

Currently an ajax link has a misleading title attribute. The title is set to that for the target page, but the link is always for a specific action on that page. See the screenshot for the Generate link.

This change adds an optional `$title` parameter to the `PageLinkAjax()` function then uses that or the `$desc` parameter for the call to `PageLink2()`.
This allows the calls to `PageLinkAjax()` to be updated later to have a meaningful title when needed.

## Related Issue



## Screenshots (if appropriate):


![image](https://github.com/phpList/phplist3/assets/3147688/68233642-53ee-4b07-bb27-cd77286bdedd)
