### PR TITLE
Bump version-number in VERSION from 3.6.15 to 3.6.16

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,4 +1,4 @@
 # file that keeps track of the latest tag in cvs and the corresponding version
 # this automates publishing a new version, when it's tagged
 # if you don't understand this, don't worry. You don't need this file
-VERSION=3.6.15
+VERSION=3.6.16


### PR DESCRIPTION
<!--- Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
The VERSION file still contains the former version 3.6.15 - this prevents phpList to do a database upgrade. I just changed the version number inside this file which then initiates the updgrade.

phplist worked perfectly even without the database upgrade (at least with my installation). It's just for correctness. :)

 <!-- 
## Contributor License Agreement

before we can accept your PR, if you haven't done this yet, please sign the 

Contributor License Agreement at https://www.phplist.com/cla

Many thanks

the phpList Team

-->


## Related Issue



## Screenshots (if appropriate):
