### PR TITLE
add SSL connection check option

### DIFF
--- a/public_html/lists/admin/mysqli.inc
+++ b/public_html/lists/admin/mysqli.inc
@@ -11,7 +11,7 @@ if (!function_exists("mysqli_init")) {
 
 function Sql_Connect($host, $user, $password, $database)
 {
-    global $database_port, $database_socket, $database_connection_compression, $database_connection_ssl;
+    global $database_port, $database_socket, $database_connection_compression, $database_connection_ssl, $database_connection_ssl_check;
 
     if (!$host || !$user) {
         header('HTTP/1.0 500 Cannot connect to database');
@@ -20,7 +20,12 @@ function Sql_Connect($host, $user, $password, $database)
     }
     $db = mysqli_init();
     $compress = empty($database_connection_compression) ? 0 : MYSQLI_CLIENT_COMPRESS;
-    $secure = empty($database_connection_ssl) ? 0 : MYSQLI_CLIENT_SSL_DONT_VERIFY_SERVER_CERT;
+    $secure = 0;
+    if (!empty($database_connection_ssl)) {
+        $secure = !empty($database_connection_ssl_check)
+            ? MYSQLI_CLIENT_SSL
+            : MYSQLI_CLIENT_SSL_DONT_VERIFY_SERVER_CERT;
+    }
 
     mysqli_report(MYSQLI_REPORT_OFF);
 

--- a/public_html/lists/admin/mysqli.inc
+++ b/public_html/lists/admin/mysqli.inc
@@ -11,7 +11,8 @@ if (!function_exists("mysqli_init")) {
 
 function Sql_Connect($host, $user, $password, $database)
 {
-    global $database_port, $database_socket, $database_connection_compression, $database_connection_ssl, $database_connection_ssl_check;
+    global $database_port, $database_socket, $database_connection_compression;
+    global $database_connection_ssl, $database_connection_ssl_force, $database_connection_ssl_ca;
 
     if (!$host || !$user) {
         header('HTTP/1.0 500 Cannot connect to database');
@@ -22,12 +23,24 @@ function Sql_Connect($host, $user, $password, $database)
     $compress = empty($database_connection_compression) ? 0 : MYSQLI_CLIENT_COMPRESS;
     $secure = 0;
     if (!empty($database_connection_ssl)) {
-        $secure = !empty($database_connection_ssl_check)
-            ? MYSQLI_CLIENT_SSL
-            : MYSQLI_CLIENT_SSL_DONT_VERIFY_SERVER_CERT;
+        $secure = MYSQLI_CLIENT_SSL_DONT_VERIFY_SERVER_CERT;
+    }
+    if (!empty($database_connection_ssl_force)) {
+        $secure = MYSQLI_CLIENT_SSL;
     }
 
     mysqli_report(MYSQLI_REPORT_OFF);
+
+    if (!empty($database_connection_ssl_ca)) {
+        mysqli_ssl_set(
+            $db,
+            null,
+            null,
+            realpath($database_connection_ssl_ca),
+            null,
+            null
+        );
+    }
 
     if (!mysqli_real_connect($db, $host, $user, $password, $database, $database_port, $database_socket, $compress | $secure)) {
         $errno = mysqli_connect_errno();
@@ -432,5 +445,3 @@ function sql_escape($text)
         return '';
     }
 }
-
-

--- a/public_html/lists/admin/mysqli.inc
+++ b/public_html/lists/admin/mysqli.inc
@@ -32,11 +32,18 @@ function Sql_Connect($host, $user, $password, $database)
     mysqli_report(MYSQLI_REPORT_OFF);
 
     if (!empty($database_connection_ssl_ca)) {
+        $caPath = realpath($database_connection_ssl_ca);
+        if ($caPath === false) {
+            throw new RuntimeException(
+                "Invalid SSL CA file: {$database_connection_ssl_ca}"
+            );
+        }
+
         mysqli_ssl_set(
             $db,
             null,
             null,
-            realpath($database_connection_ssl_ca),
+            $caPath,
             null,
             null
         );

--- a/public_html/lists/config/config_extended.php
+++ b/public_html/lists/config/config_extended.php
@@ -41,6 +41,9 @@ $database_connection_compression = false;
 // force database connection to use SSL
 $database_connection_ssl = false;
 
+// force to check SSL connection
+$database_connection_ssl_check = false;
+
 // if you use multiple installations of phpList you can set this to
 // something to identify this one. it will be prepended to email report
 // subjects

--- a/public_html/lists/config/config_extended.php
+++ b/public_html/lists/config/config_extended.php
@@ -38,11 +38,15 @@ $database_socket = null;
 // enable database connection compression
 $database_connection_compression = false;
 
-// force database connection to use SSL
+// Use SSL/TLS for the database connection.
 $database_connection_ssl = false;
 
-// force to check SSL connection
-$database_connection_ssl_check = false;
+// Set to true if MySQL is configured with require_secure_transport=ON.
+$database_connection_ssl_force = false;
+
+// If the database user requires SSL, set this to the path
+// of the CA certificate used to verify the MySQL server certificate.
+$database_connection_ssl_ca = '/path/to/ca.pem';
 
 // if you use multiple installations of phpList you can set this to
 // something to identify this one. it will be prepended to email report


### PR DESCRIPTION
<!--- Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->

This PR:

- preserves the existing SSL behavior by default 
- adds option to connect using MYSQLI_CLIENT_SSL
- adds option to set SSL cert for MySql user

```php
$database_connection_ssl_force = true;
$database_connection_ssl_ca = '/path/to/ca.pem';
```
 <!-- 
## Contributor License Agreement

before we can accept your PR, if you haven't done this yet, please sign the 

Contributor License Agreement at https://www.phplist.com/cla

Many thanks

the phpList Team

-->


## Related Issue
[issue](https://github.com/phpList/phplist3/issues/833)

## Screenshots (if appropriate):
