### PR TITLE
update CI to remove old PHP versions and add 8.3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,14 +11,10 @@ jobs:
     strategy:
       fail-fast: false     
       matrix:   
-        php-version: ['7.4', '8.0', '8.1']
+        php-version: ['7.4', '8.0', '8.1','8.2']
         experimental: [false]
         include:
-          - php-version: 7.2
-            experimental: true
-          - php-version: 7.3
-            experimental: true
-          - php-version: 8.2
+          - php-version: 8.3
             experimental: true
 
     steps:


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
Update the CI to stop running PHP 7.2 and 7.3 and add PHP 8.3

## Related Issue



## Screenshots (if appropriate):
