### PR TITLE
use the list order, even when grouping by category

### DIFF
--- a/public_html/lists/admin/subscribelib2.php
+++ b/public_html/lists/admin/subscribelib2.php
@@ -760,7 +760,7 @@ function ListAvailableLists($userid = 0, $lists_to_show = '')
     if (isset($GLOBALS['showCat'])&& $GLOBALS['showCat']===true){
         $listspercategory = array();
         $categories = array();
-        $catresult = Sql_query(sprintf('select * from %s %s order by category, listorder, name',
+        $catresult = Sql_query(sprintf('select * from %s %s order by listorder, name',
             $GLOBALS['tables']['list'], $subselect));
 
 


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
When listing lists grouped by category, still use the listorder for the order, and not the category

## Related Issue



## Screenshots (if appropriate):
