### PR TITLE
use mb_* functions for UTF-8 safe string operations in list descriptions

### DIFF
--- a/public_html/lists/admin/list.php
+++ b/public_html/lists/admin/list.php
@@ -246,7 +246,9 @@ while ($row = Sql_fetch_array($result)) {
     //foreach ($GLOBALS['plugins'] as $plugin) {
     //$desc = $plugin->displayLists($row) . $desc;
     //}
-    $displayDesc = strlen($desc) > 50 ? substr($desc, 0, 50) . '...' : $desc;
+    $displayDesc = mb_strlen($desc, 'UTF-8') > 50
+        ? mb_substr($desc, 0, 50, 'UTF-8') . '...'
+        : $desc;
 
     $element = '<!-- '.
     $row['id'].'-->'.'<a href="./?page=members&id='.


### PR DESCRIPTION
<!--- Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
use mb_* functions for UTF-8 safe string operations in list descriptions
 <!-- 
## Contributor License Agreement

before we can accept your PR, if you haven't done this yet, please sign the 

Contributor License Agreement at https://www.phplist.com/cla

Many thanks

the phpList Team

-->


## Related Issue
[issue](https://github.com/phpList/phplist3/issues/1097)


## Screenshots (if appropriate):
