### PR TITLE
Bouncemgt - allowing processing only existing bounces + a related new rule action

### DIFF
--- a/public_html/lists/admin/bouncemgt.php
+++ b/public_html/lists/admin/bouncemgt.php
@@ -14,7 +14,7 @@ echo $spb.PageLink2('listbounces', s('View Bounces per list')).$spe;
 echo $spb.PageLink2('checkbouncerules', s('Check Current Bounce Rules')).$spe;
 
 echo $spb.PageLink2('processbounces', s('Process Bounces')).$spe;
-echo $spb.PageLink2('processbounces&justexisting=true', s('Reprocess Only Existing Bounces')).$spe;
+echo $spb.PageLink2('processbounces&justexisting=true', s('Reprocess Only Existing Bounces'), title: s('Reprocess Only Existing Bounces')).$spe;
 
 echo '</ul><br />';
 
@@ -25,3 +25,4 @@ if (!$numrules[0]) {
     echo '<p class="information text-warning"><big>'.s('You have already defined bounce rules in your system.      Be careful with generating new ones, because these may interfere with the ones that exist.').'</big></p>';
 }
 echo '<br /><p class="button">'.PageLink2('generatebouncerules', s('Generate Bounce Rules')).'</p>';
+

--- a/public_html/lists/admin/bouncemgt.php
+++ b/public_html/lists/admin/bouncemgt.php
@@ -14,11 +14,7 @@ echo $spb.PageLink2('listbounces', s('View Bounces per list')).$spe;
 echo $spb.PageLink2('checkbouncerules', s('Check Current Bounce Rules')).$spe;
 
 echo $spb.PageLink2('processbounces', s('Process Bounces')).$spe;
-if (version_compare(PHP_VERSION, '8.0.0', '<') { // Hardcoding defaults when not supporting Named Arguments
-    echo $spb.PageLink2('processbounces&justexisting=true', s('Reprocess Only Existing Bounces'), '', false, s('Reprocess Only Existing Bounces')).$spe;
-} else {
-    echo $spb.PageLink2('processbounces&justexisting=true', s('Reprocess Only Existing Bounces'), title: s('Reprocess Only Existing Bounces')).$spe;
-}
+echo $spb.PageLink2('processbounces&justexisting=true', s('Reprocess Only Existing Bounces'), '', false, s('Reprocess Only Existing Bounces')).$spe;
 
 echo '</ul><br />';
 

--- a/public_html/lists/admin/bouncemgt.php
+++ b/public_html/lists/admin/bouncemgt.php
@@ -14,7 +14,11 @@ echo $spb.PageLink2('listbounces', s('View Bounces per list')).$spe;
 echo $spb.PageLink2('checkbouncerules', s('Check Current Bounce Rules')).$spe;
 
 echo $spb.PageLink2('processbounces', s('Process Bounces')).$spe;
-echo $spb.PageLink2('processbounces&justexisting=true', s('Reprocess Only Existing Bounces'), title: s('Reprocess Only Existing Bounces')).$spe;
+if (version_compare(PHP_VERSION, '8.0.0', '<') { // Hardcoding defaults when not supporting Named Arguments
+    echo $spb.PageLink2('processbounces&justexisting=true', s('Reprocess Only Existing Bounces'), '', false, s('Reprocess Only Existing Bounces')).$spe;
+} else {
+    echo $spb.PageLink2('processbounces&justexisting=true', s('Reprocess Only Existing Bounces'), title: s('Reprocess Only Existing Bounces')).$spe;
+}
 
 echo '</ul><br />';
 

--- a/public_html/lists/admin/bouncemgt.php
+++ b/public_html/lists/admin/bouncemgt.php
@@ -14,6 +14,7 @@ echo $spb.PageLink2('listbounces', s('View Bounces per list')).$spe;
 echo $spb.PageLink2('checkbouncerules', s('Check Current Bounce Rules')).$spe;
 
 echo $spb.PageLink2('processbounces', s('Process Bounces')).$spe;
+echo $spb.PageLink2('processbounces&justexisting=true', s('Reprocess Only Existing Bounces')).$spe;
 
 echo '</ul><br />';
 

--- a/public_html/lists/admin/lib.php
+++ b/public_html/lists/admin/lib.php
@@ -30,6 +30,7 @@ $GLOBALS['bounceruleactions'] = array(
     'unconfirmuseranddeletebounce'  => $GLOBALS['I18N']->get('unconfirm subscriber and delete bounce'),
     'blacklistuseranddeletebounce'  => $GLOBALS['I18N']->get('blacklist subscriber and delete bounce'),
     'blacklistemailanddeletebounce' => $GLOBALS['I18N']->get('blacklist email address and delete bounce'),
+    'decreasecountconfirmuseranddeletebounce'  => $GLOBALS['I18N']->get('decrease count and confirm subscriber and delete bounce'),
     'deletebounce'                  => $GLOBALS['I18N']->get('delete bounce'),
 );
 


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
1. Added support for processing bounces without downloading new bounces (great for testing rules!)
1. Added support for a new bounce rule action that allows defining cases when that should undo automatic actions (this connects to point 1 when you accidentally unconfirm subscribers and wish to test how not to do it again without affecting bounces that were to be affected since they weren't downloaded yet)

## Screenshots (if appropriate):
![image](https://github.com/phpList/phplist3/assets/1773306/918a7c8f-ef16-4c6e-9e47-df04aba12327)
![image](https://github.com/phpList/phplist3/assets/1773306/bf8cb98f-880a-4247-a708-f444a5e7043d)