### PR TITLE
Fix Dockerfile to use build-entrypoint.sh

### DIFF
--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -46,4 +46,4 @@ RUN tar zxf phplist-$VERSION.tgz && \
 
 EXPOSE 80 
 
-ENTRYPOINT ["/usr/local/bin/build-test.sh"]
+ENTRYPOINT ["/usr/local/bin/build-entrypoint.sh"]


### PR DESCRIPTION
<!--- Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
- Fix Dockerfile to use build-entrypoint.sh
 <!-- 
## Contributor License Agreement

before we can accept your PR, if you haven't done this yet, please sign the 

Contributor License Agreement at https://www.phplist.com/cla

Many thanks

the phpList Team

-->


## Related Issue



## Screenshots (if appropriate):
