### PR TITLE
Fix: undefined variable $filterSelectDefault

### DIFF
--- a/public_html/lists/admin/messages.php
+++ b/public_html/lists/admin/messages.php
@@ -5,6 +5,7 @@ require_once dirname(__FILE__).'/accesscheck.php';
 $subselect = $whereClause = '';
 $action_result = '';
 $access = accessLevel('messages');
+$filterSelectDefault = ' --- filter --- ';
 
 $messageSortOptions = array(
     'subjectasc'  => array(


### PR DESCRIPTION
<!--- Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
Fixes undefined variable $filterSelectDefault on messages page
 <!-- 
## Contributor License Agreement

before we can accept your PR, if you haven't done this yet, please sign the 

Contributor License Agreement at https://www.phplist.com/cla

Many thanks

the phpList Team

-->


## Screenshots (if appropriate):
<img width="694" height="381" alt="image" src="https://github.com/user-attachments/assets/454efa2a-4822-4227-a70e-47746ab99c77" />

