### PR TITLE
Escape single quote in error message returned by allowMessageToBeQueued()

### DIFF
--- a/public_html/lists/admin/send_core.php
+++ b/public_html/lists/admin/send_core.php
@@ -610,7 +610,7 @@ if (!$done) {
         ++$counttabs;
 
         // print $tabs->display();
-    } 
+    }
     echo '<input id="followupto" type="hidden" name="followupto" value="" />';
 
     if ($_GET['page'] == 'preparemessage') {
@@ -1333,7 +1333,7 @@ foreach ($GLOBALS['plugins'] as $pluginname => $plugin) {
     $pluginerror = $plugin->allowMessageToBeQueued($messagedata);
     if ($pluginerror) {
         $allReady = false;
-        $pluginerror = preg_replace("/\n/", '', $pluginerror);
+        $pluginerror = str_replace(["\n", "'"], ['', "\\'"], $pluginerror);
         $GLOBALS['pagefooter']['addtoqueue'] .= '<script type="text/javascript">
     $("#addtoqueue").append(\'<div class="missing">' .$pluginerror.'</div>\');
     </script>';


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
The error message returned by a plugin from `allowMessageToBeQueued()` needs to have any single-quote character escaped because it is within a javascript literal.
## Related Issue



## Screenshots (if appropriate):
