### PR TITLE
Update plugin installation script

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1061,12 +1061,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpList/phplist-plugin-saml2.git",
-                "reference": "31c6f67c946ca343af49b9e21036558cf39dc383"
+                "reference": "8f1ca9ff9ed0812103126bc0c0b9fe064bb6575d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpList/phplist-plugin-saml2/zipball/31c6f67c946ca343af49b9e21036558cf39dc383",
-                "reference": "31c6f67c946ca343af49b9e21036558cf39dc383",
+                "url": "https://api.github.com/repos/phpList/phplist-plugin-saml2/zipball/8f1ca9ff9ed0812103126bc0c0b9fe064bb6575d",
+                "reference": "8f1ca9ff9ed0812103126bc0c0b9fe064bb6575d",
                 "shasum": ""
             },
             "require": {
@@ -1092,7 +1092,7 @@
                 "wiki": "http://resources.phplist.com/",
                 "source": "https://github.com/phpList/phpList3"
             },
-            "time": "2026-05-05T11:40:02+00:00"
+            "time": "2026-05-06T08:58:48+00:00"
         },
         {
             "name": "phplist/phplist-plugin-subjectlineplaceholders",

--- a/composer.lock
+++ b/composer.lock
@@ -1061,12 +1061,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpList/phplist-plugin-saml2.git",
-                "reference": "ad8aaa2f5a22f42b3cc50f720de039ddeb6d56f1"
+                "reference": "31c6f67c946ca343af49b9e21036558cf39dc383"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpList/phplist-plugin-saml2/zipball/ad8aaa2f5a22f42b3cc50f720de039ddeb6d56f1",
-                "reference": "ad8aaa2f5a22f42b3cc50f720de039ddeb6d56f1",
+                "url": "https://api.github.com/repos/phpList/phplist-plugin-saml2/zipball/31c6f67c946ca343af49b9e21036558cf39dc383",
+                "reference": "31c6f67c946ca343af49b9e21036558cf39dc383",
                 "shasum": ""
             },
             "require": {
@@ -1092,7 +1092,7 @@
                 "wiki": "http://resources.phplist.com/",
                 "source": "https://github.com/phpList/phpList3"
             },
-            "time": "2025-06-28T09:36:08+00:00"
+            "time": "2026-05-05T11:40:02+00:00"
         },
         {
             "name": "phplist/phplist-plugin-subjectlineplaceholders",

--- a/scripts/install-plugins.sh
+++ b/scripts/install-plugins.sh
@@ -23,9 +23,14 @@ while IFS= read -r -d '' plugin; do
 
   case "$plugin_name" in
     phplist-plugin-saml2)
-      echo "Preserving SAML2 settings.php"
+      settings_file="$to/simplesaml/settings.php"
 
-      rsync_args+=(--exclude='simplesaml/settings.php')
+      if [[ -f "$settings_file" ]]; then
+        echo "Preserving existing SAML2 settings.php"
+        rsync_args+=(--exclude='simplesaml/settings.php')
+      else
+        echo "SAML2 settings.php does not exist, it will be created"
+      fi
       ;;
   esac
 

--- a/scripts/install-plugins.sh
+++ b/scripts/install-plugins.sh
@@ -11,9 +11,24 @@ echo $from $to
   apt install -y rsync
 }
 
-for plugin in $(find $from -type d -name phplist-plugin-*); do
-  [[ ! -z "$(ls -A $plugin/plugins/)" ]] && {
-    echo installing plugin $plugin
-    rsync -a $plugin/plugins/* $to
-  }
-done
+while IFS= read -r -d '' plugin; do
+  plugin_name="$(basename "$plugin")"
+
+  [[ -d "$plugin/plugins" ]] || continue
+  [[ -n "$(find "$plugin/plugins" -mindepth 1 -maxdepth 1 -print -quit)" ]] || continue
+
+  echo "Installing plugin: $plugin_name"
+
+  rsync_args=(-a)
+
+  case "$plugin_name" in
+    phplist-plugin-saml2)
+      echo "Preserving SAML2 settings.php"
+
+      rsync_args+=(--exclude='simplesaml/settings.php')
+      ;;
+  esac
+
+  rsync "${rsync_args[@]}" "$plugin/plugins/" "$to/"
+
+done < <(find "$from" -type d -name 'phplist-plugin-*' -print0)


### PR DESCRIPTION
<!--- Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
The issue: some SAML redirect/auth flows happen outside the normal phpList3 request lifecycle, so phpList3 code is not involved and it cannot read DB settings there. Because of that, the plugin writes to simplesaml/settings.php as a bridge file for the SimpleSAML flow. The database remains the source of truth, but this file is generated from those DB settings so SimpleSAML can read the config before phpList is involved.

- Update plugin installation script to preserve an existing saml settings.php during plugin sync
- Update saml plugin to latest version
 <!-- 
## Contributor License Agreement

before we can accept your PR, if you haven't done this yet, please sign the 

Contributor License Agreement at https://www.phplist.com/cla

Many thanks

the phpList Team

-->


## Related Issue



## Screenshots (if appropriate):
