### PR TITLE
Use php functions instead of imap functions

### DIFF
--- a/public_html/lists/admin/bounce.php
+++ b/public_html/lists/admin/bounce.php
@@ -84,7 +84,7 @@ if (isset($_GET['doit']) && isSuperUser()) {
             $actionresult .= sprintf(s('Made subscriber %s confirmed').'<br />', $userid);
         } else {
             $actionresult .= sprintf(s('Made subscriber %s unconfirmed').'<br />', $userid);
-        }          
+        }
     }
 
     if (!empty($userid) && $maketext) {
@@ -223,10 +223,10 @@ if ($id) {
 
     switch ($transfer_encoding) {
         case 'quoted-printable':
-            $bounceBody = imap_qprint($bounce['data']);
+            $bounceBody = quoted_printable_decode($bounce['data']);
             break;
         case 'base64':
-            $bounceBody = imap_base64($bounce['data']);
+            $bounceBody = base64_decode($bounce['data']);
             break;
         case '7bit':
         case '8bit':

--- a/public_html/lists/admin/processbounces.php
+++ b/public_html/lists/admin/processbounces.php
@@ -166,10 +166,10 @@ function decodeBody($header, $body)
     }
     switch ($transfer_encoding) {
         case 'quoted-printable':
-            $decoded_body = @imap_qprint($body);
+            $decoded_body = quoted_printable_decode($body);
             break;
         case 'base64':
-            $decoded_body = @imap_base64($body);
+            $decoded_body = base64_decode($body);
             break;
         case '7bit':
         case '8bit':


### PR DESCRIPTION
<!--- Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
The php-imap2 package used by the IMAP2 plugin doesn't replace the `imap_qprint` and `imap_base64` functions correctly. To avoid any problems with using those functions the equivalent php functions `quoted_printable_decode` and `base64_decode` can be used instead.
 <!-- 
## Contributor License Agreement

before we can accept your PR, if you haven't done this yet, please sign the 

Contributor License Agreement at https://www.phplist.com/cla

Many thanks

the phpList Team

-->


## Related Issue

#1063 

## Screenshots (if appropriate):
