### PR TITLE
Remove POP3 from error message when unable to connect to bounce mailbox

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,22 @@
-<!---Thanks for contributing to phpList!-->
+<!--- Thanks for contributing to phpList!-->
 
 ## Description
 <!--- Please provide a general description of your changes in the Pull Request -->
+
+## Contributor License Agreement
+ 
+<!-- 
+
+before we can accept your PR, if you haven't done this yet, please sign the 
+
+Contributor License Agreement at https://www.phplist.com/cla
+
+Many thanks
+
+the phpList Team
+
+-->
+
 
 ## Related Issue
 

--- a/public_html/lists/admin/processbounces.php
+++ b/public_html/lists/admin/processbounces.php
@@ -376,7 +376,7 @@ function processPop($server, $user, $password)
         $link = imap_open($mailbox, $user, $password);
 
         if (!$link) {
-            outputProcessBounce($GLOBALS['I18N']->get('Cannot create POP3 connection to')." $mailbox: ".imap_last_error());
+            outputProcessBounce($GLOBALS['I18N']->get('Cannot create connection to')." $mailbox: ".imap_last_error());
 
             return false;
         }


### PR DESCRIPTION
<!--- Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
If https://github.com/phpList/phplist3/pull/1063 is implemented then IMAP will be used to connect to the bounce mailbox. The existing error message then would be confusing as it refers to POP3

![image](https://github.com/user-attachments/assets/58c2dc82-c39a-4b61-992c-72cbaaad658f)

## Contributor License Agreement
 
<!-- 

before we can accept your PR, if you haven't done this yet, please sign the 

Contributor License Agreement at https://www.phplist.com/cla

Many thanks

the phpList Team

-->


## Related Issue



## Screenshots (if appropriate):
