### PR TITLE
Support for indicating and getting feedback for e-mail test messages

### DIFF
--- a/public_html/lists/admin/sendemaillib.php
+++ b/public_html/lists/admin/sendemaillib.php
@@ -14,6 +14,7 @@ if (!function_exists('output')) {
 
 function sendEmail($messageid, $email, $hash, $htmlpref = 0, $rssitems = array(), $forwardedby = array())
 {
+    global $admin_auth;
     $getspeedstats = VERBOSE && !empty($GLOBALS['getspeedstats']) && isset($GLOBALS['processqueue_timer']);
     $sqlCountStart = $GLOBALS['pagestats']['number_of_queries'];
     $isTestMail = isset($_GET['page']) && $_GET['page'] == 'send';
@@ -895,8 +896,8 @@ function sendEmail($messageid, $email, $hash, $htmlpref = 0, $rssitems = array()
             if (!empty($cached[$messageid]['replytoemail'])) {
                 $mail->AddReplyTo($cached[$messageid]['replytoemail'], $cached[$messageid]['replytoname']);
             } elseif ($isTestMail) {
-                $testReplyAddress = Sql_Fetch_Row_Query(sprintf('select email from %s where id = %d', $GLOBALS['tables']['admin'], $_SESSION['logindetails']['id']))[0];
-                $testReplyName = adminName();
+                $testReplyAddress = $admin_auth->adminEmail($_SESSION['logindetails']['id']);
+                $testReplyName = $admin_auth->adminName($_SESSION['logindetails']['id']);
                 if (empty($testReplyAddress)) {
                     $testReplyAddress = getConfig('admin_address');
                     $testReplyName = '';
@@ -1640,3 +1641,4 @@ if (!Sql_Affected_Rows()) {
         $newpoweredimage,
         70, 30));
 }
+

--- a/public_html/lists/admin/sendemaillib.php
+++ b/public_html/lists/admin/sendemaillib.php
@@ -895,14 +895,14 @@ function sendEmail($messageid, $email, $hash, $htmlpref = 0, $rssitems = array()
             if (!empty($cached[$messageid]['replytoemail'])) {
                 $mail->AddReplyTo($cached[$messageid]['replytoemail'], $cached[$messageid]['replytoname']);
             } elseif ($isTestMail) {
-                $testReplyFrom = Sql_Fetch_Row_Query(sprintf('select email from %s where id = %d', $GLOBALS['tables']['admin'], $_SESSION['logindetails']['id']))[0];
+                $testReplyAddress = Sql_Fetch_Row_Query(sprintf('select email from %s where id = %d', $GLOBALS['tables']['admin'], $_SESSION['logindetails']['id']))[0];
                 $testReplyName = adminName();
-                if (empty($testReplyFrom)) {
-                    $testReplyFrom = getConfig('admin_address');
+                if (empty($testReplyAddress)) {
+                    $testReplyAddress = getConfig('admin_address');
                     $testReplyName = '';
                 }
-                if (!empty($testReplyFrom)) {
-                    $mail->AddReplyTo($testReplyFrom, $testReplyName);
+                if (!empty($testReplyAddress)) {
+                    $mail->AddReplyTo($testReplyAddress, $testReplyName);
                 }
             }
         } else {

--- a/public_html/lists/admin/sendemaillib.php
+++ b/public_html/lists/admin/sendemaillib.php
@@ -890,10 +890,20 @@ function sendEmail($messageid, $email, $hash, $htmlpref = 0, $rssitems = array()
 
         if ($hash != 'forwarded' || !count($forwardedby)) {
             $fromname = $cached[$messageid]['fromname'];
-            $subject = $cached[$messageid]['subject'];
+            $subject = (!$isTestMail ? '' : ($GLOBALS['I18N']->get('(test)')) . ' ') . $cached[$messageid]['subject'];
 
             if (!empty($cached[$messageid]['replytoemail'])) {
                 $mail->AddReplyTo($cached[$messageid]['replytoemail'], $cached[$messageid]['replytoname']);
+            } elseif ($isTestMail) {
+                $testReplyFrom = Sql_Fetch_Row_Query(sprintf('select email from %s where id = %d', $GLOBALS['tables']['admin'], $_SESSION['logindetails']['id']))[0];
+                $testReplyName = adminName();
+                if (empty($testReplyFrom)) {
+                    $testReplyFrom = getConfig('admin_address');
+                    $testReplyName = '';
+                }
+                if (!empty($testReplyFrom)) {
+                    $mail->AddReplyTo($testReplyFrom, $testReplyName);
+                }
             }
         } else {
             $fromname = $forwardedby['subscriberName'];


### PR DESCRIPTION
<!---Thanks for contributing to phpList!-->

## Description
1. Appended a test subject indicator to test messages (based on the existing translation of the word `test`)
1. Added a reply-to address to test messages with this logic:
   1. Left the current approach of using a manual reply-to address if one was supplied
   1. But if one wasn't supplied, take the currently logged-in admin's address
   1. If it's empty, take the general admin's address

## Screenshots (if appropriate):
![image](https://github.com/phpList/phplist3/assets/1773306/d244f819-5276-46f6-bac8-2e82ff7efe45)