### PR TITLE
Show where attributes are used

### DIFF
--- a/public_html/lists/admin/attributes.php
+++ b/public_html/lists/admin/attributes.php
@@ -424,6 +424,7 @@ if ($c) {
 echo '<br /><br /><br /><div id="new-attribute">
 <a name="new"></a>
 <h3>' .s('Add new Attribute').'</h3>
+<p>' .s('Note: Each attribute that you add will apply to members for all lists.'). '</p>
 <div class="alert alert-warning">' .s('Warning: Storage of sensitive personal data such as race, health, and sexual orientation is regulated by some data protection laws').'. <a href="https://www.phplist.org/manual/ch048_gdpr.xhtml" target="_blank">' .s('Read more'). '&hellip;</a></div>
 
 <div class="label pull-left"><label class="label">' .s('Name').': </label></div>


### PR DESCRIPTION
## Description

Adds a note about how attributes work.

Note: Mailchimp is a popular email software. And the way it works is that each list has its own attributes.

I learned that phplist uses the same attributes for all lists, this adding this note in case it will be helpful to other people.

## Related Issue



## Screenshots (if appropriate):

![Screenshot 2024-07-12 at 12 08 39](https://github.com/user-attachments/assets/1118599d-5f68-4438-8c54-cdf04f969680)

