### PR TITLE
Add processQueueUserSelectQuery hook to let plugins order the send queue

### DIFF
--- a/public_html/lists/admin/actions/processqueue.php
+++ b/public_html/lists/admin/actions/processqueue.php
@@ -897,6 +897,12 @@ while ($message = Sql_fetch_array($messages)) {
         );
     }
 
+    //# this allows plugins to change the order in which the subscribers are
+    //# processed, by adding an "order by" clause to the query
+    foreach ($GLOBALS['plugins'] as $pluginname => $plugin) {
+        $query = $plugin->processQueueUserSelectQuery($query, $messageid);
+    }
+
     if (VERBOSE) {
         processQueueOutput('User select query '.$query);
     }
@@ -938,6 +944,9 @@ while ($message = Sql_fetch_array($messages)) {
         //# rerun the initial query, in order to continue as normal
         $query = sprintf('select userid from '.$tables['usermessage'].' where messageid = %d and status = "todo"',
             $messageid);
+        foreach ($GLOBALS['plugins'] as $pluginname => $plugin) {
+            $query = $plugin->processQueueUserSelectQuery($query, $messageid);
+        }
         $userids = Sql_Query($query);
         $counters['total_users_for_message '.$messageid] = Sql_Affected_Rows();
     }

--- a/public_html/lists/admin/defaultplugin.php
+++ b/public_html/lists/admin/defaultplugin.php
@@ -849,6 +849,22 @@ class phplistPlugin
     }
 
     /**
+     * processQueueUserSelectQuery
+     * called with the query that selects the subscribers of a campaign, just
+     * before that query is run
+     * allows a plugin to change the order in which subscribers are processed,
+     * for example to interleave imported segments instead of sending in
+     * database order
+     * @param string query the query that is about to be run
+     * @param int messageid the campaign being processed
+     * @return string the query to run
+     */
+    public function processQueueUserSelectQuery($query, $messageid)
+    {
+        return $query;
+    }
+
+    /**
      * allowProcessQueue
      * called at the beginning of processQueue
      * if this returns anything but "true" processing will be cancelled


### PR DESCRIPTION
## Description

Adds a `processQueueUserSelectQuery` hook, called with the subscriber select query just before it is run, so that a plugin can change the order in which subscribers are sent to. It is called at both selection points, including the `MESSAGEQUEUE_PREPARE` branch. With no plugin the query is returned unchanged, so behaviour is unchanged for existing installations.

## Related Issue

[#1125](https://github.com/phpList/phplist3/issues/1125)

## Contributor License Agreement

The GitHub authorisation works (confirmed by email), but the return lands on a blank page, on every attempt. I will sign as soon as it is fixed.
