### PR TITLE
Fix problem with sql_escape() introduced in 3.6.15

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,22 @@
-<!---Thanks for contributing to phpList!-->
+<!--- Thanks for contributing to phpList!-->
 
 ## Description
 <!--- Please provide a general description of your changes in the Pull Request -->
+
+## Contributor License Agreement
+ 
+<!-- 
+
+before we can accept your PR, if you haven't done this yet, please sign the 
+
+Contributor License Agreement at https://www.phplist.com/cla
+
+Many thanks
+
+the phpList Team
+
+-->
+
 
 ## Related Issue
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,9 +3,8 @@
 ## Description
 <!--- Please provide a general description of your changes in the Pull Request -->
 
+ <!-- 
 ## Contributor License Agreement
- 
-<!-- 
 
 before we can accept your PR, if you haven't done this yet, please sign the 
 

--- a/public_html/lists/admin/mysqli.inc
+++ b/public_html/lists/admin/mysqli.inc
@@ -410,7 +410,7 @@ function Sql_create_Table($table, $structure)
 
 function sql_escape($text)
 {
-    if (empty($text)) {
+    if ($text === null) {
       return '';
     }
     if (empty($GLOBALS['database_connection'])) {


### PR DESCRIPTION
<!--- Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
A change in release 3.6.15 to the `sql_escape()` function incorrectly changes "0" to an empty string. That can cause a subsequent sql statement to fail due to trying to update an integer column with an empty string. Whether that is allowed depends on the sql mode.
See this issue raised on the forum https://discuss.phplist.org/t/un-confirming-from-subscriber-profile-fails/10031/1

This is the commit in question, see the change to file public_html/lists/admin/mysqli.inc
https://github.com/phpList/phplist3/commit/f0443c32c1756f5bf3df7099171e79c4aab7c1d9#diff-165411d48091a926d6eee355a541b83d13a57f8db5fb0c1b04f11170b2fe75b4

I think that a null value is the only special case that needs to be handled, not any `empty` value.
 <!-- 
## Contributor License Agreement

before we can accept your PR, if you haven't done this yet, please sign the 

Contributor License Agreement at https://www.phplist.com/cla

Many thanks

the phpList Team

-->


## Related Issue



## Screenshots (if appropriate):
