### PR TITLE
Fix RSS subject placeholders in campaign notifications

### DIFF
--- a/public_html/lists/admin/actions/processqueue.php
+++ b/public_html/lists/admin/actions/processqueue.php
@@ -666,6 +666,9 @@ while ($message = Sql_fetch_array($messages)) {
     foreach ($GLOBALS['plugins'] as $pluginname => $plugin) {
         $plugin->campaignStarted($msgdata);
     }
+    if (isset($GLOBALS['MD'][$messageid]['subject'])) {
+        $msgdata['subject'] = $GLOBALS['MD'][$messageid]['subject'];
+    }
 
     if (!empty($msgdata['resetstats'])) {
         resetMessageStatistics($msgdata['id']);
@@ -1360,6 +1363,9 @@ while ($message = Sql_fetch_array($messages)) {
             repeatMessage($messageid);
             foreach ($GLOBALS['plugins'] as $pluginname => $plugin) {
                 $plugin->processSendingCampaignFinished($messageid, $msgdata);
+            }
+            if (isset($GLOBALS['MD'][$messageid]['subject'])) {
+                $msgdata['subject'] = $GLOBALS['MD'][$messageid]['subject'];
             }
             $status = Sql_query(sprintf('update %s set status = "sent",sent = now() where id = %d',
                 $GLOBALS['tables']['message'], $messageid));


### PR DESCRIPTION
<!--- Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->

For RSS campaigns, the RssFeedPlugin updates the effective subject during campaign processing, but processqueue.php was still sending notify_start and notify_end emails using the original message subject. As a result, placeholders such as [RSS:N] could appear unprocessed in notification emails.

Updated queue processing to refresh $msgdata['subject'] from the plugin-updatedmessage data after campaignStarted() and after processSendingCampaignFinished().

This keeps non-RSS behaviour unchanged and makes both campaign notificationemails use the final resolved subject.

### Changes:
Started Campaign
#### Before
```bash
phpList has started sending the campaign with subject XXXXXX has [RSS:N] new posts

to view the progress of this campaign, go to https://example.com/lists/admin/?page=messages&tab=active 
```
#### After
```bash
phpList has started sending the campaign with subject XXXXXX has 5 new posts

to view the progress of this campaign, go to https://example.com/lists/admin/?page=messages&tab=active 
```

Finishing Campaign
#### Before
```bash
phpList has finished sending the campaign with subject XXXXXX has [RSS:N] new posts

to view the statistics of this campaign, go to https://example.com/lists/admin/?page=statsoverview&id=10
```
#### After
```bash
phpList has finished sending the campaign with subject XXXXXX has 5 new posts

to view the statistics of this campaign, go to https://example.com/lists/admin/?page=statsoverview&id=10
```
 <!-- 
## Contributor License Agreement

before we can accept your PR, if you haven't done this yet, please sign the 

Contributor License Agreement at https://www.phplist.com/cla

Many thanks

the phpList Team

-->


## Related Issue



## Screenshots (if appropriate):
