### PR TITLE
Added a username reminder for admins

### DIFF
--- a/public_html/lists/admin/css/app.css
+++ b/public_html/lists/admin/css/app.css
@@ -287,3 +287,7 @@ div.plugindetails > div.detail > span.value {
     font-weight: bold;
     height: 150px;
 }
+
+form#forgotpassword-form input[type="submit"] {
+    margin-top: 10px;
+}

--- a/public_html/lists/admin/index.php
+++ b/public_html/lists/admin/index.php
@@ -351,12 +351,22 @@ if (!empty($GLOBALS['require_login'])) {
             }
         }
         //If passwords are encrypted and a password recovery request was made, send mail to the admin of the given email address.
-    } elseif (isset($_REQUEST['forgotpassword'])) {
-        $adminId = $GLOBALS['admin_auth']->adminIdForEmail($_REQUEST['forgotpassword']);
+    } elseif (isset($_REQUEST['forgotpassword']) || isset($_REQUEST['forgotusername'])) {
+        $addressReminderType = '';
+        $addressReminder = '';
+        if (isset($_REQUEST['forgotpassword']) && !empty($_REQUEST['forgotpassword'])) {
+            $addressReminderType = 'password';
+            $addressReminder = $_REQUEST['forgotpassword'];
+        } elseif (isset($_REQUEST['forgotusername']) && !empty($_REQUEST['forgotusername'])) {
+            $addressReminderType = 'username';
+            $addressReminder = $_REQUEST['forgotusername'];
+        }
+        $adminId = $GLOBALS['admin_auth']->adminIdForEmail($addressReminder);
         if ($adminId) {
-            $msg = sendAdminPasswordToken($adminId);
+            $msg = ($addressReminderType == 'password') ? sendAdminPasswordToken($adminId) : sendAdminUsernameReminder($adminId);
         } else {
-            $msg = $GLOBALS['I18N']->get('Failed sending a change password token');
+            if (empty($addressReminderType)) $addressReminderType = 'password';
+            $msg = $GLOBALS['I18N']->get('Failed sending a ' . (($addressReminderType == 'password') ? 'change password token' : 'username reminder'));
         }
         $page = 'login';
     } elseif (!empty($_GET['secret'])

--- a/public_html/lists/admin/lib.php
+++ b/public_html/lists/admin/lib.php
@@ -417,6 +417,29 @@ function sendAdminPasswordToken($adminId)
     }
 }
 
+//Send an email with a username reminder the specified adminId.
+function sendAdminUsernameReminder($adminId)
+{
+    //Retrieve the admin login name and email address
+    $SQLquery = sprintf('select loginname,email from %s where id=%d;', $GLOBALS['tables']['admin'], $adminId);
+    $row = Sql_Fetch_Row_Query($SQLquery);
+    $adminName = $row[0];
+    $email = $row[1];
+
+    $urlroot = getConfig('website').$GLOBALS['adminpages'];
+    //Build the email body to be sent, and finally send it.
+    $emailBody = $GLOBALS['I18N']->get('Hello')."\n\n";
+    $emailBody .= $GLOBALS['I18N']->get('You have requested a username reminder for phpList.')."\n\n";
+    $emailBody .= $GLOBALS['I18N']->get('Your username is:')."\n\n";
+    $emailBody .= $adminName;
+
+    if (sendMail($email, $GLOBALS['I18N']->get('Username reminder'), "\n\n".$emailBody, '', '', true)) {
+        return $GLOBALS['I18N']->get('A username reminder has been sent to the corresponding email address.');
+    } else {
+        return $GLOBALS['I18N']->get('Error sending user reminder');
+    }
+}
+
 function getTopSmtpServer($domain)
 {
     $mx = getmxrr($domain, $mxhosts, $weight);

--- a/public_html/lists/admin/login.php
+++ b/public_html/lists/admin/login.php
@@ -40,8 +40,12 @@ function footer()
     echo '<form method="post" id="forgotpassword-form" action="">';
     echo '<div class="login"><p>';
     echo $GLOBALS['I18N']->get('Forgot password').' ';
-    echo $GLOBALS['I18N']->get('Enter your email address').': </p><input type="text" name="forgotpassword" value="" size="30" />';
+    echo $GLOBALS['I18N']->get('Enter your email address').': </p><input type="email" name="forgotpassword" value="" size="30" />';
     echo '  <input class="submit" type="submit" name="process" value="'.$GLOBALS['I18N']->get('Send password').'" />';
+    echo '  <p>';
+    echo $GLOBALS['I18N']->get('Forgot username').' ';
+    echo $GLOBALS['I18N']->get('Enter your email address').': </p><input type="email" name="forgotusername" value="" size="30" />';
+    echo '  <input class="submit" type="submit" name="process" value="'.$GLOBALS['I18N']->get('Send username').'" />';
     echo '  <div class="clear"></div>';
     echo '</div></form>';
 }


### PR DESCRIPTION
<!--- Thanks for contributing to phpList!-->

## Description
<!--- Please provide a general description of your changes in the Pull Request -->
Although password reminder insecurely mentions the username, it does it without using the word "username", but either way there should be an independent username reminder without the possibility to accidentally modify the database and change the password.

As a side fix, the e-mail field was defined as text rather than email.

All of this was done by adding support in:
1. Frontend
1. Backend
1. E-mail itself

I didn't duplicate `public_html/lists/admin/tests/subscriber_password.php` since it's meant for end-users while this task is for admins.

Note this requires the following new translations:

For `public_html/lists/admin/tests/admin/index.php`:
1. Failed sending a username reminder

For `public_html/lists/admin/tests/admin/lib.php`:
1. You have requested a username reminder for phpList.
1. Your username is:
1. Username reminder
1. A username reminder has been sent to the corresponding email address.
1. Error sending user reminder

For `public_html/lists/admin/tests/admin/login.php`:
1. Forgot username
1. Enter your email address
1. Send username

 <!-- 
## Contributor License Agreement

before we can accept your PR, if you haven't done this yet, please sign the 

Contributor License Agreement at https://www.phplist.com/cla

Many thanks

the phpList Team

-->


## Related Issue
N/A


## Screenshots (if appropriate):
![Username reminder](https://github.com/user-attachments/assets/d076f1df-de63-4e18-acb5-16180114738b)
