### PR TITLE
Add preselect to subscribe page

### DIFF
--- a/public_html/lists/admin/languages.php
+++ b/public_html/lists/admin/languages.php
@@ -297,7 +297,7 @@ class phplist_I18N
         }
 
         $tr = Sql_Fetch_Row_Query(sprintf('select translation from '.$GLOBALS['tables']['i18n'].' where original = "%s" and lan = "%s"',
-            sql_escape(trim($text)), $this->language), 1);
+            sql_escape(trim($text ?? '')), $this->language), 1);
         if (empty($tr[0])) {
             $tr = Sql_Fetch_Row_Query(sprintf('select translation from '.$GLOBALS['tables']['i18n'].' where original = "%s" and lan = "%s"',
                 sql_escape($text), $this->language), 1);
@@ -514,7 +514,7 @@ $lan = array(
 
     public function get($text)
     {
-        if (trim($text) == '') {
+        if (trim($text ?? '') == '') {
             return '';
         }
         if (strip_tags($text) == '') {

--- a/public_html/lists/admin/spageedit.php
+++ b/public_html/lists/admin/spageedit.php
@@ -370,7 +370,7 @@ foreach ($GLOBALS['plugins'] as $pluginname => $plugin) {
 }
 
 $listsHTML = '<h3><a name="lists">'.s('Select the lists to offer').'</a></h3>';
-$listsHTML .= '<div>';
+$listsHTML .= '<div class="spageedit-lists">';
 $listsHTML .= sprintf('<label for="listcategories">%s</label><br/>',
     s('Display list categories'));
 $listsHTML .= sprintf('<input type="radio" name="showcategories" value="no" %s />%s<br/>',
@@ -398,23 +398,38 @@ $preselectList = (int) $data['preselectlist'];
 if (!in_array($preselectList, $selected_lists)) {
     $preselectList = 0;
 }
-$listsHTML .= sprintf('<p><label><input type="radio" name="preselectlist" value="0" %s /> %s</label></p>',
-    empty($preselectList) ? 'checked="checked"' : '',
-    s('Do not preselect any list'));
+$listsHTML .= '<table class="spageedit-lists-table">';
+$listsHTML .= sprintf(
+    '<tr><td>%s</td><td>%s</td><td>%s</td></tr>',
+    ucfirst(s('Select')),
+    ucfirst(s('Default')),
+    ucfirst(s('Description'))
+);
+$listsHTML .= '<tbody>';
 while ($row = Sql_Fetch_Array($req)) {
     $listSelected = in_array($row['id'], $selected_lists);
+    $listName = htmlspecialchars(stripslashes($row['name'] ?? ''), ENT_QUOTES);
+    $listDescription = htmlspecialchars(stripslashes($row['description'] ?? ''), ENT_QUOTES);
+    if ($listDescription === '') {
+        $listDescription = '&nbsp;';
+    }
     $listsHTML .= sprintf(
-        '<label><input type="checkbox" name="list[%d]" value="%d" %s /> %s</label> <label><input type="radio" name="preselectlist" value="%d" %s /> %s</label><div>%s</div>',
+        '<tr><td><label><input type="checkbox" name="list[%d]" value="%d" %s /> %s</label></td><td><input type="radio" name="preselectlist" value="%d" %s /></td><td>%s</td></tr>',
         $row['id'],
         $row['id'],
         $listSelected ? 'checked="checked"' : '',
-        stripslashes($row['name'] ?? ''),
+        $listName,
         $row['id'],
         $preselectList == $row['id'] ? 'checked="checked"' : '',
-        s('Preselect'),
-        htmlspecialchars(stripslashes($row['description'] ?? ''))
+        $listDescription
     );
 }
+$listsHTML .= sprintf(
+    '<tr><td></td><td><label><input type="radio" name="preselectlist" value="0" %s /> %s</label></td><td></td></tr>',
+    empty($preselectList) ? 'checked="checked"' : '',
+    s('none')
+);
+$listsHTML .= '</tbody></table>';
 
 $listsHTML .= '</div>';
 
@@ -428,6 +443,36 @@ echo $transactionHTML;
 echo $pluginsHTML;
 
 echo '</div>'; // accordion
+
+echo '
+<style>
+.spageedit-lists-table {
+    width: 100% !important;
+    border-collapse: collapse;
+}
+.spageedit-lists-table th,
+.spageedit-lists-table td {
+    padding: 10px 8px;
+    vertical-align: top;
+    text-align: left;
+}
+.spageedit-lists-table th {
+    font-weight: bold;
+    border-bottom: 1px solid #cfcfcf;
+}
+.spageedit-lists-table tbody tr td {
+    border-bottom: 1px solid #d9d9d9;
+}
+.spageedit-lists-table td label {
+    margin: 0;
+    font-weight: normal;
+}
+.spageedit-lists-table td input[type="checkbox"],
+.spageedit-lists-table td input[type="radio"] {
+    margin: 0 6px 0 0;
+    vertical-align: middle;
+}
+</style>';
 
 $ownerHTML = $singleOwner = '';
 $adminCount = 0;

--- a/public_html/lists/admin/spageedit.php
+++ b/public_html/lists/admin/spageedit.php
@@ -386,6 +386,7 @@ if (!Sql_Affected_Rows()) {
 } else {
 
     $listsHTML .= '<br/>'.s('If you do not choose a list here, all public lists will be displayed.');
+    $listsHTML .= '<br/>'.s('One list may be chosen to be selected by default on the subscribe page.');
     $hideSingle = getConfig('hide_single_list');
     if ($hideSingle) {
         $listsHTML .= '<br/>'.s('If you choose one list only, a checkbox for this list will not be displayed and the subscriber will automatically be added to this list.');

--- a/public_html/lists/admin/spageedit.php
+++ b/public_html/lists/admin/spageedit.php
@@ -108,10 +108,21 @@ if (isset($_POST['save'])) {
     }
     Sql_Query(sprintf('replace into %s (id,name,data) values(%d,"attributes","%s")',
         $tables['subscribepage_data'], $id, $attributes));
+    $preselectList = 0;
+    if (!empty($_POST['preselectlist'])) {
+        $preselectList = (int) $_POST['preselectlist'];
+    }
     if (isset($_POST['list']) && is_array($_POST['list'])) {
+        if (!$preselectList || !isset($_POST['list'][$preselectList])) {
+            $preselectList = 0;
+        }
         Sql_Query(sprintf('replace into %s (id,name,data) values(%d,"lists","%s")',
             $tables['subscribepage_data'], $id, implode(',', $_POST['list'])));
+    } else {
+        $preselectList = 0;
     }
+    Sql_Query(sprintf('replace into %s (id,name,data) values(%d,"preselectlist","%d")',
+        $tables['subscribepage_data'], $id, $preselectList));
 
     //## Store plugin data
     foreach ($GLOBALS['plugins'] as $pluginname => $plugin) {
@@ -144,6 +155,7 @@ $data['unsubscribemessage'] = getConfig('unsubscribemessage');
 $data['unsubscribesubject'] = getConfig('unsubscribesubject');
 $data['htmlchoice'] = 'htmlonly';
 $data['emaildoubleentry'] = 'yes';
+$data['preselectlist'] = 0;
 $data['rssdefault'] = 'daily'; //Leftover from the preplugin era
 $data['rssintro'] = s('Please indicate how often you want to receive messages');  //Leftover from the preplugin era
 $selected_lists = array();
@@ -382,10 +394,26 @@ if (!Sql_Affected_Rows()) {
     }
 }
 $listsHTML .= '</p>';
+$preselectList = (int) $data['preselectlist'];
+if (!in_array($preselectList, $selected_lists)) {
+    $preselectList = 0;
+}
+$listsHTML .= sprintf('<p><label><input type="radio" name="preselectlist" value="0" %s /> %s</label></p>',
+    empty($preselectList) ? 'checked="checked"' : '',
+    s('Do not preselect any list'));
 while ($row = Sql_Fetch_Array($req)) {
-    $listsHTML .= sprintf('<label><input type="checkbox" name="list[%d]" value="%d" %s /> %s</label><div>%s</div>',
-        $row['id'], $row['id'], in_array($row['id'], $selected_lists) ? 'checked="checked"' : '',
-        stripslashes($row['name']), htmlspecialchars(stripslashes($row['description'])));
+    $listSelected = in_array($row['id'], $selected_lists);
+    $listsHTML .= sprintf(
+        '<label><input type="checkbox" name="list[%d]" value="%d" %s /> %s</label> <label><input type="radio" name="preselectlist" value="%d" %s /> %s</label><div>%s</div>',
+        $row['id'],
+        $row['id'],
+        $listSelected ? 'checked="checked"' : '',
+        stripslashes($row['name']),
+        $row['id'],
+        $preselectList == $row['id'] ? 'checked="checked"' : '',
+        s('Preselect'),
+        htmlspecialchars(stripslashes($row['description']))
+    );
 }
 
 $listsHTML .= '</div>';

--- a/public_html/lists/admin/spageedit.php
+++ b/public_html/lists/admin/spageedit.php
@@ -204,7 +204,7 @@ $generalinfoHTML .= '<div>';
 
 $generalinfoHTML .= sprintf('<label for="title">%s</label><input type="text" name="title" value="%s" size="60" />',
     s('Title'),
-    htmlspecialchars(stripslashes($data['title'])));
+    htmlspecialchars(stripslashes($data['title'] ?? '')));
 
 $language_files = array();
 $language_file = $GLOBALS['language_module'];
@@ -232,24 +232,24 @@ $generalinfoHTML .= sprintf('<label for="language_file">%s</label>%s',
 
 $generalinfoHTML .= sprintf('<label for="intro">%s</label><textarea name="intro" cols="60" rows="10" class="virtual">%s</textarea>',
     s('Intro'),
-    htmlspecialchars(stripslashes($data['intro'])));
+    htmlspecialchars(stripslashes($data['intro'] ?? '')));
 $generalinfoHTML .= sprintf('<label for="header">%s</label><textarea name="header" cols="60" rows="10" class="virtual">%s</textarea>',
     s('Header'),
-    htmlspecialchars(stripslashes($data['header'])));
+    htmlspecialchars(stripslashes($data['header'] ?? '')));
 $generalinfoHTML .= sprintf('<label for="footer">%s</label><textarea name="footer" cols="60" rows="10" class="virtual">%s</textarea>',
     s('Footer'),
-    htmlspecialchars(stripslashes($data['footer'])));
+    htmlspecialchars(stripslashes($data['footer'] ?? '')));
 $generalinfoHTML .= sprintf('<label for="thankyoupage">%s</label><textarea name="thankyoupage" cols="60" rows="10" class="virtual">%s</textarea>',
     s('Thank you page'),
-    htmlspecialchars(stripslashes($data['thankyoupage'])));
+    htmlspecialchars(stripslashes($data['thankyoupage'] ?? '')));
 
 $generalinfoHTML .= sprintf('<label for="ajax_subscribeconfirmation">%s</label><textarea name="ajax_subscribeconfirmation" cols="60" rows="10" class="virtual">%s</textarea>',
     s('Text to display when subscription with an AJAX request was successful'),
-    htmlspecialchars(stripslashes($data['ajax_subscribeconfirmation'])));
+    htmlspecialchars(stripslashes($data['ajax_subscribeconfirmation'] ?? '')));
 
 $generalinfoHTML .= sprintf('<label for="button">%s</label><input type="text" name="button" value="%s" size="60" />',
     s('Text for Button'),
-    htmlspecialchars(stripslashes($data['button'])));
+    htmlspecialchars(stripslashes($data['button'] ?? '')));
 $generalinfoHTML .= sprintf('<label for="htmlchoice">%s</label>', s('HTML Email choice'));
 $generalinfoHTML .= sprintf('<input type="radio" name="htmlchoice" value="textonly" %s />
   %s <br/>',
@@ -293,24 +293,24 @@ $transactionHTML .= '<div>';
 $transactionHTML .= '<h4>'.s('Message they receive when they subscribe').'</h4>';
 $transactionHTML .= sprintf('<label for="subscribesubject">%s</label><input type="text" name="subscribesubject" value="%s" size="60" />',
     s('Subject'),
-    htmlspecialchars(stripslashes($data['subscribesubject'])));
+    htmlspecialchars(stripslashes($data['subscribesubject'] ?? '')));
 $transactionHTML .= sprintf('<label for="subscribemessage">%s</label><textarea name="subscribemessage" cols="60" rows="10" class="virtual">%s</textarea>',
     s('Message'),
-    htmlspecialchars(stripslashes($data['subscribemessage'])));
+    htmlspecialchars(stripslashes($data['subscribemessage'] ?? '')));
 $transactionHTML .= '<h4>'.s('Message they receive when they confirm their subscription').'</h4>';
 $transactionHTML .= sprintf('<label for="confirmationsubject">%s</label><input type="text" name="confirmationsubject" value="%s" size="60" />',
     s('Subject'),
-    htmlspecialchars(stripslashes($data['confirmationsubject'])));
+    htmlspecialchars(stripslashes($data['confirmationsubject'] ?? '')));
 $transactionHTML .= sprintf('<label for="confirmationmessage">%s</label><textarea name="confirmationmessage" cols="60" rows="10" class="virtual">%s</textarea>',
     s('Message'),
-    htmlspecialchars(stripslashes($data['confirmationmessage'])));
+    htmlspecialchars(stripslashes($data['confirmationmessage'] ?? '')));
 $transactionHTML .= '<h4>'.s('Message they receive when they unsubscribe').'</h4>';
 $transactionHTML .= sprintf('<label for="unsubscribesubject">%s</label><input type="text" name="unsubscribesubject" value="%s" size="60" />',
     s('Subject'),
-    htmlspecialchars(stripslashes($data['unsubscribesubject'])));
+    htmlspecialchars(stripslashes($data['unsubscribesubject'] ?? '')));
 $transactionHTML .= sprintf('<label for="unsubscribemessage">%s</label><textarea name="unsubscribemessage" cols="60" rows="10" class="virtual">%s</textarea>',
     s('Message'),
-    htmlspecialchars(stripslashes($data['unsubscribemessage'])));
+    htmlspecialchars(stripslashes($data['unsubscribemessage'] ?? '')));
 
 $sendtest_content = sprintf('<div class="sendTest" id="sendTest">
     ' .$sendtestresult.'
@@ -346,9 +346,9 @@ while ($row = Sql_Fetch_Array($req)) {
     $attributesHTML .= '<table class="spageeditListing" border="1" width="100%" bgcolor="'.$bgcol.'">';
     $attributesHTML .= '<tr><td colspan="2" width="150">'.s('Attribute').': '.$row['id'].'</td>';
     $attributesHTML .= '<td colspan="2">'.s('Check this box to use this attribute in the page').'<input type="checkbox" name="attr_use['.$row['id'].']" value="1" '.$checked[$row['id']].' /></td></tr>';
-    $attributesHTML .= '<tr><td colspan="2">'.s('Name').': </td><td colspan="2"><h4>'.htmlspecialchars(stripslashes($row['name'])).'</h4></td></tr>';
+    $attributesHTML .= '<tr><td colspan="2">'.s('Name').': </td><td colspan="2"><h4>'.htmlspecialchars(stripslashes($row['name'] ?? '')).'</h4></td></tr>';
     $attributesHTML .= '<tr><td colspan="2">'.s('Type').': </td><td colspan="2"><h4>'.s($row['type']).'</h4></td></tr>';
-    $attributesHTML .= '<tr><td colspan="2">'.s('Default Value').': </td><td colspan="2"><input type="text" name="attr_default['.$row['id'].']" value="'.htmlspecialchars(stripslashes($value['default_value'])).'" size="40" /></td></tr>';
+    $attributesHTML .= '<tr><td colspan="2">'.s('Default Value').': </td><td colspan="2"><input type="text" name="attr_default['.$row['id'].']" value="'.htmlspecialchars(stripslashes($value['default_value'] ?? '')).'" size="40" /></td></tr>';
     $attributesHTML .= '<tr><td>'.s('Order of Listing').': </td><td><input type="text" name="attr_listorder['.$row['id'].']" value="'.$value['listorder'].'" size="5" /></td>';
     $attributesHTML .= '<td>'.s('Is this attribute required?').': </td><td><input type="checkbox" name="attr_required['.$row['id'].']" value="1" ';
     $attributesHTML .= $value['required'] ? 'checked="checked"' : '';
@@ -408,11 +408,11 @@ while ($row = Sql_Fetch_Array($req)) {
         $row['id'],
         $row['id'],
         $listSelected ? 'checked="checked"' : '',
-        stripslashes($row['name']),
+        stripslashes($row['name'] ?? ''),
         $row['id'],
         $preselectList == $row['id'] ? 'checked="checked"' : '',
         s('Preselect'),
-        htmlspecialchars(stripslashes($row['description']))
+        htmlspecialchars(stripslashes($row['description'] ?? ''))
     );
 }
 

--- a/public_html/lists/admin/subscribelib2.php
+++ b/public_html/lists/admin/subscribelib2.php
@@ -714,6 +714,24 @@ if (isset($_POST['subscribe']) || isset($_POST['update'])) {
 }
 
 /**
+ * Determine whether a list checkbox should be preselected.
+ *
+ * @param bool $hasExplicitListSelection
+ * @param int $preselect_list_id
+ * @param int $listId
+ * @param mixed $rowPreselect
+ * @return bool
+ */
+function shouldPreselectList($hasExplicitListSelection, $preselect_list_id, $listId, $rowPreselect)
+{
+    return !$hasExplicitListSelection &&
+    (
+        ($preselect_list_id && $preselect_list_id == $listId) ||
+        (!$preselect_list_id && !empty($rowPreselect))
+    );
+}
+
+/**
  * @param int $userid
  * @param string $lists_to_show
  * @param int $preselect_list_id
@@ -814,12 +832,13 @@ function ListAvailableLists($userid = 0, $lists_to_show = '', $preselect_list_id
                             if (Sql_Affected_Rows()) {
                                 $html .= 'checked="checked"';
                             }
-                        } elseif (!$hasExplicitListSelection) {
-                            if ($preselect_list_id && $preselect_list_id == $listelement['id']) {
-                                $html .= 'checked="checked"';
-                            } elseif (!$preselect_list_id && !empty($listelement['preselect'])) {
-                                $html .= 'checked="checked"';
-                            }
+                        } elseif (shouldPreselectList(
+                            $hasExplicitListSelection,
+                            $preselect_list_id,
+                            $listelement['id'],
+                            $listelement['preselect']
+                        )) {
+                            $html .= 'checked="checked"';
                         }
 
 
@@ -861,12 +880,13 @@ function ListAvailableLists($userid = 0, $lists_to_show = '', $preselect_list_id
                     if (Sql_Affected_Rows()) {
                         $html .= 'checked="checked"';
                     }
-                } elseif (!$hasExplicitListSelection) {
-                    if ($preselect_list_id && $preselect_list_id == $row['id']) {
-                        $html .= 'checked="checked"';
-                    } elseif (!$preselect_list_id && !empty($row['preselect'])) {
-                        $html .= 'checked="checked"';
-                    }
+                } elseif (shouldPreselectList(
+                    $hasExplicitListSelection,
+                    $preselect_list_id,
+                    $row['id'],
+                    isset($row['preselect']) ? $row['preselect'] : 0
+                )) {
+                    $html .= 'checked="checked"';
                 }
                 $html .= " /> <label for=\"list$row[id]\"><b>".stripslashes($row['name']).'</b></label><div class="listdescription">';
                 $desc = nl2br(disableJavascript(stripslashes($row['description'])));

--- a/public_html/lists/admin/subscribelib2.php
+++ b/public_html/lists/admin/subscribelib2.php
@@ -716,9 +716,10 @@ if (isset($_POST['subscribe']) || isset($_POST['update'])) {
 /**
  * @param int $userid
  * @param string $lists_to_show
+ * @param int $preselect_list_id
  * @return string
  */
-function ListAvailableLists($userid = 0, $lists_to_show = '')
+function ListAvailableLists($userid = 0, $lists_to_show = '', $preselect_list_id = 0)
 {
     global $tables;
     if (isset($_POST['list'])) {
@@ -730,6 +731,9 @@ function ListAvailableLists($userid = 0, $lists_to_show = '')
     } else {
         $list = '';
     }
+    $hasExplicitListSelection = isset($_POST['list'])
+        || (!isset($_POST['subscribe']) && isset($_GET['list']) && preg_match("/^(\d+,)*\d+$/", $_GET['list']));
+    $preselect_list_id = (int) $preselect_list_id;
     $subselect = '';
     $listset = array();
     $subscribed = array();
@@ -766,7 +770,14 @@ function ListAvailableLists($userid = 0, $lists_to_show = '')
 
         while ($row = Sql_fetch_array($catresult)) {
 
-            $listspercategory[] = array('id' => $row ['id'], 'name' => $row ['name'], 'description' => $row ['description'], 'active' => $row ['active'], 'category' => $row ['category']);
+            $listspercategory[] = array(
+                'id' => $row['id'],
+                'name' => $row['name'],
+                'description' => $row['description'],
+                'active' => $row['active'],
+                'category' => $row['category'],
+                'preselect' => isset($row['preselect']) ? $row['preselect'] : 0,
+            );
 
         }
 
@@ -801,6 +812,12 @@ function ListAvailableLists($userid = 0, $lists_to_show = '')
                             $req = Sql_Fetch_Row_Query(sprintf('select userid from %s where userid = %d and listid = %d',
                                 $GLOBALS['tables']['listuser'], $userid, $listelement['id']));
                             if (Sql_Affected_Rows()) {
+                                $html .= 'checked="checked"';
+                            }
+                        } elseif (!$hasExplicitListSelection) {
+                            if ($preselect_list_id && $preselect_list_id == $listelement['id']) {
+                                $html .= 'checked="checked"';
+                            } elseif (!$preselect_list_id && !empty($listelement['preselect'])) {
                                 $html .= 'checked="checked"';
                             }
                         }
@@ -842,6 +859,12 @@ function ListAvailableLists($userid = 0, $lists_to_show = '')
                     $req = Sql_Fetch_Row_Query(sprintf('select userid from %s where userid = %d and listid = %d',
                         $GLOBALS['tables']['listuser'], $userid, $row['id']));
                     if (Sql_Affected_Rows()) {
+                        $html .= 'checked="checked"';
+                    }
+                } elseif (!$hasExplicitListSelection) {
+                    if ($preselect_list_id && $preselect_list_id == $row['id']) {
+                        $html .= 'checked="checked"';
+                    } elseif (!$preselect_list_id && !empty($row['preselect'])) {
                         $html .= 'checked="checked"';
                     }
                 }

