### PR TITLE
Update the ckeditor url to the latest version

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,22 @@
-<!---Thanks for contributing to phpList!-->
+<!--- Thanks for contributing to phpList!-->
 
 ## Description
 <!--- Please provide a general description of your changes in the Pull Request -->
+
+## Contributor License Agreement
+ 
+<!-- 
+
+before we can accept your PR, if you haven't done this yet, please sign the 
+
+Contributor License Agreement at https://www.phplist.com/cla
+
+Many thanks
+
+the phpList Team
+
+-->
+
 
 ## Related Issue
 

--- a/public_html/lists/admin/upgrade.php
+++ b/public_html/lists/admin/upgrade.php
@@ -338,7 +338,7 @@ if ($dbversion == VERSION && !$force) {
         cl_output(s('Creating new table "admin_login"'));
         createTable('admin_login');
         ## add an entry for current admin to avoid being kicked out
-        Sql_Query(sprintf('insert into %s (moment,adminid,remote_ip4,remote_ip6,sessionid,active) 
+        Sql_Query(sprintf('insert into %s (moment,adminid,remote_ip4,remote_ip6,sessionid,active)
           values(%d,%d,"%s","%s","%s",1)',
           $GLOBALS['tables']['admin_login'],time(),$_SESSION['logindetails']['id'],$_SESSION['adminloggedin'],"",session_id()));
     }
@@ -368,6 +368,23 @@ if ($dbversion == VERSION && !$force) {
             'alter table %s modify time timestamp not null default current_timestamp on update current_timestamp',
             $GLOBALS['tables']['user_message_forward']
         ));
+    }
+
+    if (version_compare($dbversion, '3.6.16', '<')) {
+        if (isset($plugins['CKEditorPlugin'])) {
+            // Update the version of CKEditor if the CDN is being used
+            $latestUrl = $plugins['CKEditorPlugin']->settings['ckeditor_url']['value'];
+
+            if (preg_match('/\d+\.\d+\.\d+/', $latestUrl, $matches)) {
+                $latestVersion = $matches[0];
+                $currentUrl = getConfig('ckeditor_url');
+
+                if (strpos($currentUrl, 'cdn.ckeditor.com') !== false) {
+                    $newUrl = preg_replace('/\d+\.\d+\.\d+/', $latestVersion, $currentUrl);
+                    SaveConfig('ckeditor_url', $newUrl);
+                }
+            }
+        }
     }
 
     //# longblobs are better at mixing character encoding. We don't know the encoding of anything we may want to store in cache

--- a/public_html/lists/admin/upgrade.php
+++ b/public_html/lists/admin/upgrade.php
@@ -370,19 +370,17 @@ if ($dbversion == VERSION && !$force) {
         ));
     }
 
-    if (version_compare($dbversion, '3.6.16', '<')) {
-        if (isset($plugins['CKEditorPlugin'])) {
-            // Update the version of CKEditor if the CDN is being used
-            $latestUrl = $plugins['CKEditorPlugin']->settings['ckeditor_url']['value'];
+    if (isset($plugins['CKEditorPlugin'])) {
+        // Update the version of CKEditor if the CDN is being used
+        $latestUrl = $plugins['CKEditorPlugin']->settings['ckeditor_url']['value'];
 
-            if (preg_match('/\d+\.\d+\.\d+/', $latestUrl, $matches)) {
-                $latestVersion = $matches[0];
-                $currentUrl = getConfig('ckeditor_url');
+        if (preg_match('/\d+\.\d+\.\d+/', $latestUrl, $matches)) {
+            $latestVersion = $matches[0];
+            $currentUrl = getConfig('ckeditor_url');
 
-                if (strpos($currentUrl, 'cdn.ckeditor.com') !== false) {
-                    $newUrl = preg_replace('/\d+\.\d+\.\d+/', $latestVersion, $currentUrl);
-                    SaveConfig('ckeditor_url', $newUrl);
-                }
+            if (strpos($currentUrl, 'cdn.ckeditor.com') !== false) {
+                $newUrl = preg_replace('/\d+\.\d+\.\d+/', $latestVersion, $currentUrl);
+                SaveConfig('ckeditor_url', $newUrl);
             }
         }
     }


### PR DESCRIPTION
<!--- Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
Currently a new release of phplist will include the latest version of the CKEditor plugin but does not change the version of ckeditor.js that is being used. That has to be changed by the administrator on the Settings page. However a new installation of phplist will be using the latest version of ckeditor.js as that is the default value within the plugin.

This change is to update the ckeditor version of an existing installation to the default value in the plugin. This is 4.22.1 and is probably not now going to change. This is applied only when the CDN is being used, so anyone with a local copy will not be affected. Also, the ckeditor package being used, basic, standard or full, is not changed.

## Contributor License Agreement
 
<!-- 

before we can accept your PR, if you haven't done this yet, please sign the 

Contributor License Agreement at https://www.phplist.com/cla

Many thanks

the phpList Team

-->


## Related Issue



## Screenshots (if appropriate):