--- a/public_html/lists/index.php
+++ b/public_html/lists/index.php
@@ -532,7 +532,11 @@ function checkEmail()
         }
     }
 
-    $html .= ListAvailableLists($userid, $GLOBALS['pagedata']['lists']);
+    $html .= ListAvailableLists(
+        $userid,
+        $GLOBALS['pagedata']['lists'],
+        isset($GLOBALS['pagedata']['preselectlist']) ? (int) $GLOBALS['pagedata']['preselectlist'] : 0
+    );
     if (isBlackListedID($userid)) {
         $html .= $GLOBALS['strYouAreBlacklisted'];
     }
@@ -690,7 +694,11 @@ function checkGroup(name,value)
             $html .= $plugin->displaySubscriptionChoice($GLOBALS['pagedata']);
         }
     }
-    $html .= ListAvailableLists('', $GLOBALS['pagedata']['lists']);
+    $html .= ListAvailableLists(
+        '',
+        $GLOBALS['pagedata']['lists'],
+        isset($GLOBALS['pagedata']['preselectlist']) ? (int) $GLOBALS['pagedata']['preselectlist'] : 0
+    );
 
     if (empty($GLOBALS['pagedata']['button'])) {
         $GLOBALS['pagedata']['button'] = $GLOBALS['strSubmit'];
@@ -799,7 +807,11 @@ function subscribePage2($id)
   $html .= formStart();
   $html .= '<fieldset class="phplist"><legend>'.strip_tags($GLOBALS['pagedata']['intro']).'</legend>';
   $html .= ListAttributes2011($attributes,$attributedata,$GLOBALS['pagedata']["htmlchoice"],0,$GLOBALS['pagedata']['emaildoubleentry']);
-  $html .= ListAvailableLists("",$GLOBALS['pagedata']["lists"]);
+  $html .= ListAvailableLists(
+      "",
+      $GLOBALS['pagedata']["lists"],
+      isset($GLOBALS['pagedata']['preselectlist']) ? (int) $GLOBALS['pagedata']['preselectlist'] : 0
+  );
 
   if (empty($GLOBALS['pagedata']['button'])) {
     $GLOBALS['pagedata']['button'] = $GLOBALS['strSubmit'];


### PR DESCRIPTION
<!--- Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
Add preselect to the subscribe page: a list can be marked as preselected when creating a public subscribe page.
 <!-- 
## Contributor License Agreement

before we can accept your PR, if you haven't done this yet, please sign the 

Contributor License Agreement at https://www.phplist.com/cla

Many thanks

the phpList Team

-->


## Related Issue
[issue](https://github.com/phpList/phplist3/issues/806)


## Screenshots (if appropriate):
<img width="692" height="414" alt="image" src="https://github.com/user-attachments/assets/c4fd700f-72f2-4803-a789-b2516ae4219d" />

